### PR TITLE
Missing Windows Service Globalization Invariant

### DIFF
--- a/DnsServerWindowsService/DnsServerWindowsService.csproj
+++ b/DnsServerWindowsService/DnsServerWindowsService.csproj
@@ -19,6 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="TechnitiumLibrary.Net.Firewall">
       <HintPath>..\..\TechnitiumLibrary\bin\TechnitiumLibrary.Net.Firewall.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Dns Server wasn't working properly in service mode. Based on the logs, i saw that it was missing.

I tested it by changing the DnsService.runtimeconfig.json and it worked fine.