### PR TITLE
Update Dockerfile image reference to pull podman from Docker Hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   dns-server:
     container_name: dns-server
     hostname: dns-server
-    image: technitium/dns-server:latest
+    image: docker.io/technitium/dns-server:latest
     # For DHCP deployments, use "host" network mode and remove all the port mappings, including the ports array by commenting them
     # network_mode: "host"
     ports:


### PR DESCRIPTION
Podman does not reliably resolve unqualified image names.
This change updates the container image reference to a fully qualified Docker Hub URL to ensure it pulls correctly when using Podman.