### PR TITLE
Update zone.js - add partial match search to zone records filtering

### DIFF
--- a/DnsServerCore/www/js/zone.js
+++ b/DnsServerCore/www/js/zone.js
@@ -3253,9 +3253,12 @@ function showEditZonePage(pageNumber) {
                 filterType = filterType.toUpperCase();
 
             for (var i = 0; i < editZoneRecords.length; i++) {
-                if ((filterDomain != null) && (editZoneRecords[i].name !== filterDomain))
-                    continue;
-
+                if (filterDomain != null)
+                    var splittedDomainFilter = filterDomain.trim().split(".")[0].toLowerCase();
+                    var recordName = editZoneRecords[i].name.toLowerCase();
+                    if (!recordName.includes(splittedDomainFilter))
+                        continue;
+                        
                 if ((filterType != null) && (editZoneRecords[i].type !== filterType))
                     continue;
 


### PR DESCRIPTION
Improved the zone records search functionality in zone.js to support partial matching. 

The previous implementation required an exact match on record names, which was unintuitive and restrictive. 

This update allows the search input to match any record that contains the entered string, regardless of position or case.  Also includes a split on "." to isolate the relevant prefix for matching purposes. 

The filtering logic was adjusted to ensure a more user-friendly experience during zone editing.