### PR TITLE
Fix the setting of cluster node IP records for Dual-Stack IP addresses

### DIFF
--- a/DnsServerCore/Cluster/ClusterManager.cs
+++ b/DnsServerCore/Cluster/ClusterManager.cs
@@ -980,10 +980,12 @@ namespace DnsServerCore.Cluster
                 {
                     case AddressFamily.InterNetwork:
                         record = new DnsResourceRecord(node.Name, DnsResourceRecordType.A, DnsClass.IN, 60, new DnsARecordData(ipAddress));
+                        v4AddressRecords.Add(record);
                         break;
 
                     case AddressFamily.InterNetworkV6:
                         record = new DnsResourceRecord(node.Name, DnsResourceRecordType.AAAA, DnsClass.IN, 60, new DnsAAAARecordData(ipAddress));
+                        v6AddressRecords.Add(record);
                         break;
 
                     default:
@@ -993,18 +995,6 @@ namespace DnsServerCore.Cluster
                 GenericRecordInfo recordInfo = record.GetAuthGenericRecordInfo();
                 recordInfo.LastModified = DateTime.UtcNow;
                 recordInfo.Comments = recordComments;
-
-                switch (record.Type)
-                {
-                    case DnsResourceRecordType.A:
-                        v4AddressRecords.Add(record);
-                        break;
-                    case DnsResourceRecordType.AAAA:
-                        v6AddressRecords.Add(record);
-                        break;
-                    default:
-                        throw new InvalidOperationException();
-                }
             }
             
             if (v4AddressRecords.Count > 0)

--- a/DnsServerCore/Cluster/ClusterManager.cs
+++ b/DnsServerCore/Cluster/ClusterManager.cs
@@ -969,7 +969,8 @@ namespace DnsServerCore.Cluster
             _dnsWebService.DnsServer.AuthZoneManager.AddRecord(_clusterDomain, nsRecord);
 
             //set A/AAAA record
-            List<DnsResourceRecord> addressRecords = new List<DnsResourceRecord>(node.IPAddresses.Count);
+            List<DnsResourceRecord> v4AddressRecords = new List<DnsResourceRecord>(node.IPAddresses.Count);
+            List<DnsResourceRecord> v6AddressRecords = new List<DnsResourceRecord>(node.IPAddresses.Count);
 
             foreach (IPAddress ipAddress in node.IPAddresses)
             {
@@ -993,10 +994,23 @@ namespace DnsServerCore.Cluster
                 recordInfo.LastModified = DateTime.UtcNow;
                 recordInfo.Comments = recordComments;
 
-                addressRecords.Add(record);
+                switch (record.Type)
+                {
+                    case DnsResourceRecordType.A:
+                        v4AddressRecords.Add(record);
+                        break;
+                    case DnsResourceRecordType.AAAA:
+                        v6AddressRecords.Add(record);
+                        break;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-
-            _dnsWebService.DnsServer.AuthZoneManager.SetRecords(_clusterDomain, addressRecords);
+            
+            if (v4AddressRecords.Count > 0)
+                _dnsWebService.DnsServer.AuthZoneManager.SetRecords(_clusterDomain, v4AddressRecords);
+            if (v6AddressRecords.Count > 0)
+                _dnsWebService.DnsServer.AuthZoneManager.SetRecords(_clusterDomain, v6AddressRecords);
 
             //set PTR record
             foreach (IPAddress ipAddress in node.IPAddresses)


### PR DESCRIPTION
Split the setting of A/AAAA records because the AuthZoneManager does not accept setting multiple record types simultaneously in the same SetRecords call.

Closes #1552 