### PR TITLE
Accept Proxy Protocol local requests without source address

### DIFF
--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -413,7 +413,12 @@ namespace DnsServerCore.Dns
                                 }
 
                                 ProxyProtocolStream proxyStream = await ProxyProtocolStream.CreateAsServerAsync(recvBufferStream);
-                                remoteEP = new IPEndPoint(proxyStream.SourceAddress, proxyStream.SourcePort);
+
+                                if (!proxyStream.IsLocal)
+                                {
+                                    remoteEP = new IPEndPoint(proxyStream.SourceAddress, proxyStream.SourcePort);
+                                }
+                                
                                 recvBufferStream.Position = proxyStream.DataOffset;
                             }
 


### PR DESCRIPTION
When Technitium is used as a downstream DNS server, the upstream proxy could send health check requests which are not forwarded from a client. Hence, the Proxy Protocol header does not include a source address. For this purpose, the specification describes the "local" command. With this flag, the proxy signals the absence of source address and port.
Technitium did non respect this and threw an error because of missing source address.

lowest 4 bits of byte 13 is the command (local vs proxy)
https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

The change was successfully tested with dnsdist as DNS proxy. The healthcheck with local flag succeeds and the regular relayed requests are processed with source address from the proxy header.