### PR TITLE
feat: accept json body in SetDnsSettings endpoint

### DIFF
--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -350,6 +350,8 @@ namespace DnsServerCore
 
             builder.WebHost.ConfigureKestrel(delegate (WebHostBuilderContext context, KestrelServerOptions serverOptions)
             {
+                serverOptions.AllowSynchronousIO = true;
+
                 //http
                 foreach (IPAddress webServiceLocalAddress in webServiceLocalAddresses)
                     serverOptions.Listen(webServiceLocalAddress, webServiceHttpPort);


### PR DESCRIPTION
This would be the minimally invasive way of implementing this but it reads the json body over and over again which is not very memory efficient but this way I don't have to adapt any of the callers and everything just works