### PR TITLE
Filter AAAA: add config option for TTL

### DIFF
--- a/Apps/FilterAaaaApp/App.cs
+++ b/Apps/FilterAaaaApp/App.cs
@@ -37,6 +37,7 @@ namespace FilterAaaa
         IDnsServer _dnsServer;
 
         bool _enableFilterAaaa;
+        uint _defaultTtl;
         bool _bypassLocalZones;
         NetworkAddress[] _bypassNetworks;
         string[] _bypassDomains;
@@ -62,6 +63,7 @@ namespace FilterAaaa
             JsonElement jsonConfig = jsonDocument.RootElement;
 
             _enableFilterAaaa = jsonConfig.GetPropertyValue("enableFilterAaaa", false);
+            _defaultTtl = jsonConfig.GetPropertyValue("defaultTtl", 30u);
             _bypassLocalZones = jsonConfig.GetPropertyValue("bypassLocalZones", false);
 
             if (jsonConfig.TryReadArray("bypassNetworks", NetworkAddress.Parse, out NetworkAddress[] bypassNetworks))
@@ -146,7 +148,7 @@ namespace FilterAaaa
                         }
                     }
 
-                    DnsResourceRecord[] authority = [new DnsResourceRecord(qname, DnsResourceRecordType.SOA, DnsClass.IN, 30, new DnsSOARecordData(_dnsServer.ServerDomain, _dnsServer.ResponsiblePerson.Address, 1, 3600, 900, 86400, 30))];
+                    DnsResourceRecord[] authority = [new DnsResourceRecord(qname, DnsResourceRecordType.SOA, DnsClass.IN, _defaultTtl, new DnsSOARecordData(_dnsServer.ServerDomain, _dnsServer.ResponsiblePerson.Address, 1, 3600, 900, 86400, _defaultTtl))];
 
                     return new DnsDatagram(response.Identifier, true, response.OPCODE, false, false, response.RecursionDesired, response.RecursionAvailable, false, false, DnsResponseCode.NoError, response.Question, answer, authority);
                 }

--- a/Apps/FilterAaaaApp/dnsApp.config
+++ b/Apps/FilterAaaaApp/dnsApp.config
@@ -1,5 +1,6 @@
 {
   "enableFilterAaaa": true,
+  "defaultTtl": 30,
   "bypassLocalZones": false,
   "bypassNetworks": [
   ],


### PR DESCRIPTION
Add a `defaultTtl` configuration option to set the TTL for use in SOA records returned by the Filter AAAA app. The default remains at the previous value of `30`.