### PR TITLE
Change remaining references of UseSpecifiedNetworks to UseSpecifiedNetworkACL

### DIFF
--- a/DockerEnvironmentVariables.md
+++ b/DockerEnvironmentVariables.md
@@ -18,9 +18,9 @@ The environment variables are described below:
 | DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS        | Boolean | Enables HTTPS for the DNS web console.                                                                                                   |
 | DNS_SERVER_WEB_SERVICE_USE_SELF_SIGNED_CERT| Boolean | Enables self signed TLS certificate for the DNS web console.                                                                             |
 | DNS_SERVER_OPTIONAL_PROTOCOL_DNS_OVER_HTTP | Boolean | Enables DNS server optional protocol DNS-over-HTTP on TCP port 80 to be used with a TLS terminating reverse proxy like nginx.            |
-| DNS_SERVER_RECURSION                       | String  | Recursion options: `Allow`, `Deny`, `AllowOnlyForPrivateNetworks`, `UseSpecifiedNetworks`.                                               |
-| DNS_SERVER_RECURSION_DENIED_NETWORKS       | String  | A comma separated list of IP addresses or network addresses to deny recursion. Valid only for `UseSpecifiedNetworks` recursion option.   |
-| DNS_SERVER_RECURSION_ALLOWED_NETWORKS      | String  | A comma separated list of IP addresses or network addresses to allow recursion. Valid only for `UseSpecifiedNetworks` recursion option.  |
+| DNS_SERVER_RECURSION                       | String  | Recursion options: `Allow`, `Deny`, `AllowOnlyForPrivateNetworks`, `UseSpecifiedNetworkACL`.                                               |
+| DNS_SERVER_RECURSION_DENIED_NETWORKS       | String  | A comma separated list of IP addresses or network addresses to deny recursion. Valid only for `UseSpecifiedNetworkACL` recursion option.   |
+| DNS_SERVER_RECURSION_ALLOWED_NETWORKS      | String  | A comma separated list of IP addresses or network addresses to allow recursion. Valid only for `UseSpecifiedNetworkACL` recursion option.  |
 | DNS_SERVER_ENABLE_BLOCKING                 | Boolean | Sets the DNS server to block domain names using Blocked Zone and Block List Zone.                                                        |
 | DNS_SERVER_ALLOW_TXT_BLOCKING_REPORT       | Boolean | Specifies if the DNS Server should respond with TXT records containing a blocked domain report for TXT type requests.                    |
 | DNS_SERVER_BLOCK_LIST_URLS                 | String  | A comma separated list of block list URLs.                                                                                               |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       # - "443:443/tcp" #DNS-over-HTTPS service (HTTP/1.1, HTTP/2)
       # - "80:80/tcp" #DNS-over-HTTP service (use with reverse proxy or certbot certificate renewal)
       # - "8053:8053/tcp" #DNS-over-HTTP service (use with reverse proxy)
-      # - "67:67/udp" #DHCP service      
+      # - "67:67/udp" #DHCP service
     environment:
       - DNS_SERVER_DOMAIN=dns-server #The primary domain name used by this DNS Server to identify itself.
       # - DNS_SERVER_ADMIN_PASSWORD=password #DNS web console admin user password.
@@ -29,9 +29,9 @@ services:
       # - DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS=false #Enables HTTPS for the DNS web console.
       # - DNS_SERVER_WEB_SERVICE_USE_SELF_SIGNED_CERT=false #Enables self signed TLS certificate for the DNS web console.
       # - DNS_SERVER_OPTIONAL_PROTOCOL_DNS_OVER_HTTP=false #Enables DNS server optional protocol DNS-over-HTTP on TCP port 8053 to be used with a TLS terminating reverse proxy like nginx.
-      # - DNS_SERVER_RECURSION=AllowOnlyForPrivateNetworks #Recursion options: Allow, Deny, AllowOnlyForPrivateNetworks, UseSpecifiedNetworks.
-      # - DNS_SERVER_RECURSION_DENIED_NETWORKS=1.1.1.0/24 #Comma separated list of IP addresses or network addresses to deny recursion. Valid only for `UseSpecifiedNetworks` recursion option.
-      # - DNS_SERVER_RECURSION_ALLOWED_NETWORKS=127.0.0.1, 192.168.1.0/24 #Comma separated list of IP addresses or network addresses to allow recursion. Valid only for `UseSpecifiedNetworks` recursion option.
+      # - DNS_SERVER_RECURSION=AllowOnlyForPrivateNetworks #Recursion options: Allow, Deny, AllowOnlyForPrivateNetworks, UseSpecifiedNetworkACL.
+      # - DNS_SERVER_RECURSION_DENIED_NETWORKS=1.1.1.0/24 #Comma separated list of IP addresses or network addresses to deny recursion. Valid only for `UseSpecifiedNetworkACL` recursion option.
+      # - DNS_SERVER_RECURSION_ALLOWED_NETWORKS=127.0.0.1, 192.168.1.0/24 #Comma separated list of IP addresses or network addresses to allow recursion. Valid only for `UseSpecifiedNetworkACL` recursion option.
       # - DNS_SERVER_ENABLE_BLOCKING=false #Sets the DNS server to block domain names using Blocked Zone and Block List Zone.
       # - DNS_SERVER_ALLOW_TXT_BLOCKING_REPORT=false #Specifies if the DNS Server should respond with TXT records containing a blocked domain report for TXT type requests.
       # - DNS_SERVER_BLOCK_LIST_URLS= #A comma separated list of block list URLs.
@@ -43,6 +43,6 @@ services:
     restart: unless-stopped
     sysctls:
       - net.ipv4.ip_local_port_range=1024 65000
- 
+
 volumes:
     config:


### PR DESCRIPTION
While testing version 13, the dns-server process kept crashing with an exception saying that `UseSpecifiedNetworks` wasn't found in the DnsServerRecursion enum.  It looks like `UseSpecifiedNetworks` was updated to `UseSpecifiedNetworkACL` as part of [commit bdda47d](https://github.com/TechnitiumSoftware/DnsServer/commit/bdda47db3f0a3553fdfcc2f7d3a308a0fd424a69#diff-14c7cc7d9bd05bdaea5eda94726c8e1c026a683ed4e2982cd4886e7481809632L67).  This PR is just a simple find and replace on the remaining two files which contain references to the old value.