### PR TITLE
Change hostname display command on linux install.sh

### DIFF
--- a/DnsServerApp/install.sh
+++ b/DnsServerApp/install.sh
@@ -107,7 +107,7 @@ then
 	
 		echo ""
 		echo "Technitium DNS Server was installed successfully!"
-		echo "Open http://$(hostname):5380/ to access the web console."
+		echo "Open http://$(cat /proc/sys/kernel/hostname):5380/ to access the web console."
 		echo ""
 		echo "Donate! Make a contribution by becoming a Patron: https://www.patreon.com/technitium"
 		echo ""


### PR DESCRIPTION
Very small issue but when the install.sh script finishes, on minimal distro without inetutils or net-tools, you get a hostname command not found error.
printing the current hostname from /proc/sys/kernel/hostname would work for any distro and fix the issue on minimal base.
also works from within containers