### PR TITLE
AppQueryLogsSqlite use contains instead of exact match

### DIFF
--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -420,7 +420,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
                 whereClause += "rcode = @rcode AND ";
 
             if (qname is not null)
-                whereClause += "qname = @qname AND ";
+                whereClause += "qname like @qname AND ";
 
             if (qtype is not null)
                 whereClause += "qtype = @qtype AND ";
@@ -461,7 +461,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
                         command.Parameters.AddWithValue("@rcode", (byte)rcode);
 
                     if (qname is not null)
-                        command.Parameters.AddWithValue("@qname", qname);
+                        command.Parameters.Add(new SqliteParameter("@qname", "%"+qname+"%"));
 
                     if (qtype is not null)
                         command.Parameters.AddWithValue("@qtype", (ushort)qtype);
@@ -540,7 +540,7 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                         command.Parameters.AddWithValue("@rcode", (byte)rcode);
 
                     if (qname is not null)
-                        command.Parameters.AddWithValue("@qname", qname);
+                        command.Parameters.AddWithValue("@qname", "%"+qname+"%");
 
                     if (qtype is not null)
                         command.Parameters.AddWithValue("@qtype", (ushort)qtype);

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -420,7 +420,17 @@ CREATE TABLE IF NOT EXISTS dns_logs
                 whereClause += "rcode = @rcode AND ";
 
             if (qname is not null)
-                whereClause += "qname like @qname AND ";
+            {
+                if (qname.Contains("*"))
+                {
+                    whereClause += "qname like @qname AND ";
+                    qname = qname.Replace("*", "%");
+                }
+                else
+                {
+                    whereClause += "qname = @qname AND ";
+                }
+            }
 
             if (qtype is not null)
                 whereClause += "qtype = @qtype AND ";
@@ -461,7 +471,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
                         command.Parameters.AddWithValue("@rcode", (byte)rcode);
 
                     if (qname is not null)
-                        command.Parameters.AddWithValue("@qname", "%"+qname+"%");
+                        command.Parameters.AddWithValue("@qname", qname);
 
                     if (qtype is not null)
                         command.Parameters.AddWithValue("@qtype", (ushort)qtype);
@@ -540,7 +550,7 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                         command.Parameters.AddWithValue("@rcode", (byte)rcode);
 
                     if (qname is not null)
-                        command.Parameters.AddWithValue("@qname", "%"+qname+"%");
+                        command.Parameters.AddWithValue("@qname", qname);
 
                     if (qtype is not null)
                         command.Parameters.AddWithValue("@qtype", (ushort)qtype);

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -461,7 +461,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
                         command.Parameters.AddWithValue("@rcode", (byte)rcode);
 
                     if (qname is not null)
-                        command.Parameters.Add(new SqliteParameter("@qname", "%"+qname+"%"));
+                        command.Parameters.AddWithValue("@qname", "%"+qname+"%");
 
                     if (qtype is not null)
                         command.Parameters.AddWithValue("@qtype", (ushort)qtype);


### PR DESCRIPTION
Looking for a domain in the logs currently requires an exact match e.g. www.google.com
It would be nice to search for all items from root domain (e.g. *.google.com), or all queries with a certain subdomain e.g. (ads.*) etc.
Thus we should use 'like' instead of exact match for domain search, and allow user to enter any part of the domain name to search
