### PR TITLE
Auto detect dark mode

### DIFF
--- a/DnsServerCore/www/js/main.js
+++ b/DnsServerCore/www/js/main.js
@@ -2879,6 +2879,12 @@ function applyTheme() {
         document.body.classList.remove("dark-mode");
 }
 
+if (window.matchMedia && !localStorage.getItem("theme")) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+        applyTheme();
+    });
+}
+
 function toggleTheme() {
     document.body.classList.toggle("dark-mode");
 

--- a/DnsServerCore/www/js/main.js
+++ b/DnsServerCore/www/js/main.js
@@ -2871,6 +2871,10 @@ function applyTheme() {
 
     if (currentTheme === "dark")
         document.body.classList.add("dark-mode");
+    else if (currentTheme === "light")
+        document.body.classList.remove("dark-mode");
+    else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        document.body.classList.add("dark-mode");
     else
         document.body.classList.remove("dark-mode");
 }


### PR DESCRIPTION
I often find myself switching between light and dark mode system wide either manually (based on how light the room is) or automatically (system setting based on the time of day).

Rather than having to manually toggle dark/light mode, this PR will auto detect if dark mode should be enabled based on the users system preference.