### PR TITLE
Update envs in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,17 @@ services:
       # - DNS_SERVER_ADMIN_PASSWORD=password #DNS web console admin user password.
       # - DNS_SERVER_ADMIN_PASSWORD_FILE=password.txt #The path to a file that contains a plain text password for the DNS web console admin user.
       # - DNS_SERVER_PREFER_IPV6=false #DNS Server will use IPv6 for querying whenever possible with this option enabled.
+      
+      # - DNS_SERVER_WEB_SERVICE_LOCAL_ADDRESSES=172.17.0.1,127.0.0.1 
+          # The above is a list of IPv4/IPv6 addresses for the net adapters that the web ui will be accessible from.
+          # - 172.17.0.1 listed above is the built in Docker bridge.
+          # - 0.0.0.0 is the default value if this is left blank.
+          # - Recommended only for "host" network mode behind a reverse HTTP/HTTPS proxy.
       # - DNS_SERVER_WEB_SERVICE_HTTP_PORT=5380 #The TCP port number for the DNS web console over HTTP protocol.
       # - DNS_SERVER_WEB_SERVICE_HTTPS_PORT=53443 #The TCP port number for the DNS web console over HTTPS protocol.
       # - DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS=false #Enables HTTPS for the DNS web console.
       # - DNS_SERVER_WEB_SERVICE_USE_SELF_SIGNED_CERT=false #Enables self signed TLS certificate for the DNS web console.
+      
       # - DNS_SERVER_OPTIONAL_PROTOCOL_DNS_OVER_HTTP=false #Enables DNS server optional protocol DNS-over-HTTP on TCP port 8053 to be used with a TLS terminating reverse proxy like nginx.
       # - DNS_SERVER_RECURSION=AllowOnlyForPrivateNetworks #Recursion options: Allow, Deny, AllowOnlyForPrivateNetworks, UseSpecifiedNetworks.
       # - DNS_SERVER_RECURSION_DENIED_NETWORKS=1.1.1.0/24 #Comma separated list of IP addresses or network addresses to deny recursion. Valid only for `UseSpecifiedNetworks` recursion option.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
           # The above is a list of IPv4/IPv6 addresses for the net adapters that the web ui will be accessible from.
           # - 172.17.0.1 listed above is the built in Docker bridge.
           # - 0.0.0.0 is the default value if this is left blank.
-          # - Recommended only for "host" network mode behind a reverse HTTP/HTTPS proxy.
+          # - Recommended only for "host" network mode. Intended for use with a reverse proxy.
       # - DNS_SERVER_WEB_SERVICE_HTTP_PORT=5380 #The TCP port number for the DNS web console over HTTP protocol.
       # - DNS_SERVER_WEB_SERVICE_HTTPS_PORT=53443 #The TCP port number for the DNS web console over HTTPS protocol.
       # - DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS=false #Enables HTTPS for the DNS web console.


### PR DESCRIPTION
Added the new env var to compose.yml and an explanatory blurb for it.
Added newlines to delimit the WEB_SERVICE envs for easier readability.

Specified that that when used in Docker, this new var is only recommended for use with "host" network mode. Reasoning:

> Docker's builtin NAT and firewall already offers network-level security, and the container's internal IP address is typically assigned automatically by the Docker host. Using this var in non-host mode Docker environments will likely break the compose file especially if the user is unfamiliar with the var's purpose. The main reason for using this variable in a Docker environment is that Docker's NAT (and firewall) is not available in host mode. So, you would likely want to protect the host mode web ui with a reverse proxy by pointing to an internal IP address instead of Docker's NAT.

See #877