### PR TITLE
Fixing MISP Connector

### DIFF
--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -161,20 +161,20 @@ namespace MispConnector
             DnsResourceRecord[] answer = null;
             DnsResourceRecord[] authority = null;
             bool authoritative = false;
-            DnsResponseCode RCODE;
+            DnsResponseCode rCode;
             if (_config.AllowTxtBlockingReport && question.Type == DnsResourceRecordType.TXT)
             {
                 answer = new DnsResourceRecord[] { new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _config.BlockingAnswerTtl, new DnsTXTRecordData(blockingReport)) };
-                RCODE = DnsResponseCode.NoError;
+                rCode = DnsResponseCode.NoError;
             }
             else
             {
                 authority = new DnsResourceRecord[] { new DnsResourceRecord(question.Name, DnsResourceRecordType.SOA, question.Class, _config.BlockingAnswerTtl, _soaRecord) };
-                RCODE = DnsResponseCode.NxDomain;
+                rCode = DnsResponseCode.NxDomain;
                 authoritative = true;
             }
 
-            return BlockResponse(request: request, options: options, authority: authority, answer: answer, authoritativeAnswer: authoritative, rCode: RCODE);
+            return BlockResponse(request: request, options: options, authority: authority, answer: answer, authoritativeAnswer: authoritative, rCode: rCode);
         }
 
         private Task<DnsDatagram> BlockResponse(DnsDatagram request, EDnsOption[] options, DnsResourceRecord[] authority, DnsResourceRecord[] answer, bool authoritativeAnswer, DnsResponseCode rCode)
@@ -532,8 +532,8 @@ namespace MispConnector
             public string MaxIocAge { get; set; }
 
             [JsonPropertyName("blockingAnswerTtl")]
-            [Range(30, 86400, ErrorMessage = "The minimum available TTL is usually 30, equivalent to 30 seconds. However, most sites use a default TTL of 3600 (one hour). The maximum TTL that you can apply is 86,400 (24 hours).")]
-            public uint BlockingAnswerTtl { get; set; }
+            [Range(30, 86400, ErrorMessage = "blockingAnswerTtl must be between 30 and 86400 seconds.")]
+            public uint BlockingAnswerTtl { get; set; } = 30;
 
             [JsonPropertyName("mispApiKey")]
             [Required(ErrorMessage = "mispApiKey is a required configuration property.")]

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -151,50 +151,47 @@ namespace MispConnector
 
             string blockingReport = $"source=misp-connector;domain={blockedDomain}";
 
+            // Add blocking report as EDE to EDNS options for both TXT and other queries if the query datagram has EDNS field
             EDnsOption[] options = null;
             if (_config.AddExtendedDnsError && request.EDNS is not null)
             {
-                options = new EDnsOption[] { new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, string.Empty)) };
+                options = new EDnsOption[] { new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, blockingReport)) };
             }
 
+            DnsResourceRecord[] answer = null;
+            DnsResourceRecord[] authority = null;
+            bool authoritative = false;
+            DnsResponseCode RCODE;
             if (_config.AllowTxtBlockingReport && question.Type == DnsResourceRecordType.TXT)
             {
-                DnsResourceRecord[] answer = new DnsResourceRecord[] { new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, 60, new DnsTXTRecordData(string.Empty)) };
-                return Task.FromResult(new DnsDatagram(
-                                    ID: request.Identifier,
-                                    isResponse: true,
-                                    OPCODE: DnsOpcode.StandardQuery,
-                                    authoritativeAnswer: false,
-                                    truncation: false,
-                                    recursionDesired: request.RecursionDesired,
-                                    recursionAvailable: true,
-                                    authenticData: false,
-                                    checkingDisabled: false,
-                                    RCODE: DnsResponseCode.NoError,
-                                    question: request.Question,
-                                    answer: answer,
-                                    authority: null,
-                                    additional: null,
-                                    udpPayloadSize: request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize,
-                                    ednsFlags: EDnsHeaderFlags.None,
-                                    options: options
-                                ));
+                answer = new DnsResourceRecord[] { new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _config.BlockingAnswerTtl, new DnsTXTRecordData(blockingReport)) };
+                RCODE = DnsResponseCode.NoError;
+            }
+            else
+            {
+                authority = new DnsResourceRecord[] { new DnsResourceRecord(question.Name, DnsResourceRecordType.SOA, question.Class, _config.BlockingAnswerTtl, _soaRecord) };
+                RCODE = DnsResponseCode.NxDomain;
+                authoritative = true;
             }
 
