### PR TITLE
Add GitHub Actions Workflow and update Dockerfile to build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,64 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v**
+  pull_request:
+
+jobs:
+  build:
+    name: Build software
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      attestations: write
+    steps:
+      - name: Checkout code DnsServer
+        uses: actions/checkout@v4
+
+      - name: Checkout code TechnitiumLibrary
+        uses: actions/checkout@v4
+        with:
+          repository: TechnitiumSoftware/TechnitiumLibrary
+          path: TechnitiumLibrary
+
+      - name: Define tags and metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/dns-server,enable=true
+          flavor: |
+            latest=true
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        id: docker
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,28 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+# syntax=docker/dockerfile:1.7-labs
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+WORKDIR /opt/technitium/dns
+
+RUN apt update; apt install curl -y; \
+curl https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb --output packages-microsoft-prod.deb; \
+dpkg -i packages-microsoft-prod.deb; \
+rm packages-microsoft-prod.deb
+
+RUN apt update; apt install dnsutils libmsquic -y; apt clean -y;
+
+# make sure TechnitiumLibrary folder exists!
+COPY --parents /TechnitiumLibrary .
+COPY . ./DnsServer
+
+RUN dotnet build TechnitiumLibrary/TechnitiumLibrary.ByteTree/TechnitiumLibrary.ByteTree.csproj -c Release && \
+    dotnet build TechnitiumLibrary/TechnitiumLibrary.Net/TechnitiumLibrary.Net.csproj -c Release
+
+RUN dotnet publish DnsServer/DnsServerApp/DnsServerApp.csproj -c Release
+
+# ---
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS run
 LABEL product="Technitium DNS Server"
 LABEL vendor="Technitium"
 LABEL email="support@technitium.com"
@@ -14,7 +38,7 @@ rm packages-microsoft-prod.deb
 
 RUN apt update; apt install dnsutils libmsquic -y; apt clean -y;
 
-COPY ./DnsServerApp/bin/Release/publish/ .
+COPY --from=build /opt/technitium/dns/DnsServer/DnsServerApp/bin/Release/publish/ .
 
 EXPOSE 5380/tcp
 EXPOSE 53443/tcp


### PR DESCRIPTION
This will build a Container image and publish to ghcr.io (this GitHub repository).

Dockerfile is modified to be self-contanied (so it can build anywhere), but it requires having [TechnitiumSoftware/TechnitiumLibrary](https://github.com/TechnitiumSoftware/TechnitiumLibrary) present in the same folder.