### PR TITLE
feat: add env variable for api token creation

### DIFF
--- a/DnsServerCore/Auth/AuthManager.cs
+++ b/DnsServerCore/Auth/AuthManager.cs
@@ -485,6 +485,14 @@ namespace DnsServerCore.Auth
 
             string adminPassword = Environment.GetEnvironmentVariable("DNS_SERVER_ADMIN_PASSWORD");
             string adminPasswordFile = Environment.GetEnvironmentVariable("DNS_SERVER_ADMIN_PASSWORD_FILE");
+            string adminApiToken = Environment.GetEnvironmentVariable("DNS_SERVER_ADMIN_API_TOKEN");
+            string adminApiTokenFile = Environment.GetEnvironmentVariable("DNS_SERVER_ADMIN_API_TOKEN_FILE");
+
+            bool passwordProvided = !string.IsNullOrEmpty(adminPassword) || !string.IsNullOrEmpty(adminPasswordFile);
+            bool apiTokenProvided = !string.IsNullOrEmpty(adminApiToken) || !string.IsNullOrEmpty(adminApiTokenFile);
+
+            if (apiTokenProvided && !passwordProvided)
+                throw new InvalidOperationException("DNS_SERVER_ADMIN_API_TOKEN requires DNS_SERVER_ADMIN_PASSWORD or DNS_SERVER_ADMIN_PASSWORD_FILE.");
 
             User adminUser;
 
@@ -515,6 +523,36 @@ namespace DnsServerCore.Auth
             }
 
             adminUser.AddToGroup(adminGroup);
+
+            if (apiTokenProvided)
+            {
+                string adminApiTokenValue = null;
+
+                if (!string.IsNullOrEmpty(adminApiToken))
+                {
+                    adminApiTokenValue = adminApiToken;
+                }
+                else if (!string.IsNullOrEmpty(adminApiTokenFile))
+                {
+                    try
+                    {
+                        using (StreamReader sR = new StreamReader(adminApiTokenFile, true))
+                        {
+                            adminApiTokenValue = sR.ReadLine();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Write(ex);
+                        throw new InvalidOperationException("Failed to read DNS_SERVER_ADMIN_API_TOKEN_FILE.");
+                    }
+                }
+
+                if (string.IsNullOrWhiteSpace(adminApiTokenValue))
+                    throw new InvalidOperationException("DNS_SERVER_ADMIN_API_TOKEN must be a 64-character hex string.");
+
+                CreateApiTokenWithToken("Initial Admin Token", adminUser.Username, IPAddress.Loopback, "Environment Variable", adminApiTokenValue);
+            }
         }
 
         private async Task<User> AuthenticateUserAsync(string username, string password, string totp, IPAddress remoteAddress)
@@ -863,6 +901,25 @@ namespace DnsServerCore.Auth
 
             if (!_sessions.TryAdd(session.Token, session))
                 throw new DnsWebServiceException("Error while creating session. Please try again.");
+
+            user.LoggedInFrom(remoteAddress);
+
+            return session;
+        }
+
+        public UserSession CreateApiTokenWithToken(string tokenName, string username, IPAddress remoteAddress, string userAgent, string token)
+        {
+            User user = GetUser(username);
+            if (user is null)
+                throw new DnsWebServiceException("No such user exists: " + username);
+
+            if (user.Disabled)
+                throw new DnsWebServiceException("Account is suspended.");
+
+            UserSession session = new UserSession(UserSessionType.ApiToken, tokenName, user, remoteAddress, userAgent, token);
+
+            if (!_sessions.TryAdd(session.Token, session))
+                throw new DnsWebServiceException("API token already exists.");
 
             user.LoggedInFrom(remoteAddress);
 

--- a/DnsServerCore/Auth/UserSession.cs
+++ b/DnsServerCore/Auth/UserSession.cs
@@ -73,6 +73,29 @@ namespace DnsServerCore.Auth
                 _lastSeenUserAgent = _lastSeenUserAgent.Substring(0, 255);
         }
 
