### PR TITLE
feat: Implement graceful shutdown on SIGTERM

### DIFF
--- a/DnsServerApp/Program.cs
+++ b/DnsServerApp/Program.cs
@@ -21,6 +21,7 @@ using DnsServerCore;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace DnsServerApp
 {
@@ -82,6 +83,16 @@ namespace DnsServerApp
                     waitHandle.Set();
                     exitHandle.WaitOne();
                 };
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    PosixSignalRegistration.Create(PosixSignal.SIGTERM, (context) =>
+                    {
+                        context.Cancel = true;
+                        waitHandle.Set();
+                        exitHandle.WaitOne();
+                    });
+                }
 
                 Console.WriteLine("Technitium DNS Server was started successfully.\r\nUsing config folder: " + service.ConfigFolder + "\r\n\r\nNote: Open http://" + Environment.MachineName.ToLowerInvariant() + ":" + service.WebServiceHttpPort + "/ in web browser to access web console.\r\n\r\nPress [CTRL + C] to stop...");
 

--- a/DnsServerApp/systemd.service
+++ b/DnsServerApp/systemd.service
@@ -7,7 +7,6 @@ ExecStart=/usr/bin/dotnet /opt/technitium/dns/DnsServerApp.dll /etc/dns
 Restart=always
 # Restart service after 10 seconds if the dotnet service crashes:
 RestartSec=10
-KillSignal=SIGINT
 SyslogIdentifier=dns-server
 
 [Install]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ HEREDOC
 WORKDIR /opt/technitium/dns
 COPY --link ./DnsServerApp/bin/Release/publish /opt/technitium/dns
 
-# Support for graceful shutdown:
-STOPSIGNAL SIGINT
-
 ENTRYPOINT ["/usr/bin/dotnet", "/opt/technitium/dns/DnsServerApp.dll"]
 CMD ["/etc/dns"]
 


### PR DESCRIPTION
Adds a handler for the SIGTERM signal on Linux and macOS to allow the DNS server to shut down gracefully. This is the standard signal sent by `systemd` and Docker to stop a service.

- Updated `DnsServerApp/Program.cs` to handle `PosixSignal.SIGTERM`.
- Removed `KillSignal=SIGINT` from `systemd.service` to use the default `SIGTERM`.
- Removed `STOPSIGNAL SIGINT` from `Dockerfile` to use the default `SIGTERM`.

This ensures that the application has a chance to clean up resources properly before exiting when stopped as a service or container.