### PR TITLE
For IPv4-only support on Windows, add the Windows-friendly 127.0.0.1 IP

### DIFF
--- a/DnsServerCore/WebService.cs
+++ b/DnsServerCore/WebService.cs
@@ -1202,7 +1202,7 @@ namespace DnsServerCore
             if (strDnsServerLocalAddresses != null)
             {
                 if (string.IsNullOrEmpty(strDnsServerLocalAddresses))
-                    strDnsServerLocalAddresses = "0.0.0.0,::";
+                    strDnsServerLocalAddresses = "0.0.0.0,127.0.0.1,::";
 
                 string[] strLocalAddresses = strDnsServerLocalAddresses.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 IPAddress[] localAddresses = new IPAddress[strLocalAddresses.Length];

--- a/DnsServerCore/www/js/main.js
+++ b/DnsServerCore/www/js/main.js
@@ -700,7 +700,7 @@ function saveDnsSettings() {
     var dnsServerLocalAddresses = cleanTextList($("#txtdnsServerLocalAddresses").val());
 
     if ((dnsServerLocalAddresses.length === 0) || (dnsServerLocalAddresses === ","))
-        dnsServerLocalAddresses = "0.0.0.0,::";
+        dnsServerLocalAddresses = "0.0.0.0,127.0.0.1,::";
     else
         $("#txtdnsServerLocalAddresses").val(dnsServerLocalAddresses.replace(/,/g, "\n"));
 


### PR DESCRIPTION
This fixes the following problem. See my

**STEPS TO REPRODUCE:**
1. Run DNS
2. Disable IPv6 on your network connection
3. Set IPv4 DNS to 127.0.0.1
4. Run `nslookup google.com`

**EXPECTED BEHAVIOR:**
DNS works

**ACTUAL BEHAVIOR:**
```
> google.com
Server:  [127.0.0.1]
Address:  127.0.0.1

*** [127.0.0.1] can't find google.com: No response from server
```
