### PR TITLE
chore: Revise `Dockerfile`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,8 @@
 *.sh text eol=lf
 supervisor.conf text eol=lf
 systemd.service text eol=lf
+# Using the HEREDOC feature expects LF:
+Dockerfile      text eol=lf
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ HEREDOC
 
 ## Published image - No shell or package manager (only what is needed to run the service)
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled AS runtime-image
-COPY ./DnsServerApp/bin/Release/publish/ .
+COPY ./DnsServerApp/bin/Release/publish/ /opt/technitium/dns/
 # DNS-over-QUIC support (libmsquic):
 COPY --link --from=deps /runtime-deps/ /usr/lib/x86_64-linux-gnu/
 
@@ -30,7 +30,7 @@ STOPSIGNAL SIGINT
 
 # `/etc/dns` is expected to exist:
 WORKDIR /etc/dns
-WORKDIR /
+WORKDIR /opt/technitium/dns/
 
 ENTRYPOINT ["/usr/bin/dotnet", "/opt/technitium/dns/DnsServerApp.dll"]
 CMD ["/etc/dns"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
+# Add the MS repo to install `libmsquic` to support DNS-over-QUIC:
+ADD --link https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb /
 RUN <<HEREDOC
-  # Add the MS repo to install `libmsquic` to support DNS-over-QUIC:
-  apt update && apt install -y curl
-  curl https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb --output packages-microsoft-prod.deb
-  dpkg -i packages-microsoft-prod.deb
-  rm packages-microsoft-prod.deb
+  dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb
   # `dnsutils` added to include the `dig` command for troubleshooting:
-  apt update && apt install -y libmsquic dnsutils
-  apt clean -y && rm -rf /var/lib/apt/lists/*
+  apt-get update && apt-get install -y libmsquic dnsutils
+  apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
   # `/etc/dns` is expected to exist the default directory for persisting state:
   # (Users should volume mount to this location or modify the `CMD` of their container)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,60 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
-LABEL product="Technitium DNS Server"
-LABEL vendor="Technitium"
-LABEL email="support@technitium.com"
-LABEL project_url="https://technitium.com/dns/"
-LABEL github_url="https://github.com/TechnitiumSoftware/DnsServer"
+# syntax=docker.io/docker/dockerfile:1
 
-WORKDIR /opt/technitium/dns/
+## This stage is only used to support preparing the runtime-image stage
+FROM ubuntu:24.04 AS deps
+RUN <<HEREDOC
+  # Add the MS repo to install libmsquic (which also adds libnuma):
+  apt update && apt install -y curl
+  curl https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb --output packages-microsoft-prod.deb
+  dpkg -i packages-microsoft-prod.deb
+  rm packages-microsoft-prod.deb
+  apt update && apt install -y libmsquic
+  apt clean -y
 
-RUN apt update; apt install curl -y; \
-curl https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb --output packages-microsoft-prod.deb; \
-dpkg -i packages-microsoft-prod.deb; \
-rm packages-microsoft-prod.deb
+  # Workaround for `COPY` semantics to preserve symlinks you must copy at the directory level:
+  # https://github.com/moby/moby/issues/40449
+  mkdir /runtime-deps
+  mv /usr/lib/x86_64-linux-gnu/libmsquic.so* /runtime-deps
+  mv /usr/lib/x86_64-linux-gnu/libnuma.so* /runtime-deps
+HEREDOC
 
-RUN apt update; apt install dnsutils libmsquic -y; apt clean -y;
 
+## Published image - No shell or package manager (only what is needed to run the service)
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled AS runtime-image
 COPY ./DnsServerApp/bin/Release/publish/ .
+# DNS-over-QUIC support (libmsquic):
+COPY --link --from=deps /runtime-deps/ /usr/lib/x86_64-linux-gnu/
 
-EXPOSE 5380/tcp
-EXPOSE 53443/tcp
-EXPOSE 53/udp
-EXPOSE 53/tcp
-EXPOSE 853/udp
-EXPOSE 853/tcp
-EXPOSE 443/udp
-EXPOSE 443/tcp
-EXPOSE 80/tcp
-EXPOSE 8053/tcp
-EXPOSE 67/udp
-
-VOLUME ["/etc/dns"]
-
+# Graceful shutdown support:
 STOPSIGNAL SIGINT
+
+# `/etc/dns` is expected to exist:
+WORKDIR /etc/dns
+WORKDIR /
 
 ENTRYPOINT ["/usr/bin/dotnet", "/opt/technitium/dns/DnsServerApp.dll"]
 CMD ["/etc/dns"]
+
+
+## Only append image metadata below this line:
+EXPOSE \
+  # Standard DNS service
+  53/udp 53/tcp      \
+  # DNS-over-QUIC (UDP) + DNS-over-TLS (TCP)
+  853/udp 853/tcp    \
+  # DNS-over-HTTPS (UDP => HTTP/3) (TCP => HTTP/1.1 + HTTP/2)
+  443/udp 443/tcp    \
+  # DNS-over-HTTP (for when running behind a reverse-proxy that terminates TLS)
+  80/tcp 8053/tcp    \
+  # Technitium web console + API (HTTP / HTTPS)
+  5380/tcp 53443/tcp \
+  # DHCP
+  67/udp
+
+# https://specs.opencontainers.org/image-spec/annotations/
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.title="Technitium DNS Server"
+LABEL org.opencontainers.image.vendor="Technitium"
+LABEL org.opencontainers.image.source="https://github.com/TechnitiumSoftware/DnsServer"
+LABEL org.opencontainers.image.url="https://technitium.com/dns/"
+LABEL org.opencontainers.image.authors="support@technitium.com"


### PR DESCRIPTION
This PR branches from the earlier attempted `chisel` image contribution: https://github.com/TechnitiumSoftware/DnsServer/pull/1046

This PR variant is based on the maintainer feedback received [from this discussion](https://github.com/TechnitiumSoftware/DnsServer/issues/1012#issuecomment-2378344643).

---

The `chisel` related changes have been reverted (_and `dig` added back_), while keeping the other improvements to the `Dockerfile`.
- This produces a 252MB image, that comes from the added `rm -rf`. 
- The linked PR reference details the changes to `EXPOSE`, `LABEL` and `VOLUME` (removed) directives.
- A single `RUN` directive is used with the [HereDoc syntax feature](https://docs.docker.com/reference/dockerfile/#here-documents). This allows for easier to read and maintain sequences of shell commands as you can see via the diff.
- Additional commentary added for readers to grok. `WORKDIR` co-located with the relevant `COPY` (_although I've made the target path absolute instead of relative, I can change that back if you prefer_).

The commit history probably isn't important to you, so if you merge this you may want to ensure you do a squash merge instead of the default merge commit option. Alternatively, I can squash this branch instead.

## A note regarding HereDoc support

This feature expects the files line endings to be `LF`, not `CRLF` which without updating your `.gitattributes` to [include `Dockerfile text eol=lf`](https://github.com/docker-mailserver/docker-mailserver/blob/025a38d7366d7e08cf61b5106af762ec69e1505d/.gitattributes#L23) a git checkout on Windows will likely be in CRLF which would cause this to fail building.

I noticed your project that is copied over is built on Windows at a `Z:\` disk. There doesn't appear to be any CI workflow to build the project on Github, and given the language choice is commonly developed on a Windows environment, developers / contributors may encounter this issue when building the image.

I can update `.gitattributes` for you, or remove the HereDoc usage. I am bringing this to your attention since `.gitattributes` will only be useful for a git checkout, if someone were to copy/paste this `Dockerfile` on Windows instead of clone it they'd likely hit the same issue and the error output is not obvious to someone unfamiliar with the importance of line endings management (_`.sh` should always be `LF`, `.bat` should always be `CRLF` for example_).