### PR TITLE
chore(`Dockerfile`): Migrate to slimmer `chiseled` image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ HEREDOC
 
 ## Published image - No shell or package manager (only what is needed to run the service)
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled AS runtime-image
-COPY ./DnsServerApp/bin/Release/publish/ .
+COPY ./DnsServerApp/bin/Release/publish/ /opt/technitium/dns/
 # DNS-over-QUIC support (libmsquic):
 COPY --link --from=deps /runtime-deps/ /usr/lib/x86_64-linux-gnu/
 
@@ -30,7 +30,7 @@ STOPSIGNAL SIGINT
 
 # `/etc/dns` is expected to exist:
 WORKDIR /etc/dns
-WORKDIR /
+WORKDIR /opt/technitium/dns/
 
 ENTRYPOINT ["/usr/bin/dotnet", "/opt/technitium/dns/DnsServerApp.dll"]
 CMD ["/etc/dns"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,60 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
-LABEL product="Technitium DNS Server"
-LABEL vendor="Technitium"
-LABEL email="support@technitium.com"
-LABEL project_url="https://technitium.com/dns/"
-LABEL github_url="https://github.com/TechnitiumSoftware/DnsServer"
+# syntax=docker.io/docker/dockerfile:1
 
-WORKDIR /opt/technitium/dns/
+## This stage is only used to support preparing the runtime-image stage
+FROM ubuntu:24.04 AS deps
+RUN <<HEREDOC
+  # Add the MS repo to install libmsquic (which also adds libnuma):
+  apt update && apt install -y curl
+  curl https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb --output packages-microsoft-prod.deb
+  dpkg -i packages-microsoft-prod.deb
+  rm packages-microsoft-prod.deb
+  apt update && apt install -y libmsquic
+  apt clean -y
 
-RUN apt update; apt install curl -y; \
-curl https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb --output packages-microsoft-prod.deb; \
-dpkg -i packages-microsoft-prod.deb; \
-rm packages-microsoft-prod.deb
+  # Workaround for `COPY` semantics to preserve symlinks you must copy at the directory level:
+  # https://github.com/moby/moby/issues/40449
+  mkdir /runtime-deps
+  mv /usr/lib/x86_64-linux-gnu/libmsquic.so* /runtime-deps
+  mv /usr/lib/x86_64-linux-gnu/libnuma.so* /runtime-deps
+HEREDOC
 
-RUN apt update; apt install dnsutils libmsquic -y; apt clean -y;
 
+## Published image - No shell or package manager (only what is needed to run the service)
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled AS runtime-image
 COPY ./DnsServerApp/bin/Release/publish/ .
+# DNS-over-QUIC support (libmsquic):
+COPY --link --from=deps /runtime-deps/ /usr/lib/x86_64-linux-gnu/
 
-EXPOSE 5380/tcp
-EXPOSE 53443/tcp
-EXPOSE 53/udp
-EXPOSE 53/tcp
-EXPOSE 853/udp
-EXPOSE 853/tcp
-EXPOSE 443/udp
-EXPOSE 443/tcp
-EXPOSE 80/tcp
-EXPOSE 8053/tcp
-EXPOSE 67/udp
-
-VOLUME ["/etc/dns"]
-
+# Graceful shutdown support:
 STOPSIGNAL SIGINT
+
+# `/etc/dns` is expected to exist:
+WORKDIR /etc/dns
+WORKDIR /
 
 ENTRYPOINT ["/usr/bin/dotnet", "/opt/technitium/dns/DnsServerApp.dll"]
 CMD ["/etc/dns"]
+
+
+## Only append image metadata below this line:
+EXPOSE \
+  # Standard DNS service
+  53/udp 53/tcp      \
+  # DNS-over-QUIC (UDP) + DNS-over-TLS (TCP)
+  853/udp 853/tcp    \
+  # DNS-over-HTTPS (UDP => HTTP/3) (TCP => HTTP/1.1 + HTTP/2)
+  443/udp 443/tcp    \
+  # DNS-over-HTTP (for when running behind a reverse-proxy that terminates TLS)
+  80/tcp 8053/tcp    \
+  # Technitium web console + API (HTTP / HTTPS)
+  5380/tcp 53443/tcp \
+  # DHCP
+  67/udp
+
+# https://specs.opencontainers.org/image-spec/annotations/
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.title="Technitium DNS Server"
+LABEL org.opencontainers.image.vendor="Technitium"
+LABEL org.opencontainers.image.source="https://github.com/TechnitiumSoftware/DnsServer"
+LABEL org.opencontainers.image.url="https://technitium.com/dns/"
+LABEL org.opencontainers.image.authors="support@technitium.com"


### PR DESCRIPTION
More details at: https://github.com/TechnitiumSoftware/DnsServer/issues/1012#issuecomment-2373082530

- `VOLUME` directive removed (_it is an anti-pattern_).
- `EXPOSE` revised to use single directive with inline comments for context on relevancy.
- `LABEL` revised to use [standardized OCI label schema](https://specs.opencontainers.org/image-spec/annotations/) (annotations), I've not added additional ones, but you could benefit from using build args to include release specific metadata (_which can also be appended to the image via CI instead of within the actual `Dockerfile`_).
- The image will no longer include a package manager, shell, or the `dig` DNS utility. It's purely focused on leveraging Docker to bundle and deploy `DnsServer` as a service.
- Reduction in size by over 50%:
  - Uncompressed (_local storage_): 270MB => 123MB
  - Compressed (_at image registry_): 110MB => 50MB

---

The repeated `WORKDIR` directive is a bit clumsy, but it will create the `/etc/dns` directory to support the existing `CMD` (_since `VOLUME` was dropped_). `mkdir` is not available (_although it can be used via a `RUN --mount` directive, I tried to minimize complexity_).

Technically, you could prefer the startup failure by default when `/etc/dns` does not exist to ensure the user is properly aware of the expectation to persist the data from this location (_`/etc` is meant for config, not really state though_), or to adjust the default `CMD`. Personally I prefer an image to work by default and would have just used something like `/tmp`, but at this point that sort of change would be breaking to users that update with explicit volumes.