-            DnsResourceRecord[] authority = { new DnsResourceRecord(question.Name, DnsResourceRecordType.SOA, question.Class, 60, _soaRecord) };
+            return BlockResponse(request: request, options: options, authority: authority, answer: answer, authoritativeAnswer: authoritative, rCode: RCODE);
+        }
+
+        private Task<DnsDatagram> BlockResponse(DnsDatagram request, EDnsOption[] options, DnsResourceRecord[] authority, DnsResourceRecord[] answer, bool authoritativeAnswer, DnsResponseCode rCode)
+        {
             return Task.FromResult(new DnsDatagram(
                             ID: request.Identifier,
                             isResponse: true,
                             OPCODE: DnsOpcode.StandardQuery,
-                            authoritativeAnswer: true,
+                            authoritativeAnswer: authoritativeAnswer,
                             truncation: false,
                             recursionDesired: request.RecursionDesired,
                             recursionAvailable: true,
                             authenticData: false,
                             checkingDisabled: false,
-                            RCODE: DnsResponseCode.NxDomain,
+                            RCODE: rCode,
                             question: request.Question,
-                            answer: null,
+                            answer: answer,
                             authority: authority,
                             additional: null,
                             udpPayloadSize: request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize,
@@ -528,10 +525,15 @@ namespace MispConnector
 
             [JsonPropertyName("enableBlocking")]
             public bool EnableBlocking { get; set; } = true;
+
             [JsonPropertyName("maxIocAge")]
             [Required(ErrorMessage = "maxIocAge is a required configuration property.")]
             [RegularExpression(@"^\d+[mhd]$", ErrorMessage = "Invalid interval format. Use a number followed by 'm', 'h', or 'd' (e.g., '90m', '2h', '7d').", MatchTimeoutInMilliseconds = 3000)]
             public string MaxIocAge { get; set; }
+
+            [JsonPropertyName("blockingAnswerTtl")]
+            [Range(30, 86400, ErrorMessage = "The minimum available TTL is usually 30, equivalent to 30 seconds. However, most sites use a default TTL of 3600 (one hour). The maximum TTL that you can apply is 86,400 (24 hours).")]
+            public uint BlockingAnswerTtl { get; set; }
 
             [JsonPropertyName("mispApiKey")]
             [Required(ErrorMessage = "mispApiKey is a required configuration property.")]
@@ -542,6 +544,7 @@ namespace MispConnector
             [Required(ErrorMessage = "mispServerUrl is a required configuration property.")]
             [Url(ErrorMessage = "mispServerUrl must be a valid URL.")]
             public string MispServerUrl { get; set; }
+
             [JsonPropertyName("paginationLimit")]
             public int PaginationLimit { get; set; } = 5000;
 

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -395,7 +395,8 @@ namespace MispConnector
 
                 foreach (MispAttribute attribute in attributes)
                 {
-                    string ioc = attribute.Value?.Trim().ToLowerInvariant();
+                    string ioc = attribute.Value?.Trim();
+
                     if (!string.IsNullOrEmpty(ioc))
                     {
                         if (DnsClient.IsDomainNameValid(ioc))

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -382,8 +382,10 @@ namespace MispConnector
 
                 }
 
-                List<MispAttribute> attributes = mispResponse?.Response?.Attribute;
-                if (attributes == null || attributes.Count == 0)
+                List<MispAttribute> attributes = (mispResponse?.Response?.Attribute) ?? 
+                    throw new InvalidDataException("Invalid or unexpected MISP response schema.");
+                
+                if (attributes.Count == 0)
                 {
                     hasMorePages = false;
                     continue;

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -495,8 +495,10 @@ namespace MispConnector
 
                     await foreach (var line in File.ReadLinesAsync(_domainCacheFilePath))
                     {
-                        if (!string.IsNullOrWhiteSpace(line))
-                            set.Add(line);
+                        var d = line.Trim();
+
+                        if (d.Length > 0)
+                            set.Add(d);
                     }
 
                     FrozenSet<string> domains = set.ToFrozenSet(StringComparer.OrdinalIgnoreCase);

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -405,12 +405,9 @@ namespace MispConnector
                 {
                     string ioc = attribute.Value?.Trim();
 
-                    if (!string.IsNullOrEmpty(ioc))
+                    if (!string.IsNullOrEmpty(ioc) && DnsClient.IsDomainNameValid(ioc))
                     {
-                        if (DnsClient.IsDomainNameValid(ioc))
-                        {
-                            iocSet.Add(ioc);
-                        }
+                        iocSet.Add(ioc);
                     }
                 }
 

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -467,7 +467,15 @@ namespace MispConnector
             {
                 try
                 {
-                    FrozenSet<string> domains = (await File.ReadAllLinesAsync(_domainCacheFilePath)).ToHashSet(StringComparer.OrdinalIgnoreCase).ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+                    var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                    await foreach (var line in File.ReadLinesAsync(_domainCacheFilePath))
+                    {
+                        if (!string.IsNullOrWhiteSpace(line))
+                            set.Add(line);
+                    }
+
+                    FrozenSet<string> domains = set.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
                     Interlocked.Exchange(ref _domainBlocklist, domains);
                     _dnsServer.WriteLog($"MISP Connector: Loaded {domains.Count} domains from cache.");
                 }

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -216,7 +216,7 @@ namespace MispConnector
             await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(5, 30)), cancellationToken);
             using (PeriodicTimer timer = new PeriodicTimer(_updateInterval))
             {
-                while (!cancellationToken.IsCancellationRequested)
+                while (true)
                 {
                     try
                     {

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -24,7 +24,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
@@ -53,6 +52,7 @@ namespace MispConnector
         HttpClient _httpClient;
 
         Uri _mispApiUrl;
+        Uri _mispServerUrl;
 
         DnsSOARecordData _soaRecord;
         TimeSpan _updateInterval;
@@ -105,9 +105,9 @@ namespace MispConnector
 
                 _updateInterval = ParseUpdateInterval(_config.UpdateInterval);
 
-                Uri mispServerUrl = new Uri(_config.MispServerUrl);
-                _mispApiUrl = new Uri(mispServerUrl, "/attributes/restSearch");
-                _httpClient = CreateHttpClient(mispServerUrl, _config.DisableTlsValidation);
+                _mispServerUrl = new Uri(_config.MispServerUrl);
+                _mispApiUrl = new Uri(_mispServerUrl, "/attributes/restSearch");
+                _httpClient = CreateHttpClient(_mispServerUrl, _config.DisableTlsValidation);
 
                 await LoadBlocklistFromCacheAsync();
                 _appShutdownCts = new CancellationTokenSource();
@@ -514,7 +514,7 @@ namespace MispConnector
 
         private async Task UpdateIocsAsync(CancellationToken cancellationToken)
         {
-            if (!await CheckTcpPortAsync(new Uri(_config.MispServerUrl), cancellationToken))
+            if (!await CheckTcpPortAsync(_mispServerUrl, cancellationToken))
             {
                 return;
             }

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -70,7 +70,13 @@ namespace MispConnector
             {
                 if (_updateLoopTask != null)
                 {
-                    _updateLoopTask?.WaitAsync(TimeSpan.FromSeconds(2)).Wait();
+                    try
+                    {
+                        _updateLoopTask?.WaitAsync(TimeSpan.FromSeconds(2))
+                                       .GetAwaiter()
+                                       .GetResult();
+                    }
+                    catch { }
                 }
             }
             catch

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -130,6 +130,8 @@ namespace MispConnector
             }
         }
 
+        // No allowlist override in this app.
+        // ProcessRequestAsync handles blocking.
         public Task<bool> IsAllowedAsync(DnsDatagram request, IPEndPoint remoteEP)
         {
             return Task.FromResult(false);

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -367,23 +367,19 @@ namespace MispConnector
 
                         break;
                     }
-                    catch (Exception ex) when (ex is HttpRequestException || ex is SocketException || ex is OperationCanceledException)
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
-                        // These are likely transient network errors, so we should retry.
-                        _dnsServer.WriteLog($"WARNING: A transient network error occurred on page {page}, attempt {attempt}/{maxRetries}. Error: {ex.Message}");
-                        if (attempt < maxRetries)
-                        {
-                            TimeSpan delay = TimeSpan.FromSeconds(Math.Pow(2, attempt)) + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000));
-                            _dnsServer.WriteLog($"Waiting for {delay.TotalSeconds:F1} seconds before retrying...");
-                            await Task.Delay(delay, cancellationToken);
-                        }
-                        else
-                        {
-                            // All retries have failed for this page.
-                            _dnsServer.WriteLog($"ERROR: Failed to fetch page {page} after {maxRetries} attempts. Aborting entire update cycle.");
-                            throw;
-                        }
+                        throw;
                     }
+                    catch (HttpRequestException ex)
+                    {
+                        await HandleRetry(ex, page, maxRetries, attempt, cancellationToken);
+                    }
+                    catch (SocketException ex)
+                    {
+                        await HandleRetry(ex, page, maxRetries, attempt, cancellationToken);
+                    }
+
                 }
 
                 List<MispAttribute> attributes = mispResponse?.Response?.Attribute;
@@ -419,6 +415,23 @@ namespace MispConnector
 
             _dnsServer.WriteLog($"Finished paginated fetch. Freezing {iocSet.Count} IOCs for optimal read performance...");
             return iocSet;
+        }
+        private async Task HandleRetry(Exception ex, int page, int maxRetries, int attempt, CancellationToken cancellationToken)
+        {
+            // These are likely transient network errors, so we should retry.
+            _dnsServer.WriteLog($"WARNING: A transient network error occurred on page {page}, attempt {attempt}/{maxRetries}. Error: {ex.Message}");
+            if (attempt < maxRetries)
+            {
+                TimeSpan delay = TimeSpan.FromSeconds(Math.Pow(2, attempt)) + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000));
+                _dnsServer.WriteLog($"Waiting for {delay.TotalSeconds:F1} seconds before retrying...");
+                await Task.Delay(delay, cancellationToken);
+            }
+            else
+            {
+                // All retries have failed for this page.
+                _dnsServer.WriteLog($"ERROR: Failed to fetch page {page} after {maxRetries} attempts. Aborting entire update cycle.");
+                throw ex;
+            }
         }
 
         private bool IsDomainBlocked(string domain, out string foundZone)

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -216,18 +216,20 @@ namespace MispConnector
                     {
                         await UpdateIocsAsync(cancellationToken);
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
                         _dnsServer.WriteLog("Update loop is shutting down gracefully.");
                         break;
                     }
