### PR TITLE
Try `CF-Connecting-IP` if `X-Real-IP` is unset.

### DIFF
--- a/DnsServerCore/Extensions.cs
+++ b/DnsServerCore/Extensions.cs
@@ -51,6 +51,13 @@ namespace DnsServerCore
                         //get the real IP address of the requesting client from X-Real-IP header set in nginx proxy_pass block
                         return new IPEndPoint(address, 0);
                     }
+                    //Cloudflare stores the original visitor IP address in the CF-Connecting-IP header instead
+                    //See https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip
+                    string cfConnectingIp = context.Request.Headers["CF-Connecting-IP"];
+                    if (IPAddress.TryParse(cfConnectingIp, out IPAddress address))
+                    {
+                        return new IPEndPoint(address, 0);
+                    }
                 }
 
                 return new IPEndPoint(remoteIP, context.Connection.RemotePort);


### PR DESCRIPTION
This is used by Cloudflare to store the original visitor IP address (see https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip).

This header is useful when accessing the DNS server via a Cloudflare tunnel.