+        public UserSession(UserSessionType type, string tokenName, User user, IPAddress remoteAddress, string lastSeenUserAgent, string token)
+        {
+            if ((tokenName is not null) && (tokenName.Length > 255))
+                throw new ArgumentOutOfRangeException(nameof(tokenName), "Token name length cannot exceed 255 characters.");
+
+            if (string.IsNullOrWhiteSpace(token) || !IsValidTokenFormat(token))
+                throw new ArgumentOutOfRangeException(nameof(token), "Token must be a 64-character hex string.");
+
+            if (remoteAddress.IsIPv4MappedToIPv6)
+                remoteAddress = remoteAddress.MapToIPv4();
+
+            _token = token.ToLowerInvariant();
+            _type = type;
+            _tokenName = tokenName;
+            _user = user;
+            _lastSeen = DateTime.UtcNow;
+            _lastSeenRemoteAddress = remoteAddress;
+            _lastSeenUserAgent = lastSeenUserAgent;
+
+            if ((_lastSeenUserAgent is not null) && (_lastSeenUserAgent.Length > 255))
+                _lastSeenUserAgent = _lastSeenUserAgent.Substring(0, 255);
+        }
+
         public UserSession(BinaryReader bR, IReadOnlyDictionary<string, User> users)
         {
             switch (bR.ReadByte())
@@ -159,6 +182,28 @@ namespace DnsServerCore.Auth
         public int CompareTo(UserSession other)
         {
             return other._lastSeen.CompareTo(_lastSeen);
+        }
+
+        #endregion
+
+        #region private
+
+        private static bool IsValidTokenFormat(string token)
+        {
+            if (token.Length != 64)
+                return false;
+
+            foreach (char ch in token)
+            {
+                bool isHex = (ch >= '0' && ch <= '9') ||
+                             (ch >= 'a' && ch <= 'f') ||
+                             (ch >= 'A' && ch <= 'F');
+
+                if (!isHex)
+                    return false;
+            }
+
+            return true;
         }
 
         #endregion

--- a/DockerEnvironmentVariables.md
+++ b/DockerEnvironmentVariables.md
@@ -11,6 +11,8 @@ The environment variables are described below:
 | DNS_SERVER_DOMAIN                              | String  | The primary domain name used by this DNS Server to identify itself.                                                                      |
 | DNS_SERVER_ADMIN_PASSWORD                      | String  | The DNS web console admin user password.                                                                                                 |
 | DNS_SERVER_ADMIN_PASSWORD_FILE                 | String  | The path to a file that contains a plain text password for the DNS web console admin user.                                               |
+| DNS_SERVER_ADMIN_API_TOKEN                     | String  | The admin user's API token (64-character hex string). Requires DNS_SERVER_ADMIN_PASSWORD or DNS_SERVER_ADMIN_PASSWORD_FILE.             |
+| DNS_SERVER_ADMIN_API_TOKEN_FILE                | String  | The path to a file that contains a plain text admin API token (64-character hex string). Requires DNS_SERVER_ADMIN_PASSWORD or DNS_SERVER_ADMIN_PASSWORD_FILE. |
 | DNS_SERVER_PREFER_IPV6                         | Boolean | DNS Server will use IPv6 for querying whenever possible with this option enabled.                                                        |
 | DNS_SERVER_WEB_SERVICE_LOCAL_ADDRESSES         | String  | A comma separated list of IP addresses for the DNS web console to listen on.                                                             |
 | DNS_SERVER_WEB_SERVICE_HTTP_PORT               | Integer | The TCP port number for the DNS web console over HTTP protocol.                                                                          |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - DNS_SERVER_DOMAIN=dns-server #The primary domain name used by this DNS Server to identify itself.
       # - DNS_SERVER_ADMIN_PASSWORD=password #DNS web console admin user password.
       # - DNS_SERVER_ADMIN_PASSWORD_FILE=password.txt #The path to a file that contains a plain text password for the DNS web console admin user.
+      # - DNS_SERVER_ADMIN_API_TOKEN=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef #Admin API token (64-character hex). Requires admin password env var or file.
+      # - DNS_SERVER_ADMIN_API_TOKEN_FILE=token.txt #The path to a file that contains a plain text admin API token. Requires admin password env var or file.
       # - DNS_SERVER_PREFER_IPV6=false #DNS Server will use IPv6 for querying whenever possible with this option enabled.
       # - DNS_SERVER_WEB_SERVICE_LOCAL_ADDRESSES=172.17.0.1,127.0.0.1 #Comma separated list of network interface IP addresses that you want the web service to listen on for requests. The "172.17.0.1" address is the built-in Docker bridge. The "[::]" is the default value if not specified. Note! This must be used only with "host" network mode.
       # - DNS_SERVER_WEB_SERVICE_HTTP_PORT=5380 #The TCP port number for the DNS web console over HTTP protocol.


### PR DESCRIPTION
Hello! 

Thanks for building and maintaining this project! I love it. I loved it so much that I created https://github.com/kevynb/terraform-provider-technitium.

I've been trying to add automated E2E tests to this repo to make sure that terraform creates/deletes the resources properly. 

The blocker I have is that I need to use the api for those tests and for that I need an API token, I initially thought that the docker image would support setting a default value for it but it seems it doesn't so here's a PR to propose adding this feature.

I made it a requirement to provide a password for the admin user to use the api token because I thought it would avoid exposing servers with admin/admin creds when setting this api token.

I tested the two env variables were working with the following scripts below.

Let me know if you want me to make any changes to the implementation, I hope you'll find this useful!

I created a new `UserSession` but if you prefer I could extend the existing one with `, string token = null` to avoid duplicating the whole function and reduce the maintenance burden.


```
#!/usr/bin/env bash
set -euo pipefail

export DNS_SERVER_ADMIN_PASSWORD=adminpass
export DNS_SERVER_ADMIN_API_TOKEN=$(openssl rand -hex 32)
export DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS=false
export CONFIG_DIR=$(mktemp -d /tmp/dnsserver-test-XXXXXX)

docker run -d --pull=never --platform linux/amd64 --name dns-server-test -p 5380:5380 \
  -e DNS_SERVER_ADMIN_PASSWORD \
  -e DNS_SERVER_ADMIN_API_TOKEN \
  -e DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS \
  -v "$CONFIG_DIR:/etc/dns" \
  technitium/dns-server:latest

ready=0
for _ in {1..30}; do
  if curl -sS "http://localhost:5380/" >/dev/null 2>&1; then
    ready=1
    break
  fi
  sleep 1
done

if [ "$ready" -ne 1 ]; then
  echo "Server did not become ready" >&2
  docker logs --tail=200 dns-server-test || true
  docker rm -f dns-server-test || true
  rm -rf "$CONFIG_DIR" || true
  exit 1
fi

RESPONSE=$(curl -sS "http://localhost:5380/api/settings/get?token=${DNS_SERVER_ADMIN_API_TOKEN}&type=General")

printf "TOKEN=%s\nRESPONSE=%s\n" "$DNS_SERVER_ADMIN_API_TOKEN" "$RESPONSE"

docker logs --tail=50 dns-server-test || true
docker rm -f dns-server-test
rm -rf "$CONFIG_DIR"
```

And 

```
#!/usr/bin/env bash
set -euo pipefail

export DNS_SERVER_ADMIN_PASSWORD=adminpass
export DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS=false
export CONFIG_DIR=$(mktemp -d /tmp/dnsserver-test-XXXXXX)
export TOKEN_FILE=$(mktemp /tmp/dnsserver-token-XXXXXX)

openssl rand -hex 32 > "$TOKEN_FILE"
export DNS_SERVER_ADMIN_API_TOKEN_FILE="/etc/dns/token.txt"
cp "$TOKEN_FILE" "$CONFIG_DIR/token.txt"
export DNS_SERVER_ADMIN_API_TOKEN=$(cat "$TOKEN_FILE")

docker run -d --pull=never --platform linux/amd64 --name dns-server-test -p 5380:5380 \
  -e DNS_SERVER_ADMIN_PASSWORD \
  -e DNS_SERVER_ADMIN_API_TOKEN_FILE \
  -e DNS_SERVER_WEB_SERVICE_ENABLE_HTTPS \
  -v "$CONFIG_DIR:/etc/dns" \
  technitium/dns-server:latest

ready=0
for _ in {1..30}; do
  if curl -sS "http://localhost:5380/" >/dev/null 2>&1; then
    ready=1
    break
  fi
  sleep 1
done

if [ "$ready" -ne 1 ]; then
  echo "Server did not become ready" >&2
  docker logs --tail=200 dns-server-test || true
  docker rm -f dns-server-test || true
  rm -rf "$CONFIG_DIR" || true
  rm -f "$TOKEN_FILE" || true
  exit 1
fi

RESPONSE=$(curl -sS "http://localhost:5380/api/settings/get?token=${DNS_SERVER_ADMIN_API_TOKEN}&type=General")

printf "TOKEN_FILE=%s\nTOKEN=%s\nRESPONSE=%s\n" "$TOKEN_FILE" "$DNS_SERVER_ADMIN_API_TOKEN" "$RESPONSE"

docker logs --tail=50 dns-server-test || true
docker rm -f dns-server-test
rm -rf "$CONFIG_DIR"
rm -f "$TOKEN_FILE"
```