+
                     catch (Exception ex)
                     {
                         _dnsServer.WriteLog($"FATAL: The MispConnector update task failed unexpectedly. Error: {ex.Message}");
                         _dnsServer.WriteLog(ex);
                     }
 
-                    await timer.WaitForNextTickAsync(cancellationToken);
+                    if (!await timer.WaitForNextTickAsync(cancellationToken))
+                        break;
                 }
             }
         }
@@ -379,11 +381,13 @@ namespace MispConnector
                     }
                     catch (HttpRequestException ex)
                     {
-                        await HandleRetry(ex, page, maxRetries, attempt, cancellationToken);
+                        if (!await HandleRetry(ex, page, maxRetries, attempt, cancellationToken))
+                            throw;
                     }
                     catch (SocketException ex)
                     {
-                        await HandleRetry(ex, page, maxRetries, attempt, cancellationToken);
+                        if (!await HandleRetry(ex, page, maxRetries, attempt, cancellationToken))
+                            throw;
                     }
 
                 }
@@ -424,23 +428,37 @@ namespace MispConnector
             _dnsServer.WriteLog($"Finished paginated fetch. Freezing {iocSet.Count} IOCs for optimal read performance...");
             return iocSet;
         }
-        private async Task HandleRetry(Exception ex, int page, int maxRetries, int attempt, CancellationToken cancellationToken)
+
+        private async Task<bool> HandleRetry(
+            Exception ex,
+            int page,
+            int maxRetries,
+            int attempt,
+            CancellationToken cancellationToken)
         {
-            // These are likely transient network errors, so we should retry.
-            _dnsServer.WriteLog($"WARNING: A transient network error occurred on page {page}, attempt {attempt}/{maxRetries}. Error: {ex.Message}");
+            _dnsServer.WriteLog(
+                $"WARNING: A transient network error occurred on page {page}, " +
+                $"attempt {attempt}/{maxRetries}. Error: {ex.Message}");
+
             if (attempt < maxRetries)
             {
-                TimeSpan delay = TimeSpan.FromSeconds(Math.Pow(2, attempt)) + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000));
-                _dnsServer.WriteLog($"Waiting for {delay.TotalSeconds:F1} seconds before retrying...");
+                TimeSpan delay =
+                    TimeSpan.FromSeconds(Math.Pow(2, attempt)) +
+                    TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000));
+
+                _dnsServer.WriteLog(
+                    $"Waiting for {delay.TotalSeconds:F1} seconds before retrying...");
+
                 await Task.Delay(delay, cancellationToken);
