### PR TITLE
Created domain typosquatting checker

### DIFF
--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -49,6 +49,8 @@ namespace TyposquattingDetector
         TyposquattingDetector _detector;
         CancellationTokenSource _appShutdownCts;
 
+        const string DefaultDomainListUrl = "https://downloads.technitium.com/dns/typosquatting/majestic_million.csv";
+
         #endregion variables
 
         #region IDisposable
@@ -103,7 +105,7 @@ namespace TyposquattingDetector
                 {
                     _dnsServer.WriteLog($"Typosquatting Detector: Started downloading domain list to path: '{_domainListFilePath}'.");
 
-                    Uri domainList = new Uri(_config.Url);
+                    Uri domainList = new Uri(DefaultDomainListUrl);
                     _httpClient = CreateHttpClient(domainList, _config.DisableTlsValidation);
                     await _httpClient.GetStreamAsync(domainList).ContinueWith(async t =>
                     {
@@ -124,9 +126,6 @@ namespace TyposquattingDetector
                     }).GetAwaiter().GetResult().ConfigureAwait(false);
                 }
                 _dnsServer.WriteLog($"Typosquatting Detector: Domain list saved to path: '{_domainListFilePath}'.");
-                _dnsServer.WriteLog($"Typosquatting Detector: Processing domain list...");
-                _detector = new TyposquattingDetector(_domainListFilePath, _config.FuzzyMatchThreshold);
-                _dnsServer.WriteLog($"Typosquatting Detector: Processing completed.");
 
                 // We do not await this, as it's designed to run for the lifetime of the app.
                 _updateLoopTask = StartUpdateLoopAsync(_appShutdownCts.Token);
@@ -312,9 +311,10 @@ namespace TyposquattingDetector
 
             try
             {
-                var detector = new TyposquattingDetector(_domainListFilePath, _config.FuzzyMatchThreshold);
+                _dnsServer.WriteLog($"Typosquatting Detector: Processing domain list...");
+                _detector = new TyposquattingDetector(_domainListFilePath, _config.Path, _config.FuzzyMatchThreshold);
+                _dnsServer.WriteLog($"Typosquatting Detector: Processing completed.");
 
-                _dnsServer.WriteLog($"Typosquatting Detector: Loaded Alexa Top 1M domains from file.");
             }
             catch (IOException ex)
             {

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -333,7 +333,9 @@ namespace TyposquattingDetector
                     if (!safePath.StartsWith(_dnsServer.ApplicationFolder)) throw new SecurityException("Access Denied");
 
                 }
+                var oldDetector = _detector;
                 _detector = new TyposquattingDetector(_domainListFilePath, safePath, _config.FuzzyMatchThreshold);
+                oldDetector?.Dispose();
                 _dnsServer.WriteLog($"Typosquatting Detector: Processing completed.");
             }
             catch (IOException ex)

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -372,7 +372,7 @@ namespace TyposquattingDetector
                 if (!safePath.StartsWith(_dnsServer.ApplicationFolder)) throw new SecurityException("Access Denied");
 
                 var oldDetector = _detector;
-                _detector = new TyposquattingDetector(_domainListFilePath!, safePath, _config.FuzzyMatchThreshold);
+                _detector = new TyposquattingDetector(_domainListFilePath!, safePath, _config!.FuzzyMatchThreshold);
                 oldDetector?.Dispose();
                 _dnsServer.WriteLog($"Typosquatting Detector: Processing completed.");
             }

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -44,7 +44,7 @@ namespace TyposquattingDetector
         private const string DefaultDomainListUrl = "https://downloads.technitium.com/dns/typosquatting/majestic_million.csv";
         private CancellationTokenSource? _appShutdownCts;
         private Config? _config;
-        private TyposquattingDetector? _detector;
+        private volatile TyposquattingDetector? _detector;
         private IDnsServer? _dnsServer;
         private string? _domainListFilePath;
         private HttpClient? _httpClient;

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -49,7 +49,6 @@ namespace TyposquattingDetector
         private volatile TyposquattingDetector? _detector;
         private IDnsServer? _dnsServer;
         private string? _domainListFilePath;
-        private HttpClient? _httpClient;
         private DnsSOARecordData? _soaRecord;
         private TimeSpan _updateInterval;
         private Task? _updateLoopTask;
@@ -75,7 +74,6 @@ namespace TyposquattingDetector
             finally
             {
                 _appShutdownCts?.Dispose();
-                _httpClient?.Dispose();
             }
         }
 

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -199,7 +199,7 @@ namespace TyposquattingDetector
 
             DnsQuestionRecord question = request.Question[0];
             var res = _detector.Check(question.Name);
