### PR TITLE
Add dnsutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ curl https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb; \
 rm packages-microsoft-prod.deb
 
-RUN apt update; apt install libmsquic -y; apt clean -y;
+RUN apt update; apt install dnsutils libmsquic -y; apt clean -y;
 
 COPY ./DnsServerApp/bin/Release/publish/ .
 


### PR DESCRIPTION
Add dnsutils to Dockerfile so a health check can be done for docker/kubernetes. At the moment both `nslookup` and `dig` are not found in the image.

Kube example:

```
livenessProbe:
   exec:
     command:
     - nslookup
     - google.com
     - 127.0.0.1
```