+                return true; // retry
             }
-            else
-            {
-                // All retries have failed for this page.
-                _dnsServer.WriteLog($"ERROR: Failed to fetch page {page} after {maxRetries} attempts. Aborting entire update cycle.");
-                throw ex;
-            }
+
+            _dnsServer.WriteLog(
+                $"ERROR: Failed to fetch page {page} after {maxRetries} attempts.");
+
+            return false; // abort
         }
+
 
         private bool IsDomainBlocked(string domain, out string foundZone)
         {

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -281,6 +281,10 @@ namespace MispConnector
                 _dnsServer.WriteLog($"Pre-flight TCP check successful for {host}:{port}.");
                 return true;
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (OperationCanceledException)
             {
                 _dnsServer.WriteLog($"ERROR: Pre-flight TCP check failed: Connection to {host}:{port} timed out after {timeout.TotalSeconds} seconds. Check firewall rules or network route.");

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -424,24 +424,20 @@ namespace MispConnector
         {
             FrozenSet<string> currentBlocklist = _domainBlocklist;
 
+            // Span-based lookup
+            FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> lookup = currentBlocklist.GetAlternateLookup<ReadOnlySpan<char>>();
+
             ReadOnlySpan<char> currentSpan = domain.AsSpan();
 
             while (true)
             {
-                // To look up in a HashSet<string>, we must provide a string.
-                string key = new string(currentSpan);
-                if (currentBlocklist.TryGetValue(key, out foundZone))
-                {
+                if (lookup.TryGetValue(currentSpan, out foundZone))
                     return true;
-                }
 
                 int dotIndex = currentSpan.IndexOf('.');
-                if (dotIndex == -1)
-                {
-                    break; // No more parent domains.
-                }
+                if (dotIndex < 0)
+                    break;
 
-                // Slice to the parent domain view. No allocation here.
                 currentSpan = currentSpan.Slice(dotIndex + 1);
             }
 
@@ -483,11 +479,11 @@ namespace MispConnector
             {
                 await WriteIocsToCacheAsync(domains, cancellationToken);
                 Interlocked.Exchange(ref _domainBlocklist, domains);
-                _dnsServer.WriteLog($"MISP Connector: Successfully updated blocklist with {domains.Count} domains.");
+                _dnsServer.WriteLog($"MISP Connector: Successfully updated currentBlocklist with {domains.Count} domains.");
             }
             else
             {
-                _dnsServer.WriteLog("MISP data has not changed. No update to blocklist or cache is necessary.");
+                _dnsServer.WriteLog("MISP data has not changed. No update to currentBlocklist or cache is necessary.");
             }
         }
 

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -272,11 +272,11 @@ namespace MispConnector
 
             try
             {
-                using (CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, new CancellationTokenSource(timeout).Token))
-                using (TcpClient client = new TcpClient())
-                {
-                    await client.ConnectAsync(host, port, cts.Token);
-                }
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(timeout);
+
+                using var client = new TcpClient();
+                await client.ConnectAsync(host, port, cts.Token);
 
                 _dnsServer.WriteLog($"Pre-flight TCP check successful for {host}:{port}.");
                 return true;

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -70,7 +70,7 @@ namespace MispConnector
             {
                 if (_updateLoopTask != null)
                 {
-                    _ = Task.WhenAny(_updateLoopTask, Task.Delay(TimeSpan.FromSeconds(2))).GetAwaiter().GetResult();
+                    _updateLoopTask?.WaitAsync(TimeSpan.FromSeconds(2)).Wait();
                 }
             }
             catch

--- a/Apps/MispConnectorApp/MispConnectorApp.csproj
+++ b/Apps/MispConnectorApp/MispConnectorApp.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<Version>1.0</Version>
+		<Version>1.1</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<Company>Technitium</Company>
 		<Product>Technitium DNS Server</Product>

--- a/Apps/MispConnectorApp/README.md
+++ b/Apps/MispConnectorApp/README.md
@@ -4,6 +4,12 @@ A plugin that pulls malicious domain names from MISP feeds and enforces blocking
 
 It maintains in-memory blocklists with disk-backed caching and periodically refreshes from the source.
 
+## What is MISP 
+
+MISP is a threat intelligence platform for sharing, storing and correlating Indicators of Compromise (IOC) of targeted attacks, threat intelligence, financial fraud information, vulnerability information or even counter-terrorism information. Refer to the [project documentation for more details](https://www.misp-project.org/documentation/). This plugin assumes an existing MISP instance to connect to. Installation and configuration is out of scope of Technitium DNS Server.
+
+See [this article](https://zaferbalkan.com/technitium-misp/) for a sample use case. 
+
 ## Features
 
 - Retrieves indicators of compromise (IOCs) aka. malicious domain names from a MISP server via its REST API.

--- a/Apps/MispConnectorApp/dnsApp.config
+++ b/Apps/MispConnectorApp/dnsApp.config
@@ -5,6 +5,7 @@
 	"disableTlsValidation": false,
 	"updateInterval": "2h",
 	"maxIocAge": "30d",
+	"blockingAnswerTtl": 3600,
 	"allowTxtBlockingReport": true,
 	"paginationLimit": 5000,
 	"addExtendedDnsError": true

--- a/Apps/MispConnectorApp/dnsApp.config
+++ b/Apps/MispConnectorApp/dnsApp.config
@@ -5,7 +5,7 @@
 	"disableTlsValidation": false,
 	"updateInterval": "2h",
 	"maxIocAge": "30d",
-	"blockingAnswerTtl": 3600,
+	"blockingAnswerTtl": 30,
 	"allowTxtBlockingReport": true,
 	"paginationLimit": 5000,
 	"addExtendedDnsError": true


### PR DESCRIPTION
Current version accidentally sends empty string as EDE message and TXT response. Basically, blocks silently. It is mentioned here: https://github.com/TechnitiumSoftware/DnsServer/pull/1403#issuecomment-3615644655

I also added a TTL parameter like Advanced Blocker App.