-            if (res.Status == DetectionStatus.Clean)
+            if (res.IsSuspicious == false)
             {
                 return Task.FromResult<DnsDatagram?>(null);
             }

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -393,7 +393,7 @@ namespace TyposquattingDetector
         {
             get
             {
-                return "Downloads Alexa toip 1 million domains, runs a fuzzy logic, and if the match is high but not 100, it may be a typosquatting attempt.";
+                return "Evaluates queried domains against a trusted corpus and flags visually similar near-matches as potential typosquatting. Allows blocking of suspicious queries and exposes structured detection details. The fuzzy-match threshold and optional custom domain list are operator-tunable; adjust cautiously to reduce false-positive impact.";
             }
         }
 

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -321,7 +321,7 @@ namespace TyposquattingDetector
         {
             using PeriodicTimer timer = new PeriodicTimer(_updateInterval);
 
-            if (!_changed)
+            if (!Volatile.Read(ref _changed))
             {
                 // Nothing changed, skip first update
             }

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -1,0 +1,339 @@
+﻿/*
+Technitium DNS Server
+Copyright (C) 2025  Shreyas Zare (shreyas@technitium.com)
+Copyright (C) 2025  Zafer Balkan (zafer@zaferbalkan.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using DnsServerCore.ApplicationCommon;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TechnitiumLibrary.Net.Dns;
+using TechnitiumLibrary.Net.Dns.EDnsOptions;
+using TechnitiumLibrary.Net.Dns.ResourceRecords;
+using TechnitiumLibrary.Net.Http.Client;
+
+namespace TyposquattingDetector
+{
+    public sealed partial class App : IDnsApplication, IDnsRequestBlockingHandler
+    {
+        #region variables
+        string _domainListFilePath;
+        Config _config;
+        IDnsServer _dnsServer;
+        HttpClient _httpClient;
+        DnsSOARecordData _soaRecord;
+        TimeSpan _updateInterval;
+        Task _updateLoopTask;
+        TyposquattingDetector _detector;
+        CancellationTokenSource _appShutdownCts;
+
+        #endregion variables
+
+        #region IDisposable
+
+        public void Dispose()
+        {
+            _appShutdownCts?.Cancel();
+            try
+            {
+                if (_updateLoopTask != null)
+                {
+                    _ = Task.WhenAny(_updateLoopTask, Task.Delay(TimeSpan.FromSeconds(2))).GetAwaiter().GetResult();
+                }
+            }
+            catch
+            {
+            }
+            finally
+            {
+                _appShutdownCts?.Dispose();
+                _httpClient?.Dispose();
+            }
+        }
+
+        #endregion IDisposable
+
+        #region public
+
+        public async Task InitializeAsync(IDnsServer dnsServer, string config)
+        {
+            _dnsServer = dnsServer;
+            try
+            {
+                _soaRecord = new DnsSOARecordData(_dnsServer.ServerDomain, _dnsServer.ResponsiblePerson.Address, 1, 14400, 3600, 604800, 60);
+
+                JsonSerializerOptions options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                _config = JsonSerializer.Deserialize<Config>(config, options);
+
+                Validator.ValidateObject(_config, new ValidationContext(_config), validateAllProperties: true);
+                _updateInterval = ParseUpdateInterval(_config.UpdateInterval);
+                _appShutdownCts = new CancellationTokenSource();
+
+                string configDir = _dnsServer.ApplicationFolder;
+                Directory.CreateDirectory(configDir);
+                _domainListFilePath = Path.Combine(configDir, "majestic_million.csv");
+
+                if (Path.Exists(_domainListFilePath))
+                {
+                    _dnsServer.WriteLog($"Typosquatting Detector: Domain list exists at path: '{_domainListFilePath}'.");
+                }
+                else
+                {
+                    _dnsServer.WriteLog($"Typosquatting Detector: Started downloading domain list to path: '{_domainListFilePath}'.");
+
+                    Uri domainList = new Uri(_config.Url);
+                    _httpClient = CreateHttpClient(domainList, _config.DisableTlsValidation);
+                    await _httpClient.GetStreamAsync(domainList).ContinueWith(async t =>
+                    {
+                        try
+                        {
+                            using (Stream stream = await t)
+                            using (FileStream fs = new FileStream(_domainListFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+                            {
+                                await stream.CopyToAsync(fs);
+                            }
+                            _dnsServer.WriteLog($"Typosquatting Detector: Downloaded domain list from '{domainList}' to '{_domainListFilePath}'.");
+                        }
+                        catch (Exception ex)
+                        {
+                            _dnsServer.WriteLog($"FATAL: Failed to download domain list from '{domainList}'. Error: {ex.Message}");
+                            _dnsServer.WriteLog(ex);
+                        }
+                    }).GetAwaiter().GetResult().ConfigureAwait(false);
+                }
+                _dnsServer.WriteLog($"Typosquatting Detector: Domain list saved to path: '{_domainListFilePath}'.");
+                _dnsServer.WriteLog($"Typosquatting Detector: Processing domain list...");
+                _detector = new TyposquattingDetector(_domainListFilePath, _config.FuzzyMatchThreshold);
+                _dnsServer.WriteLog($"Typosquatting Detector: Processing completed.");
+
+                // We do not await this, as it's designed to run for the lifetime of the app.
+                _updateLoopTask = StartUpdateLoopAsync(_appShutdownCts.Token);
+                _ = _updateLoopTask.ContinueWith(t =>
+               {
+                   if (t.IsFaulted)
+                   {
+                       _dnsServer.WriteLog($"FATAL: Update loop terminated unexpectedly: {t.Exception?.GetBaseException().Message}");
+                       _dnsServer.WriteLog(t.Exception);
+                   }
+               }, TaskContinuationOptions.OnlyOnFaulted);
+            }
+            catch (Exception ex)
+            {
+                _dnsServer.WriteLog($"FATAL: Typosquatting Detector failed to initialize. Check configuration. Error: {ex.Message}");
+                _dnsServer.WriteLog(ex);
+            }
+        }
+
+        public Task<bool> IsAllowedAsync(DnsDatagram request, IPEndPoint remoteEP)
+        {
+            return Task.FromResult(false);
+        }
+
+        public async Task<DnsDatagram?> ProcessRequestAsync(DnsDatagram request, IPEndPoint remoteEP)
+        {
+            if (_config?.Enable != true)
+            {
+                return null;
+            }
+
+            // Download takes time. Let's nor break the app. 
+            if (_detector is null)
+            {
+                return null;
+            }
+
+            DnsQuestionRecord question = request.Question[0];
+            var res = await _detector.FuzzyMatchAsync(question.Name);
+            if (res.Status == DetectionStatus.Clean)
+            {
+                return null;
+            }
+
+            string blockingReport = $"source=typosquatting-detector;domain={res.Query};severity={res.Severity};reason={res.Reason}";
+
+            EDnsOption[]? options = null;
+            if (_config.AddExtendedDnsError && request.EDNS is not null)
+            {
+                options = new EDnsOption[] { new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, string.Empty)) };
+            }
+
+            if (_config.AllowTxtBlockingReport && question.Type == DnsResourceRecordType.TXT)
+            {
+                DnsResourceRecord[] answer = new DnsResourceRecord[] { new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, 60, new DnsTXTRecordData(string.Empty)) };
+                return new DnsDatagram(
+                                    ID: request.Identifier,
+                                    isResponse: true,
+                                    OPCODE: DnsOpcode.StandardQuery,
+                                    authoritativeAnswer: false,
+                                    truncation: false,
+                                    recursionDesired: request.RecursionDesired,
+                                    recursionAvailable: true,
+                                    authenticData: false,
+                                    checkingDisabled: false,
+                                    RCODE: DnsResponseCode.NoError,
+                                    question: request.Question,
+                                    answer: answer,
+                                    authority: null,
+                                    additional: null,
+                                    udpPayloadSize: request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize,
+                                    ednsFlags: EDnsHeaderFlags.None,
+                                    options: options
+                                );
+            }
+
+            DnsResourceRecord[] authority = { new DnsResourceRecord(question.Name, DnsResourceRecordType.SOA, question.Class, 60, _soaRecord) };
+            return new DnsDatagram(
+                            ID: request.Identifier,
+                            isResponse: true,
+                            OPCODE: DnsOpcode.StandardQuery,
+                            authoritativeAnswer: true,
+                            truncation: false,
+                            recursionDesired: request.RecursionDesired,
+                            recursionAvailable: true,
+                            authenticData: false,
+                            checkingDisabled: false,
+                            RCODE: DnsResponseCode.NxDomain,
+                            question: request.Question,
+                            answer: null,
+                            authority: authority,
+                            additional: null,
+                            udpPayloadSize: request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize,
+                            ednsFlags: EDnsHeaderFlags.None,
+                            options: options
+                        );
+        }
+
+        #endregion public
+
+        #region private
+        private async Task StartUpdateLoopAsync(CancellationToken cancellationToken)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(5, 30)), cancellationToken);
+            using (PeriodicTimer timer = new PeriodicTimer(_updateInterval))
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await UpdateDomainListAsync(cancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        _dnsServer.WriteLog("Update loop is shutting down gracefully.");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _dnsServer.WriteLog($"FATAL: The Typosquatting Detector update task failed unexpectedly. Error: {ex.Message}");
+                        _dnsServer.WriteLog(ex);
+                    }
+
+                    await timer.WaitForNextTickAsync(cancellationToken);
+                }
+            }
+        }
+        private static TimeSpan ParseUpdateInterval(string interval)
+        {
+            if (string.IsNullOrWhiteSpace(interval) || interval.Length < 2)
+            {
+                throw new FormatException("Update interval is not in a valid format (e.g., '60m', '2h', '7d').");
+            }
+
+            string unit = interval.Substring(interval.Length - 1).ToLowerInvariant();
+            string valueString = interval.Substring(0, interval.Length - 1);
+
+            if (!int.TryParse(valueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value) || value <= 0)
+            {
+                throw new FormatException($"Invalid numeric value '{valueString}' in update interval.");
+            }
+
+            switch (unit)
+            {
+                case "m":
+                    return TimeSpan.FromMinutes(value);
+
+                case "h":
+                    return TimeSpan.FromHours(value);
+
+                case "d":
+                    return TimeSpan.FromDays(value);
+                case "w":
+                    return TimeSpan.FromDays(value * 7);
+                default:
+                    throw new FormatException($"Invalid unit '{unit}' in update interval. Allowed units are 'm', 'h', 'd'. 'w'.");
+            }
+        }
+
+        private HttpClient CreateHttpClient(Uri serverUrl, bool disableTlsValidation)
+        {
+            HttpClientNetworkHandler handler = new HttpClientNetworkHandler();
+            handler.Proxy = _dnsServer.Proxy;
+            handler.NetworkType = _dnsServer.PreferIPv6 ? HttpClientNetworkType.PreferIPv6 : HttpClientNetworkType.Default;
+            handler.DnsClient = _dnsServer;
+
+            if (disableTlsValidation)
+            {
+                handler.InnerHandler.SslOptions.RemoteCertificateValidationCallback = delegate (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+                {
+                    return true;
+                };
+
+                _dnsServer.WriteLog($"WARNING: TLS certificate validation is DISABLED for server: {serverUrl}");
+            }
+
+            return new HttpClient(handler);
+        }
+
+        private async Task UpdateDomainListAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested) return;
+
+            try
+            {
+                var detector = new TyposquattingDetector(_domainListFilePath, _config.FuzzyMatchThreshold);
+
+                _dnsServer.WriteLog($"Typosquatting Detector: Loaded Alexa Top 1M domains from file.");
+            }
+            catch (IOException ex)
+            {
+                _dnsServer.WriteLog($"ERROR: Failed to read cache file '{_domainListFilePath}'. Error: {ex.Message}");
+            }
+        }
+
+        #endregion private
+
+        #region properties
+
+        public string Description
+        {
+            get
+            {
+                return "Downloads Alexa toip 1 million domains, runs a fuzzy logic, and if the match is high but not 100, it may be a typosquatting attempt.";
+            }
+        }
+
+        #endregion properties
+    }
+}

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -143,7 +143,13 @@ namespace TyposquattingDetector
                     _dnsServer.WriteLog($"Typosquatting Detector: SHA256 hash of downloaded domain list: {sha256}");
 
                     var hashPath = Path.Combine(configDir, "majestic_million.csv.sha256");
-                    if (File.Exists(hashPath) && File.ReadLines(hashPath).ToArray()[0] == sha256)
+                    string? previousHash = null;
+                    if (File.Exists(hashPath))
+                    {
+                        // Safely read the first line; handle empty or corrupted hash file
+                        previousHash = File.ReadLines(hashPath).FirstOrDefault()?.Trim();
+                    }
+                    if (!string.IsNullOrEmpty(previousHash) && string.Equals(previousHash, sha256, StringComparison.OrdinalIgnoreCase))
                     {
                         _changed = false;
                         _dnsServer.WriteLog($"Typosquatting Detector: Downloaded domain list is identical to the previous one. No changes made.");

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -318,13 +318,14 @@ namespace TyposquattingDetector
 
         private async Task StartUpdateLoopAsync(CancellationToken cancellationToken)
         {
+            using PeriodicTimer timer = new PeriodicTimer(_updateInterval);
+
             if (!_changed)
             {
                 // Nothing changed, skip first update
             }
             else
             {
-                using PeriodicTimer timer = new PeriodicTimer(_updateInterval);
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     bool flowControl = await TryUpdate(cancellationToken);

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -293,7 +293,7 @@ namespace TyposquattingDetector
                     return TimeSpan.FromDays(value * 7);
 
                 default:
-                    throw new FormatException($"Invalid unit '{unit}' in update interval. Allowed units are 'm', 'h', 'd'. 'w'.");
+                    throw new FormatException($"Invalid unit '{unit}' in update interval. Allowed units are 'm', 'h', 'd', 'w'.");
             }
         }
 
@@ -371,9 +371,8 @@ namespace TyposquattingDetector
                 string safePath = string.Empty;
                 safePath = Path.GetFullPath(_domainListFilePath!);
                 if (!safePath.StartsWith(_dnsServer.ApplicationFolder)) throw new SecurityException("Access Denied");
-
-                var oldDetector = _detector;
-                _detector = new TyposquattingDetector(_domainListFilePath!, safePath, _config!.FuzzyMatchThreshold);
+                var newDetector = new TyposquattingDetector(_domainListFilePath!, safePath, _config!.FuzzyMatchThreshold);
+                var oldDetector = Interlocked.Exchange(ref _detector, newDetector);
                 oldDetector?.Dispose();
                 _dnsServer.WriteLog($"Typosquatting Detector: Processing completed.");
             }

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -114,13 +114,10 @@ namespace TyposquattingDetector
                     try
                     {
                         Uri domainList = new Uri(DefaultDomainListUrl);
-                        _httpClient = CreateHttpClient(domainList, _config.DisableTlsValidation);
-
-                        using (Stream stream = await _httpClient.GetStreamAsync(domainList))
-                        using (FileStream fs = new FileStream(_domainListFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
-                        {
-                            await stream.CopyToAsync(fs, _appShutdownCts.Token);
-                        }
+                        using HttpClient httpClient = CreateHttpClient(domainList, _config.DisableTlsValidation);
+                        using Stream stream = await httpClient.GetStreamAsync(domainList);
+                        using FileStream fs = new FileStream(_domainListFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                        await stream.CopyToAsync(fs, _appShutdownCts.Token);
 
                         _dnsServer.WriteLog($"Typosquatting Detector: Downloaded domain list from '{domainList}' to '{_domainListFilePath}'.");
                     }

--- a/Apps/TyposquattingDetector/App.cs
+++ b/Apps/TyposquattingDetector/App.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Threading;
@@ -325,7 +326,14 @@ namespace TyposquattingDetector
             try
             {
                 _dnsServer.WriteLog($"Typosquatting Detector: Processing domain list...");
-                _detector = new TyposquattingDetector(_domainListFilePath, _config.Path, _config.FuzzyMatchThreshold);
+                string safePath = string.Empty;
+                if (!string.IsNullOrEmpty(_config.Path))
+                {
+                    safePath = Path.GetFullPath(_config.Path);
+                    if (!safePath.StartsWith(_dnsServer.ApplicationFolder)) throw new SecurityException("Access Denied");
+
+                }
+                _detector = new TyposquattingDetector(_domainListFilePath, safePath, _config.FuzzyMatchThreshold);
                 _dnsServer.WriteLog($"Typosquatting Detector: Processing completed.");
             }
             catch (IOException ex)

--- a/Apps/TyposquattingDetector/Config.cs
+++ b/Apps/TyposquattingDetector/Config.cs
@@ -52,7 +52,7 @@ namespace TyposquattingDetector
 
             [JsonPropertyName("updateInterval")]
             [Required(ErrorMessage = "updateInterval is a required configuration property.")]
-            [RegularExpression(@"^\d+[mhd]$", ErrorMessage = "Invalid interval format. Use a number followed by 'm', 'h', or 'd' (e.g., '90m', '2h', '7d').", MatchTimeoutInMilliseconds = 3000)]
+            [RegularExpression(@"^\d+[mhdw]$", ErrorMessage = "Invalid interval format. Use a number followed by 'm', 'h', or 'd' (e.g., '90m', '2h', '7d').", MatchTimeoutInMilliseconds = 3000)]
             public string UpdateInterval { get; set; } = "30d";
         }
 
@@ -84,7 +84,7 @@ namespace TyposquattingDetector
 
                         // 4. Fail-Fast Logic
                         // If any content exists, it MUST follow the domain rules
-                        if (trimmedLine.Contains("*") || !DomainRegex.IsMatch(trimmedLine))
+                        if (trimmedLine.Contains('*') || !DomainRegex.IsMatch(trimmedLine))
                         {
                             return new ValidationResult($"Invalid content: '{trimmedLine}'. Wildcards are not allowed.");
                         }

--- a/Apps/TyposquattingDetector/Config.cs
+++ b/Apps/TyposquattingDetector/Config.cs
@@ -28,33 +28,32 @@ namespace TyposquattingDetector
     {
         private class Config
         {
+            [JsonPropertyName("addExtendedDnsError")]
+            public bool AddExtendedDnsError { get; set; } = true;
+
+            [JsonPropertyName("allowTxtBlockingReport")]
+            public bool AllowTxtBlockingReport { get; set; } = true;
+
+            [JsonPropertyName("disableTlsValidation")]
+            public bool DisableTlsValidation { get; set; } = false;
+
             [JsonPropertyName("enable")]
             public bool Enable { get; set; } = true;
+
+            [JsonPropertyName("fuzzyMatchThreshold")]
+            [Range(75, 90, ErrorMessage = "fuzzyMatchThreshold must be between 75 and 90.")]
+            [Required(ErrorMessage = "fuzzyMatchThreshold is a required configuration property. The lower threshold means more false positives.")]
+            public int FuzzyMatchThreshold { get; set; } = 75;
 
             [JsonPropertyName("customList")]
             [RegularExpression("^(?:[a-zA-Z]:\\\\(?:[^\\\\\\/:*?\"<>|\\r\\n]+\\\\)*[^\\\\\\/:*?\"<>|\\r\\n]*|(?:\\/[^\\/\\0]+)+\\/?)$", ErrorMessage = "customList must be a valid file path with one domain per line.")]
             [CustomValidation(typeof(FileContentValidator), nameof(FileContentValidator.ValidateDomainFile))]
             public string? Path { get; set; }
 
-            [JsonPropertyName("disableTlsValidation")]
-            public bool DisableTlsValidation { get; set; } = false;
-
             [JsonPropertyName("updateInterval")]
             [Required(ErrorMessage = "updateInterval is a required configuration property.")]
             [RegularExpression(@"^\d+[mhd]$", ErrorMessage = "Invalid interval format. Use a number followed by 'm', 'h', or 'd' (e.g., '90m', '2h', '7d').", MatchTimeoutInMilliseconds = 3000)]
-            public string UpdateInterval { get; set; }  = "30d";
-
-            [JsonPropertyName("allowTxtBlockingReport")]
-            public bool AllowTxtBlockingReport { get; set; } = true;
-
-
-            [JsonPropertyName("addExtendedDnsError")]
-            public bool AddExtendedDnsError { get; set; } = true;
-
-            [JsonPropertyName("fuzzyMatchThreshold")]
-            [Range(75, 90, ErrorMessage = "fuzzyMatchThreshold must be between 75 and 90.")]
-            [Required(ErrorMessage = "fuzzyMatchThreshold is a required configuration property. The lower threshold means more false positives.")]
-            public int FuzzyMatchThreshold { get; set; } = 75;
+            public string UpdateInterval { get; set; } = "30d";
         }
 
         private partial class FileContentValidator
@@ -64,7 +63,7 @@ namespace TyposquattingDetector
 
             public static ValidationResult? ValidateDomainFile(string? path, ValidationContext context)
             {
-                // 1. If path is null/empty, we assume validation is not required here 
+                // 1. If path is null/empty, we assume validation is not required here
                 // (Use [Required] on the property if you want to force a path to be provided)
                 if (string.IsNullOrWhiteSpace(path)) return ValidationResult.Success;
 
@@ -105,6 +104,4 @@ namespace TyposquattingDetector
             private static partial Regex FilePathPattern();
         }
     }
-
-
 }

--- a/Apps/TyposquattingDetector/Config.cs
+++ b/Apps/TyposquattingDetector/Config.cs
@@ -46,7 +46,6 @@ namespace TyposquattingDetector
             public int FuzzyMatchThreshold { get; set; } = 75;
 
             [JsonPropertyName("customList")]
-            [RegularExpression("^(?:[a-zA-Z]:\\\\(?:[^\\\\\\/:*?\"<>|\\r\\n]+\\\\)*[^\\\\\\/:*?\"<>|\\r\\n]*|(?:\\/[^\\/\\0]+)+\\/?)$", ErrorMessage = "customList must be a valid file path with one domain per line.")]
             [CustomValidation(typeof(FileContentValidator), nameof(FileContentValidator.ValidateDomainFile))]
             public string? Path { get; set; }
 
@@ -59,7 +58,7 @@ namespace TyposquattingDetector
         public partial class FileContentValidator
         {
             // Optimized Regex: Compiled for performance during "Happy Path" scans
-            private static readonly Regex DomainRegex = FilePathPattern();
+            private static readonly Regex DomainRegex = DomainPattern();
 
             public static ValidationResult? ValidateDomainFile(string? path, ValidationContext context)
             {
@@ -100,8 +99,8 @@ namespace TyposquattingDetector
                 return ValidationResult.Success;
             }
 
-            [GeneratedRegex(@"^(?!-)[A-Za-z0-9-]+([\-\.]{1}[a-z0-9]+)*\.[A-Za-z]{2,63}$", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
-            private static partial Regex FilePathPattern();
+            [GeneratedRegex(@"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
+            private static partial Regex DomainPattern();
         }
     }
 }

--- a/Apps/TyposquattingDetector/Config.cs
+++ b/Apps/TyposquattingDetector/Config.cs
@@ -56,7 +56,7 @@ namespace TyposquattingDetector
             public string UpdateInterval { get; set; } = "30d";
         }
 
-        private partial class FileContentValidator
+        public partial class FileContentValidator
         {
             // Optimized Regex: Compiled for performance during "Happy Path" scans
             private static readonly Regex DomainRegex = FilePathPattern();

--- a/Apps/TyposquattingDetector/Config.cs
+++ b/Apps/TyposquattingDetector/Config.cs
@@ -1,0 +1,58 @@
+﻿/*
+Technitium DNS Server
+Copyright (C) 2025  Shreyas Zare (shreyas@technitium.com)
+Copyright (C) 2025  Zafer Balkan (zafer@zaferbalkan.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace TyposquattingDetector
+{
+    public sealed partial class App
+    {
+        private class Config
+        {
+            [JsonPropertyName("enable")]
+            public bool Enable { get; set; } = true;
+
+            [JsonPropertyName("url")]
+            [Required(ErrorMessage = "url is a required configuration property.")]
+            [Url(ErrorMessage = "url must be a valid URL.")]
+            public string Url { get; set; }
+
+            [JsonPropertyName("disableTlsValidation")]
+            public bool DisableTlsValidation { get; set; } = false;
+
+            [JsonPropertyName("updateInterval")]
+            [Required(ErrorMessage = "updateInterval is a required configuration property.")]
+            [RegularExpression(@"^\d+[mhd]$", ErrorMessage = "Invalid interval format. Use a number followed by 'm', 'h', or 'd' (e.g., '90m', '2h', '7d').", MatchTimeoutInMilliseconds = 3000)]
+            public string UpdateInterval { get; set; }
+
+            [JsonPropertyName("allowTxtBlockingReport")]
+            public bool AllowTxtBlockingReport { get; set; } = true;
+
+
+            [JsonPropertyName("addExtendedDnsError")]
+            public bool AddExtendedDnsError { get; set; } = true;
+            
+            [JsonPropertyName("fuzzyMatchThreshold")]
+            [Range(75, 90, ErrorMessage = "fuzzyMatchThreshold must be between 75 and 90.")]
+            [Required(ErrorMessage = "fuzzyMatchThreshold is a required configuration property. The lower threshold means more false positives.")]
+            public int FuzzyMatchThreshold { get; set; } = 75;
+        }
+    }
+}

--- a/Apps/TyposquattingDetector/DomainCache.cs
+++ b/Apps/TyposquattingDetector/DomainCache.cs
@@ -104,8 +104,14 @@ namespace TyposquattingDetector
 
         public void Clear()
         {
-            _cache.Clear();
-            _stringPool.Clear();
+            lock (_evictionLock)
+            {
+                _cache.Clear();
+                _stringPool.Clear();
+                _head = null;
+                _tail = null;
+                _hand = null;
+            }
         }
 
         #endregion

--- a/Apps/TyposquattingDetector/DomainCache.cs
+++ b/Apps/TyposquattingDetector/DomainCache.cs
@@ -1,0 +1,275 @@
+﻿/*
+Technitium DNS Server
+Copyright (C) 2025  Shreyas Zare (shreyas@technitium.com)
+Copyright (C) 2025  Zafer Balkan (zafer@zaferbalkan.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Nager.PublicSuffix;
+using Nager.PublicSuffix.RuleProviders;
+using Nager.PublicSuffix.RuleProviders.CacheProviders;
+using System;
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Threading;
+
+namespace TyposquattingDetector
+{
+
+
+    /// <summary>
+    /// Thread-safe cache for parsed domain information using the SIEVE eviction algorithm. 
+    /// SIEVE provides better scan resistance than LRU, making it ideal for DNS workloads
+    /// where one-time queries (typos, DGA domains) are common.  
+    /// 
+    /// Reference: "SIEVE is Simpler than LRU: an Efficient Turn-Key Eviction Algorithm for 
+    /// Web Caches" (NSDI '24)
+    /// </summary>
+    internal sealed class DomainCache
+    {
+        #region variables
+
+        private const int MaxSize = 10000;
+        private const int StringPoolMaxSize = 10000;
+        private static readonly DomainInfo Empty = new DomainInfo();
+
+        // ADR: Loading the PSL must not block or fail plugin startup. We defer
+        // initialization and make it best-effort to avoid network dependencies.
+        private static readonly Lazy<DomainParser?> _parser = new Lazy<DomainParser?>(InitializeParser);
+
+        private static readonly HttpClient _pslHttpClient = new HttpClient();
+
+        private static readonly Lazy<CachedHttpRuleProvider> _sharedRuleProvider =
+            new Lazy<CachedHttpRuleProvider>(static () =>
+            {
+                LocalFileSystemCacheProvider cacheProvider = new LocalFileSystemCacheProvider();
+                CachedHttpRuleProvider rp = new CachedHttpRuleProvider(cacheProvider, _pslHttpClient);
+                rp.BuildAsync().GetAwaiter().GetResult();
+                return rp;
+            }, isThreadSafe: true);
+
+        private readonly ConcurrentDictionary<string, CacheNode> _cache =
+            new ConcurrentDictionary<string, CacheNode>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, string> _stringPool =
+            new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Lock _evictionLock = new Lock();
+
+        // SIEVE data structures
+        private CacheNode? _head;
+        private CacheNode? _tail;
+        private CacheNode? _hand; 
+        #endregion
+
+        #region public
+        public DomainInfo GetOrAdd(string domainName)
+        {
+            if (string.IsNullOrWhiteSpace(domainName))
+                return Empty;
+
+            // Fast path: try cache lookup with original name first (case-insensitive)
+            if (_cache.TryGetValue(domainName, out CacheNode? node))
+            {
+                node.Visited = true;
+                return node.Domain;
+            }
+
+            // NormalizeConfig only if needed, using string pool to reduce allocations
+            string normalizedName = GetPooledNormalizedName(domainName);
+
+            // Check cache again with normalized name (may differ from original)
+            if (!ReferenceEquals(normalizedName, domainName) &&
+                _cache.TryGetValue(normalizedName, out node))
+            {
+                node.Visited = true;
+                return node.Domain;
+            }
+
+            DomainInfo domain = Parse(domainName);
+            AddToCache(normalizedName, domain);
+            return domain;
+        }
+
+
+        public void Clear()
+        {
+            _cache.Clear();
+            _stringPool.Clear();
+        }
+
+        #endregion
+
+        #region private
+
+        /// <summary>
+        /// Returns a pooled, normalized version of the domain name to reduce allocations.
+        /// If the name is already normalized, returns the original string.
+        /// </summary>
+        private string GetPooledNormalizedName(string name)
+        {
+            if (!NeedsNormalization(name))
+                return name;
+
+            string normalized = name.ToLowerInvariant().TrimEnd('.');
+
+            // Try to get from pool, or add if not present
+            if (_stringPool.TryGetValue(normalized, out string? pooled))
+                return pooled;
+
+            // Limit pool size to prevent unbounded growth
+            if (_stringPool.Count < StringPoolMaxSize)
+            {
+                _stringPool.TryAdd(normalized, normalized);
+            }
+
+            return normalized;
+        }
+
+        /// <summary>
+        /// Checks if the domain name needs normalization (has uppercase or trailing dot).
+        /// </summary>
+        private static bool NeedsNormalization(string name)
+        {
+            if (name.Length > 0 && name[^1] == '.')
+                return true;
+
+            foreach (char c in name)
+            {
+                if (c >= 'A' && c <= 'Z')
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static DomainInfo Parse(string name)
+        {
+            DomainParser? parser = _parser.Value;
+            if (parser == null)
+                return Empty;
+
+            try
+            {
+                return parser.Parse(name) ?? Empty;
+            }
+            catch
+            {
+                // Parsing errors are intentionally ignored because PSL is optional.
+                return Empty;
+            }
+        }
+
+        private static DomainParser? InitializeParser()
+        {
+            // ADR: The PSL download via SimpleHttpRuleProvider performs outbound HTTP.
+            // Relying on external network connectivity at plugin startup is unsafe in
+            // production DNS environments (offline appliances, firewalled networks,
+            // corporate proxies). Initialization must never block or fail due to PSL
+            // retrieval. We therefore treat PSL availability as optional:
+            //   - If the download succeeds, domain parsing is enriched.
+            //   - If it fails, we return null and logging continues without PSL data.
+            try
+            {
+                return new DomainParser(_sharedRuleProvider.Value);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private void AddToCache(string key, DomainInfo domain)
+        {
+            lock (_evictionLock)
+            {
+                if (_cache.ContainsKey(key))
+                    return;
+
+                while (_cache.Count >= MaxSize)
+                    Evict();
+
+                CacheNode newNode = new CacheNode(key, domain);
+                InsertAtHead(newNode);
+                _cache[key] = newNode;
+            }
+        }
+
+        private void InsertAtHead(CacheNode node)
+        {
+            node.Next = _head;
+            node.Prev = null;
+
+            if (_head != null)
+                _head.Prev = node;
+
+            _head = node;
+
+            _tail ??= node;
+
+            _hand ??= node;
+        }
+
+        private void Evict()
+        {
+            _hand ??= _tail;
+
+            while (_hand != null)
+            {
+                if (!_hand.Visited)
+                {
+                    CacheNode victim = _hand;
+                    _hand = _hand.Prev ?? _tail;
+                    RemoveNode(victim);
+                    _cache.TryRemove(victim.Key, out _);
+                    return;
+                }
+
+                _hand.Visited = false;
+                _hand = _hand.Prev ?? _tail;
+            }
+        }
+
+        private void RemoveNode(CacheNode node)
+        {
+            if (node.Prev != null)
+                node.Prev.Next = node.Next;
+            else
+                _head = node.Next;
+
+            if (node.Next != null)
+                node.Next.Prev = node.Prev;
+            else
+                _tail = node.Prev;
+
+            if (_hand == node)
+                _hand = node.Prev ?? _tail;
+        }
+
+        private class CacheNode
+        {
+            public readonly string Key;
+            public readonly DomainInfo Domain;
+            public volatile bool Visited;
+            public CacheNode? Next;
+            public CacheNode? Prev;
+
+            public CacheNode(string key, DomainInfo domain)
+            {
+                Key = key;
+                Domain = domain;
+            }
+        } 
+        #endregion
+    }
+}

--- a/Apps/TyposquattingDetector/README.md
+++ b/Apps/TyposquattingDetector/README.md
@@ -1,0 +1,51 @@
+# Typosquatting Detector for Technitium DNS Server
+
+A DNS security plugin that detects and blocks look-alike domains associated with phishing and brand impersonation. The plugin evaluates similarity between queried domains and a high-reputation corpus and blocks near-miss variants before resolution.
+
+## Detection model
+
+The plugin builds a trusted corpus from the Majestic Million list plus an optional custom list. For each query it:
+
+1. Normalizes to the registrable domain using Public Suffix rules.
+2. Performs an O(1) Bloom filter check for known legitimate domains.
+3. Runs fuzzy similarity matching against length-adjacent candidates for unknown domains.
+
+Queries above the configured similarity threshold are classified as probable typosquats and blocked.
+
+## Enforcement behavior
+
+Suspicious domains receive an authoritative NXDOMAIN with SOA. Optional Extended DNS Error metadata and optional TXT blocking reports expose structured blocking details for logs and SIEM ingestion. Clean domains are not modified and resolve normally.
+
+## Configuration
+
+Example configuration:
+
+```json
+{
+  "enable": true,
+  "fuzzyMatchThreshold": 75,
+  "customList": "/path/to/custom-domains.txt",
+  "disableTlsValidation": false,
+  "updateInterval": "30d",
+  "allowTxtBlockingReport": true,
+  "addExtendedDnsError": true
+}
+```
+
+Key options
+
+* fuzzyMatchThreshold (75–90): main sensitivity control. Lower values detect more variants but increase false positives.
+* customList: one domain per line; add organization and brand domains you want treated as trusted.
+* updateInterval: controls when the Majestic list is reprocessed; rebuilds are skipped when the file hash is unchanged.
+* allowTxtBlockingReport / addExtendedDnsError: control operator visibility of blocking decisions.
+* disableTlsValidation: test or lab use only.
+
+## Deployment and risk considerations
+
+Start with a conservative threshold (85–90) in production and observe blocks before lowering. False positives are most likely for domains visually similar to major brands but legitimate or newly emerging services. Mitigations include raising the threshold or adding the domain to the custom list.
+
+This plugin is intended for recursive resolvers operated by security teams where DNS blocking is an accepted control point. Communicate expected behavior to users and support staff to avoid confusion when NXDOMAIN is enforcement rather than resolution failure.
+
+## Acknowledgements
+
+Uses [Majestic Million dataset](https://majestic.com/reports/majestic-million), [Nager Public Suffix parser](https://github.com/nager/Nager.PublicSuffix), [BloomFilter.NetCore](https://github.com/vla/BloomFilter.NetCore) and [FuzzySharp](https://github.com/JakeBayer/FuzzySharp) libraries, and the Technitium DNS Server app framework.

--- a/Apps/TyposquattingDetector/TyposquattingDetector.MatchState.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.MatchState.cs
@@ -1,0 +1,55 @@
+﻿/*
+Technitium DNS Server
+Copyright (C) 2025  Shreyas Zare (shreyas@technitium.com)
+Copyright (C) 2025  Zafer Balkan (zafer@zaferbalkan.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.Collections.Concurrent;
+
+namespace TyposquattingDetector
+{
+     public partial class TyposquattingDetector
+    {
+        // Define the state as a class to allow locking
+        private class MatchState
+        {
+            public string? BestDomain;
+            public int BestScore;
+
+            // Reset method for reuse
+            public void Reset()
+            {
+                BestDomain = null;
+                BestScore = 0;
+            }
+        }
+
+        // Simple thread-safe pool
+        private readonly ConcurrentQueue<MatchState> _statePool = new ConcurrentQueue<MatchState>();
+
+        private MatchState GetState()
+        {
+            if (_statePool.TryDequeue(out var state)) return state;
+            return new MatchState();
+        }
+
+        private void ReturnState(MatchState state)
+        {
+            state.Reset();
+            _statePool.Enqueue(state);
+        }
+    }
+}

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -244,7 +244,10 @@ namespace TyposquattingDetector
             }
             catch
             {
-                return s.ToLowerInvariant().Trim().Replace("www.", "");
+                var clean = s.ToLowerInvariant().Trim();
+                if (clean.StartsWith("www.")) clean = clean.Substring(4);
+                if (clean.StartsWith("m.")) clean = clean.Substring(2);
+                return clean;
             }
         }
         #endregion private

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -45,7 +45,7 @@ namespace TyposquattingDetector
         public int FuzzyScore { get; set; }
         public string Query { get; }
         public Reason Reason { get; set; }
-        public Severity Severity { get; set; }
+        public Severity Severity { get; set; } = Severity.NONE;
         public bool IsSuspicious { get; set; }
     }
 

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -157,11 +157,19 @@ namespace TyposquattingDetector
 
             while (reader.ReadLine() is { } line)
             {
-                string? domain = ExtractDomain(line);
-                if (string.IsNullOrEmpty(domain)) continue;
+                string? domain = null;
+                try
+                {
+                    domain = ExtractDomain(line);
+                    if (string.IsNullOrEmpty(domain)) continue;
 
-                _bloomFilter.Add(domain);
+                    _bloomFilter.Add(domain.ToLowerInvariant());
 
+                }
+                catch (Exception)
+                {
+                    continue; // skip corrupted lines
+                }
                 if (!_lenBuckets.TryGetValue(domain.Length, out var list))
                 {
                     list = new List<string>();

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -345,16 +345,17 @@ namespace TyposquattingDetector
 
         private string? Normalize(string s)
         {
-            if (string.IsNullOrWhiteSpace(s)|| string.IsNullOrEmpty(s)) return null;
+            if (string.IsNullOrWhiteSpace(s)) return null;
 
             try
             {
-                var registrableDomain = _normalizer?.Value?.Parse(s)?.RegistrableDomain;
-                return registrableDomain ?? s;
+                var rd = _normalizer.Value?.Parse(s)?.RegistrableDomain;
+                if (string.IsNullOrWhiteSpace(rd)) rd = s;
+                return rd.TrimEnd('.').ToLowerInvariant();
             }
             catch
             {
-                var clean = s.ToLowerInvariant().Trim();
+                var clean = s.Trim().TrimEnd('.').ToLowerInvariant();
                 if (clean.StartsWith("www.")) clean = clean.Substring(4);
                 if (clean.StartsWith("m.")) clean = clean.Substring(2);
                 return clean;

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -122,6 +122,15 @@ namespace TyposquattingDetector
         public Result Check(string query)
         {
             var normalized = Normalize(query);
+            if (normalized == null)
+            {
+                return new Result(query)
+                {
+                    IsSuspicious = false,
+                    Reason = Reason.NoCandidates
+                };
+            }
+
             var result = new Result(normalized);
 
             // GATE 1: Bloom Filter Prefilter (O(1))
@@ -298,7 +307,8 @@ namespace TyposquattingDetector
             // Helper to add domains to both Bloom and Buckets
             void processDomain(string domain)
             {
-                if (string.IsNullOrWhiteSpace(domain)) return;
+                if (string.IsNullOrWhiteSpace(domain) || string.IsNullOrEmpty(domain)) return;
+
                 domain = domain.ToLowerInvariant();
                 _bloomFilter.Add(domain);
                 if (!_lenBuckets.TryGetValue(domain.Length, out var list))
@@ -332,9 +342,10 @@ namespace TyposquattingDetector
             }
         }
 
-        private string Normalize(string s)
+        private string? Normalize(string s)
         {
-            if (string.IsNullOrWhiteSpace(s)) return s;
+            if (string.IsNullOrWhiteSpace(s)|| string.IsNullOrEmpty(s)) return null;
+
             try
             {
                 var registrableDomain = _normalizer?.Value?.Parse(s)?.RegistrableDomain;

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -62,7 +62,7 @@ namespace TyposquattingDetector
         public Severity Severity { get; set; } = Severity.NONE;
     }
 
-     public class TyposquattingDetector : IDisposable
+     public partial class TyposquattingDetector : IDisposable
     {
         #region variables
 
@@ -83,12 +83,6 @@ namespace TyposquattingDetector
         private readonly int _threshold;
         private IBloomFilter? _bloomFilter;
         private bool _disposedValue;
-
-        private class MatchState
-        {
-            public string? BestDomain;
-            public int BestScore;
-        }
 
         #endregion variables
 
@@ -207,7 +201,11 @@ namespace TyposquattingDetector
 
         private Result FuzzyMatch(string query, Result result)
         {
-            MatchState globalState = new MatchState { BestDomain = null, BestScore = 0 };
+
+            //MatchState globalState = new MatchState { BestDomain = null, BestScore = 0 };
+            MatchState globalState = GetState();
+            globalState.BestDomain = null;
+            globalState.BestScore = 0;
 
             for (int delta = -1; delta <= 1; delta++)
             {
@@ -233,7 +231,7 @@ namespace TyposquattingDetector
             {
                 GetNormalResult(result);
             }
-
+            ReturnState(globalState);
             return result;
         }
 

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -75,7 +75,7 @@ namespace TyposquattingDetector
             {
                 var cacheProvider = new Nager.PublicSuffix.RuleProviders.CacheProviders.LocalFileSystemCacheProvider();
                 _sharedRuleProvider = new CachedHttpRuleProvider(cacheProvider, _httpClient);
-                _sharedRuleProvider.BuildAsync().GetAwaiter().GetResult();
+                _sharedRuleProvider.BuildAsync().GetAwaiter().GetResult(); // Initialize synchronously, explicitly
             }
 
             _normalizer = new ThreadLocal<DomainParser>(() =>
@@ -160,7 +160,7 @@ namespace TyposquattingDetector
 
         private (bool flowControl, Result? value) Prefilter(string q, Result r)
         {
-            if (_bloomFilter.Contains(q))
+            if (_bloomFilter is not null && _bloomFilter.Contains(q))
             {
                 r.Status = DetectionStatus.Clean;
                 r.Reason = Reason.Exact;

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -127,7 +127,9 @@ namespace TyposquattingDetector
             // GATE 2: Fuzzy Similarity Check
             return FuzzyMatch(normalized, result);
         }
+        #endregion public
 
+        #region private
         private Result FuzzyMatch(string query, Result result)
         {
             string? bestDomain = null;

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -279,7 +279,8 @@ namespace TyposquattingDetector
 
             // small trigram overlap check (no alloc)
             int hits = 0;
-            for (int i = 0; i < Math.Min(ql, dl) - 2; i++)
+            int maxTrigrams = Math.Min(10, Math.Min(ql, dl) - 2);
+            for (int i = 0; i < maxTrigrams; i++)
                 if (d.AsSpan().IndexOf(q.AsSpan(i, 3)) >= 0) hits++;
 
             // require minimal neighborhood similarity

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -58,7 +58,7 @@ namespace TyposquattingDetector
         private readonly ThreadLocal<DomainParser> _normalizer;
         private readonly int _threshold;
         private IBloomFilter? _bloomFilter;
-        private static readonly HttpClient _httpClient = new();
+        private readonly HttpClient _httpClient = new HttpClient();
         private bool disposedValue;
 
         #endregion variables
@@ -92,7 +92,8 @@ namespace TyposquattingDetector
             {
                 if (disposing)
                 {
-                    _normalizer.Dispose();
+                    _httpClient?.Dispose();
+                    _normalizer?.Dispose();
                 }
                 disposedValue = true;
             }

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -32,7 +32,7 @@ using System.Threading.Tasks;
 namespace TyposquattingDetector
 {
     public enum Reason
-    { BloomReject, Exact, Typosquatting, Medium, Low, NoCandidates }
+    { Exact, Typosquatting, NoCandidates }
 
     public enum Severity
     { NONE, LOW, MEDIUM, HIGH }

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -303,7 +303,8 @@ namespace TyposquattingDetector
             if (string.IsNullOrWhiteSpace(s)) return s;
             try
             {
-                return _normalizer!.Value!.Parse(s)!.RegistrableDomain ?? s;
+                var registrableDomain = _normalizer?.Value?.Parse(s)?.RegistrableDomain;
+                return registrableDomain ?? s;
             }
             catch
             {

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -31,9 +31,6 @@ using System.Threading.Tasks;
 
 namespace TyposquattingDetector
 {
-    public enum DetectionStatus
-    { Clean, Possible, Suspicious }
-
     public enum Reason
     { BloomReject, Exact, Typosquatting, Medium, Low, NoCandidates }
 
@@ -49,7 +46,7 @@ namespace TyposquattingDetector
         public string Query { get; }
         public Reason Reason { get; set; }
         public Severity Severity { get; set; }
-        public DetectionStatus Status { get; set; }
+        public bool IsSuspicious { get; set; }
     }
 
     public class TyposquattingDetector : IDisposable
@@ -119,7 +116,7 @@ namespace TyposquattingDetector
             // GATE 1: Bloom Filter Prefilter (O(1))
             if (_bloomFilter is not null && _bloomFilter.Contains(normalized))
             {
-                result.Status = DetectionStatus.Clean;
+                result.IsSuspicious = false;
                 result.Reason = Reason.Exact;
                 return result;
             }
@@ -230,13 +227,13 @@ namespace TyposquattingDetector
             {
                 result.BestMatch = bestDomain;
                 result.FuzzyScore = bestScore;
-                result.Status = DetectionStatus.Suspicious;
+                result.IsSuspicious = true;
                 result.Severity = bestScore > 90 ? Severity.HIGH : Severity.MEDIUM;
                 result.Reason = Reason.Typosquatting;
             }
             else
             {
-                result.Status = DetectionStatus.Clean;
+                result.IsSuspicious = false;
                 result.Reason = Reason.NoCandidates;
             }
 

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -1,0 +1,173 @@
+﻿/*
+Technitium DNS Server
+Copyright (C) 2025  Shreyas Zare (shreyas@technitium.com)
+Copyright (C) 2025  Zafer Balkan (zafer@zaferbalkan.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using BloomFilter;
+using FuzzySharp;
+using Nager.PublicSuffix;
+using Nager.PublicSuffix.RuleProviders;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TyposquattingDetector
+{
+    public enum DetectionStatus { Clean, Possible, Suspicious }
+    public enum Severity { NONE, LOW, MEDIUM, HIGH }
+    public enum Reason { BloomReject, Exact, Typosquatting, Medium, Low, NoCandidates }
+
+    public class Result
+    {
+        public string Query { get; }
+        public DetectionStatus Status { get; set; }
+        public Severity Severity { get; set; }
+        public Reason Reason { get; set; }
+        public string? BestMatch { get; set; }
+        public int FuzzyScore { get; set; }
+
+        public Result(string query) => Query = query;
+    }
+
+    public class TyposquattingDetector
+    {
+        private static IRuleProvider _sharedRuleProvider;
+        private readonly ThreadLocal<DomainParser> _normalizer;
+        private IBloomFilter _bloomFilter;
+        private readonly Dictionary<int, List<string>> _lenBuckets = new();
+        private readonly int _threshold;
+
+        public TyposquattingDetector(string path, int threshold)
+        {
+            _threshold = threshold;
+
+            if (_sharedRuleProvider == null)
+            {
+                var cacheProvider = new Nager.PublicSuffix.RuleProviders.CacheProviders.LocalFileSystemCacheProvider();
+                _sharedRuleProvider = new CachedHttpRuleProvider(cacheProvider, new HttpClient());
+                _sharedRuleProvider.BuildAsync().GetAwaiter().GetResult();
+            }
+
+            _normalizer = new ThreadLocal<DomainParser>(() =>
+                new DomainParser(_sharedRuleProvider, new Nager.PublicSuffix.DomainNormalizers.UriDomainNormalizer()));
+
+            LoadData(path);
+        }
+
+        private void LoadData(string filePath)
+        {
+            _bloomFilter = FilterBuilder.Build(1_000_000, 0.01);
+
+            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 65536);
+            using var reader = new StreamReader(fs);
+            reader.ReadLine();
+
+            while (reader.ReadLine() is { } line)
+            {
+                string? domain = ExtractDomain(line);
+                if (string.IsNullOrEmpty(domain)) continue;
+
+                _bloomFilter.Add(domain);
+
+                if (!_lenBuckets.TryGetValue(domain.Length, out var list))
+                {
+                    list = new List<string>();
+                    _lenBuckets[domain.Length] = list;
+                }
+                if (list.Count < 10000) list.Add(domain);
+            }
+        }
+
+        public async Task<Result> FuzzyMatchAsync(string query)
+        {
+            var q = Normalize(query);
+            var r = new Result(q);
+
+            // GATE 1: Known Famous Site
+            // If it's in the top 1M, it's 100% clean.
+            if (_bloomFilter.Contains(q))
+            {
+                r.Status = DetectionStatus.Clean;
+                r.Reason = Reason.Exact;
+                return r;
+            }
+
+            // GATE 2: Fuzzy Similarity Check
+            return await Task.Run(() =>
+            {
+                var candidates = new List<string>();
+                for (int i = -1; i <= 1; i++)
+                    if (_lenBuckets.TryGetValue(q.Length + i, out var bucket))
+                        candidates.AddRange(bucket);
+
+                var best = candidates
+                    .Select(d => new { d, score = Fuzz.WeightedRatio(q, d) })
+                    .OrderByDescending(x => x.score)
+                    .FirstOrDefault();
+
+                // Logic: If score is [75-99], it's a suspicious lookalike.
+                // If score is < 75, it's just a random domain (Clean).
+                // Note: score of 100 would have been caught by the Bloom Filter.
+                if (best != null && best.score >= _threshold)
+                {
+                    r.BestMatch = best.d;
+                    r.FuzzyScore = best.score;
+                    r.Status = DetectionStatus.Suspicious;
+                    r.Severity = Severity.HIGH;
+                    r.Reason = Reason.Typosquatting;
+                }
+                else
+                {
+                    r.Status = DetectionStatus.Clean;
+                    r.Reason = Reason.BloomReject;
+                }
+
+                return r;
+            });
+        }
+
+        private string Normalize(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return s;
+            try
+            {
+                return _normalizer!.Value!.Parse(s)!.RegistrableDomain ?? s;
+            }
+            catch
+            {
+                return s.ToLowerInvariant().Trim().Replace("www.", "");
+            }
+        }
+
+        private string? ExtractDomain(string line)
+        {
+            ReadOnlySpan<char> span = line.AsSpan();
+            int firstComma = span.IndexOf(',');
+            if (firstComma == -1) return null;
+            ReadOnlySpan<char> afterFirst = span.Slice(firstComma + 1);
+            int secondComma = afterFirst.IndexOf(',');
+            if (secondComma == -1) return null;
+            ReadOnlySpan<char> afterSecond = afterFirst.Slice(secondComma + 1);
+            int thirdComma = afterSecond.IndexOf(',');
+            return (thirdComma == -1 ? afterSecond : afterSecond.Slice(0, thirdComma)).ToString();
+        }
+    }
+}

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -60,6 +60,7 @@ namespace TyposquattingDetector
         private readonly ThreadLocal<DomainParser> _normalizer;
         private readonly int _threshold;
         private IBloomFilter? _bloomFilter;
+        private static readonly HttpClient _httpClient = new();
         private bool disposedValue;
 
         #endregion variables
@@ -73,7 +74,7 @@ namespace TyposquattingDetector
             if (_sharedRuleProvider == null)
             {
                 var cacheProvider = new Nager.PublicSuffix.RuleProviders.CacheProviders.LocalFileSystemCacheProvider();
-                _sharedRuleProvider = new CachedHttpRuleProvider(cacheProvider, new HttpClient());
+                _sharedRuleProvider = new CachedHttpRuleProvider(cacheProvider, _httpClient);
                 _sharedRuleProvider.BuildAsync().GetAwaiter().GetResult();
             }
 

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -89,7 +89,7 @@ namespace TyposquattingDetector
         // Use sequential processing for smaller buckets; benchmarks showed that below ~256
         // candidates, the overhead of parallelism outweighs its benefits.
         const int SequentialCutoff = 256;
-        
+
         private bool _disposedValue;
 
         #endregion variables
@@ -368,6 +368,7 @@ namespace TyposquattingDetector
             catch
             {
                 string? clean = s.Trim().TrimEnd('.').ToLowerInvariant();
+                if (string.IsNullOrEmpty(clean)) return null;
                 ReadOnlySpan<char> span = clean.AsSpan();
                 if (span.StartsWith("www.".AsSpan())) span = span[4..];
                 if (span.StartsWith("m.".AsSpan())) span = span[2..];

--- a/Apps/TyposquattingDetector/TyposquattingDetector.cs
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.cs
@@ -304,7 +304,7 @@ namespace TyposquattingDetector
             result.BestMatch = globalState.BestDomain;
             result.FuzzyScore = globalState.BestScore;
             result.IsSuspicious = true;
-            result.Severity = globalState.BestScore > 90 ? Severity.HIGH : Severity.MEDIUM;
+            result.Severity = globalState.BestScore > 85 ? Severity.HIGH : Severity.MEDIUM;
             result.Reason = Reason.Typosquatting;
         }
 

--- a/Apps/TyposquattingDetector/TyposquattingDetector.csproj
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.csproj
@@ -1,0 +1,51 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<Version>1.0</Version>
+		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+		<Company>Technitium</Company>
+		<Product>Technitium DNS Server</Product>
+		<Authors>Zafer Balkan</Authors>
+		<AssemblyName>TyposquattingDetector</AssemblyName>
+		<RootNamespace>TyposquattingDetector</RootNamespace>
+		<PackageProjectUrl>https://technitium.com/dns/</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/TechnitiumSoftware/DnsServer</RepositoryUrl>
+		<Description>Detects if a queried domainname MIGHT be a typosquatting attempt or not.</Description>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<OutputType>Library</OutputType>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="BloomFilter.NetCore" Version="3.0.0" />
+		<PackageReference Include="FuzzySharp" Version="2.0.2" />
+		<PackageReference Include="Nager.PublicSuffix" Version="3.7.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\DnsServerCore.ApplicationCommon\DnsServerCore.ApplicationCommon.csproj">
+			<Private>false</Private>
+		</ProjectReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<Reference Include="TechnitiumLibrary">
+			<HintPath>..\..\..\TechnitiumLibrary\bin\TechnitiumLibrary.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="TechnitiumLibrary.Net">
+			<HintPath>..\..\..\TechnitiumLibrary\bin\TechnitiumLibrary.Net.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="dnsApp.config">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+
+</Project>

--- a/Apps/TyposquattingDetector/TyposquattingDetector.csproj
+++ b/Apps/TyposquattingDetector/TyposquattingDetector.csproj
@@ -12,7 +12,7 @@
 		<RootNamespace>TyposquattingDetector</RootNamespace>
 		<PackageProjectUrl>https://technitium.com/dns/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/TechnitiumSoftware/DnsServer</RepositoryUrl>
-		<Description>Detects if a queried domainname MIGHT be a typosquatting attempt or not.</Description>
+		<Description>Evaluates queried domains against a trusted corpus and flags visually similar near-matches as potential typosquatting. Allows blocking of suspicious queries and exposes structured detection details. The fuzzy-match threshold and optional custom domain list are operator-tunable; adjust cautiously to reduce false-positive impact.</Description>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<OutputType>Library</OutputType>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Apps/TyposquattingDetector/dnsApp.config
+++ b/Apps/TyposquattingDetector/dnsApp.config
@@ -1,6 +1,6 @@
 {
 	"enable": true,
-	"url": "https://downloads.majestic.com/majestic_million.csv",
+	"customList": "sample.txt",
 	"disableTlsValidation": false,
 	"updateInterval": "30d",
 	"allowTxtBlockingReport": true,

--- a/Apps/TyposquattingDetector/dnsApp.config
+++ b/Apps/TyposquattingDetector/dnsApp.config
@@ -1,0 +1,9 @@
+{
+	"enable": true,
+	"url": "https://downloads.majestic.com/majestic_million.csv",
+	"disableTlsValidation": false,
+	"updateInterval": "30d",
+	"allowTxtBlockingReport": true,
+	"addExtendedDnsError": true,
+	"fuzzyMatchThreshold": 75
+}

--- a/Apps/TyposquattingDetector/dnsApp.config
+++ b/Apps/TyposquattingDetector/dnsApp.config
@@ -1,6 +1,6 @@
 {
 	"enable": true,
-	"customList": "sample.txt",
+	"customList": "",
 	"disableTlsValidation": false,
 	"updateInterval": "30d",
 	"allowTxtBlockingReport": true,

--- a/DnsServer.sln
+++ b/DnsServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.32014.148
+# Visual Studio Version 18
+VisualStudioVersion = 18.1.11312.151 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DnsServerApp", "DnsServerApp\DnsServerApp.csproj", "{ADE80805-9FA7-4F66-8A18-57B98F8C0B0F}"
 EndProject
@@ -68,7 +68,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueryLogsMySqlApp", "Apps\QueryLogsMySqlApp\QueryLogsMySqlApp.csproj", "{699E2A1D-D917-4825-939E-65CDB2B16A96}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MispConnectorApp", "Apps\MispConnectorApp\MispConnectorApp.csproj", "{83C8180A-0F86-F9A0-8F41-6FD61FAC41CB}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DnsServerCore.HttpApi", "DnsServerCore.HttpApi\DnsServerCore.HttpApi.csproj", "{1A49D371-D08C-475E-B7A2-6E8ECD181FD6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TyposquattingDetector", "Apps\TyposquattingDetector\TyposquattingDetector.csproj", "{FC71CB85-F69D-44E5-A447-52B39C7AB5C2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -208,6 +211,10 @@ Global
 		{1A49D371-D08C-475E-B7A2-6E8ECD181FD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A49D371-D08C-475E-B7A2-6E8ECD181FD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1A49D371-D08C-475E-B7A2-6E8ECD181FD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC71CB85-F69D-44E5-A447-52B39C7AB5C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC71CB85-F69D-44E5-A447-52B39C7AB5C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC71CB85-F69D-44E5-A447-52B39C7AB5C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC71CB85-F69D-44E5-A447-52B39C7AB5C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -240,6 +247,7 @@ Global
 		{6F655C97-FD43-4FE1-B15A-6C783D2D91C9} = {938BF8EF-74B9-4FE0-B46F-11EBB7A4B3D2}
 		{699E2A1D-D917-4825-939E-65CDB2B16A96} = {938BF8EF-74B9-4FE0-B46F-11EBB7A4B3D2}
 		{83C8180A-0F86-F9A0-8F41-6FD61FAC41CB} = {938BF8EF-74B9-4FE0-B46F-11EBB7A4B3D2}
+		{FC71CB85-F69D-44E5-A447-52B39C7AB5C2} = {938BF8EF-74B9-4FE0-B46F-11EBB7A4B3D2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6747BB6D-2826-4356-A213-805FBCCF9201}

--- a/DnsServer.sln
+++ b/DnsServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 18
-VisualStudioVersion = 18.1.11312.151 d18.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DnsServerApp", "DnsServerApp\DnsServerApp.csproj", "{ADE80805-9FA7-4F66-8A18-57B98F8C0B0F}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Nobody really bothers about domain name resolution since it works automatically 
 
 Be it a home network or an organization's network, having a locally running DNS server gives you more insights into your network and helps to understand it better using the DNS logs and stats. It improves overall performance since most queries are served from the DNS cache making web sites load faster by not having to wait for frequent DNS resolutions. It also gives you an additional control over your network allowing you to block domain names network wide and also allows you to route your DNS traffic securely using encrypted DNS protocols.
 
+[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=zbalkan_DnsServer)](https://sonarcloud.io/summary/new_code?id=zbalkan_DnsServer)
+
 # Sponsored By
 <p align="center">
 	<a href="https://althatech.com/" target="_blank"><img src="https://technitium.com/img/logo-althatech.png" width="250" alt="Altha Technology - Censorship Resistant Data Services" title="Altha Technology - Censorship Resistant Data Services" /></a>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Nobody really bothers about domain name resolution since it works automatically 
 
 Be it a home network or an organization's network, having a locally running DNS server gives you more insights into your network and helps to understand it better using the DNS logs and stats. It improves overall performance since most queries are served from the DNS cache making web sites load faster by not having to wait for frequent DNS resolutions. It also gives you an additional control over your network allowing you to block domain names network wide and also allows you to route your DNS traffic securely using encrypted DNS protocols.
 
-WW# Sponsored By
+# Sponsored By
 <p align="center">
 	<a href="https://althatech.com/" target="_blank"><img src="https://technitium.com/img/logo-althatech.png" width="250" alt="Altha Technology - Censorship Resistant Data Services" title="Altha Technology - Censorship Resistant Data Services" /></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ Nobody really bothers about domain name resolution since it works automatically 
 
 Be it a home network or an organization's network, having a locally running DNS server gives you more insights into your network and helps to understand it better using the DNS logs and stats. It improves overall performance since most queries are served from the DNS cache making web sites load faster by not having to wait for frequent DNS resolutions. It also gives you an additional control over your network allowing you to block domain names network wide and also allows you to route your DNS traffic securely using encrypted DNS protocols.
 
-[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=zbalkan_DnsServer)](https://sonarcloud.io/summary/new_code?id=zbalkan_DnsServer)
-
-# Sponsored By
+WW# Sponsored By
 <p align="center">
 	<a href="https://althatech.com/" target="_blank"><img src="https://technitium.com/img/logo-althatech.png" width="250" alt="Altha Technology - Censorship Resistant Data Services" title="Altha Technology - Censorship Resistant Data Services" /></a>
 </p>


### PR DESCRIPTION
# Summary

This is a simple app which may be helpful or phishing domains:

## Example output

For `microsoft.com`:
```bash
C:\Users\zafer>dig microsoft.com @127.0.0.1

; <<>> DiG 9.16.25 <<>> microsoft.com @127.0.0.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 42278
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;microsoft.com.                 IN      A

;; ANSWER SECTION:
microsoft.com.          3600    IN      A       13.107.213.45
microsoft.com.          3600    IN      A       13.107.246.45

;; Query time: 157 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Tue Dec 30 21:56:18 FLE Standard Time 2025
;; MSG SIZE  rcvd: 74
```

For `rnicrosoft.com`:
```bash
C:\Users\zafer>dig rnicrosoft.com @127.0.0.1

; <<>> DiG 9.16.25 <<>> rnicrosoft.com @127.0.0.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 53901
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; EDE: 15 (Blocked): (source=typosquatting-detector;domain=rnicrosoft.com;severity=HIGH;reason=Typosquatting)
;; QUESTION SECTION:
;rnicrosoft.com.                        IN      A

;; AUTHORITY SECTION:
rnicrosoft.com.         60      IN      SOA     lap29. hostadmin.lap29. 1 14400 3600 604800 60

;; Query time: 295 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Tue Dec 30 21:56:25 FLE Standard Time 2025
;; MSG SIZE  rcvd: 186
```

## Reference

- https://economictimes.indiatimes.com/wealth/save/password-change-email-from-rnicrosoft-com-is-a-phishing-scam-cybersecurity-expert-shares-how-to-protect-yourself/articleshow/125501383.cms?from=mdr