### PR TITLE
Added the ability to access the API from other origins.

### DIFF
--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -30,6 +30,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using System;
@@ -275,7 +276,20 @@ namespace DnsServerCore
 
             builder.Logging.ClearProviders();
 
+            string strCorsAllowedOrigins = Environment.GetEnvironmentVariable("CORS_ALLOWED_ORIGINS");
+            if (!string.IsNullOrEmpty(strCorsAllowedOrigins))
+            {
+                var corsAllowedOrigins = Array.ConvertAll(strCorsAllowedOrigins.Split(','), p => p.Trim());
+                builder.Services.AddCors(options =>
+                {
+                    options.AddDefaultPolicy(builder =>{builder.WithOrigins(corsAllowedOrigins);});
+                });
+            }
+
             _webService = builder.Build();
+
+            if (!string.IsNullOrEmpty(strCorsAllowedOrigins))
+                _webService.UseCors();
 
             if (_webServiceHttpToTlsRedirect && !safeMode && _webServiceEnableTls && (_webServiceTlsCertificate is not null))
                 _webService.UseHttpsRedirection();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       # - DNS_SERVER_FORWARDERS=1.1.1.1, 8.8.8.8 #Comma separated list of forwarder addresses.
       # - DNS_SERVER_FORWARDER_PROTOCOL=Tcp #Forwarder protocol options: Udp, Tcp, Tls, Https, HttpsJson.
       # - DNS_SERVER_LOG_USING_LOCAL_TIME=true #Enable this option to use local time instead of UTC for logging.
+      # - CORS_ALLOWED_ORIGINS=http://localhost:3000, http://localhost:5380 #Comma separated list of origins to allow for CORS.
     volumes:
       - config:/etc/dns
     restart: unless-stopped


### PR DESCRIPTION
[Feature Request](https://github.com/TechnitiumSoftware/DnsServer/issues/663)

I was trying to use the API and ran into the CORS problem. I can only access the API from the same origin as the DNS Server.

I added the following Environment Variable to allow other origins.
Environment variable like as follows:
# - CORS_ALLOWED_ORIGINS=http://localhost:3000, http://192.168.0.1 #Comma separated list of origins to allow for CORS.