### PR TITLE
Refactored DNS log pagination to use LIMIT and OFFSET in QueryLogsMySql (#1317)

### DIFF
--- a/Apps/QueryLogsMySqlApp/App.cs
+++ b/Apps/QueryLogsMySqlApp/App.cs
@@ -675,7 +675,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
 
         public async Task<DnsLogPage> QueryLogsAsync(long pageNumber, int entriesPerPage, bool descendingOrder, DateTime? start, DateTime? end, IPAddress clientIpAddress, DnsTransportProtocol? protocol, DnsServerResponseType? responseType, DnsResponseCode? rcode, string qname, DnsResourceRecordType? qtype, DnsClass? qclass)
         {
-            if (pageNumber < 0)
+            if (pageNumber < 1)
                 pageNumber = 1;
 
             if (qname is not null)

--- a/Apps/QueryLogsMySqlApp/App.cs
+++ b/Apps/QueryLogsMySqlApp/App.cs
@@ -823,6 +823,8 @@ LIMIT @limit OFFSET @offset";
                     if (qclass is not null)
                         command.Parameters.AddWithValue("@qclass", (short)qclass);
 
+                    long rowNumber = descendingOrder ? totalEntries - offset : offset + 1;
+
                     await using (DbDataReader reader = await command.ExecuteReaderAsync())
                     {
                         while (await reader.ReadAsync())
@@ -848,7 +850,12 @@ LIMIT @limit OFFSET @offset";
                             else
                                 answer = reader.GetString(10);
 
-                            entries.Add(new DnsLogEntry(reader.GetInt64(0), reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
+                            entries.Add(new DnsLogEntry(rowNumber, reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
+
+                            if (descendingOrder)
+                                rowNumber--;
+                            else
+                                rowNumber++;
                         }
                     }
                 }

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -571,7 +571,7 @@ END
 
         public async Task<DnsLogPage> QueryLogsAsync(long pageNumber, int entriesPerPage, bool descendingOrder, DateTime? start, DateTime? end, IPAddress clientIpAddress, DnsTransportProtocol? protocol, DnsServerResponseType? responseType, DnsResponseCode? rcode, string qname, DnsResourceRecordType? qtype, DnsClass? qclass)
         {
-            if (pageNumber == 0)
+            if (pageNumber < 1)
                 pageNumber = 1;
 
             if (qname is not null)
@@ -665,50 +665,39 @@ END
                 if ((pageNumber > totalPages) || (pageNumber < 0))
                     pageNumber = totalPages;
 
-                long endRowNum;
-                long startRowNum;
+                if (pageNumber < 1)
+                    pageNumber = 1;
 
-                if (descendingOrder)
-                {
-                    endRowNum = totalEntries - ((pageNumber - 1) * entriesPerPage);
-                    startRowNum = endRowNum - entriesPerPage;
-                }
-                else
-                {
-                    endRowNum = pageNumber * entriesPerPage;
-                    startRowNum = endRowNum - entriesPerPage;
-                }
+                long offset = (pageNumber - 1) * entriesPerPage;
 
                 List<DnsLogEntry> entries = new List<DnsLogEntry>(entriesPerPage);
 
-                await using (SqlCommand command = connection.CreateCommand())
+                if (totalEntries > 0)
                 {
-                    command.CommandText = @"
-SELECT * FROM (
-    SELECT
-        ROW_NUMBER() OVER ( 
-            ORDER BY dlid
-        ) row_num,
-        timestamp,
-        client_ip,
-        protocol,
-        response_type,
-        response_rtt,
-        rcode,
-        qname,
-        qtype,
-        qclass,
-        answer
-    FROM
-        dns_logs
-" + (string.IsNullOrEmpty(whereClause) ? "" : "WHERE " + whereClause) + @"
-) t
-WHERE 
-    row_num > @start_row_num AND row_num <= @end_row_num
-ORDER BY row_num" + (descendingOrder ? " DESC" : "");
+                    await using (SqlCommand command = connection.CreateCommand())
+                    {
+                        command.CommandText = @"
+SELECT
+    dlid,
+    timestamp,
+    client_ip,
+    protocol,
+    response_type,
+    response_rtt,
+    rcode,
+    qname,
+    qtype,
+    qclass,
+    answer
+FROM
+    dns_logs
+" + (string.IsNullOrEmpty(whereClause) ? "" : "WHERE " + whereClause + " ") + @"
+ORDER BY dlid" + (descendingOrder ? " DESC" : "") + @"
+OFFSET @offset ROWS
+FETCH NEXT @limit ROWS ONLY";
 
-                    command.Parameters.AddWithValue("@start_row_num", startRowNum);
-                    command.Parameters.AddWithValue("@end_row_num", endRowNum);
+                        command.Parameters.AddWithValue("@limit", entriesPerPage);
+                        command.Parameters.AddWithValue("@offset", offset);
 
                     if (start is not null)
                         command.Parameters.AddWithValue("@start", start);
@@ -737,6 +726,8 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                     if (qclass is not null)
                         command.Parameters.AddWithValue("@qclass", (ushort)qclass);
 
+                        long rowNumber = descendingOrder ? totalEntries - offset : offset + 1;
+
                     await using (SqlDataReader reader = await command.ExecuteReaderAsync())
                     {
                         while (await reader.ReadAsync())
@@ -762,9 +753,15 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                             else
                                 answer = reader.GetString(10);
 
-                            entries.Add(new DnsLogEntry(reader.GetInt64(0), reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
+                            entries.Add(new DnsLogEntry(rowNumber, reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
+
+                            if (descendingOrder)
+                                rowNumber--;
+                            else
+                                rowNumber++;
                         }
                     }
+                }
                 }
 
                 return new DnsLogPage(pageNumber, totalPages, totalEntries, entries);

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -655,7 +655,7 @@ END
                         command.Parameters.AddWithValue("@qtype", (short)qtype);
 
                     if (qclass is not null)
-                        command.Parameters.AddWithValue("@qclass", (ushort)qclass);
+                        command.Parameters.AddWithValue("@qclass", (short)qclass);
 
                     totalEntries = Convert.ToInt64(await command.ExecuteScalarAsync() ?? 0L);
                 }
@@ -699,69 +699,69 @@ FETCH NEXT @limit ROWS ONLY";
                         command.Parameters.AddWithValue("@limit", entriesPerPage);
                         command.Parameters.AddWithValue("@offset", offset);
 
-                    if (start is not null)
-                        command.Parameters.AddWithValue("@start", start);
+                        if (start is not null)
+                            command.Parameters.AddWithValue("@start", start);
 
-                    if (end is not null)
-                        command.Parameters.AddWithValue("@end", end);
+                        if (end is not null)
+                            command.Parameters.AddWithValue("@end", end);
 
-                    if (clientIpAddress is not null)
-                        command.Parameters.AddWithValue("@client_ip", clientIpAddress.ToString());
+                        if (clientIpAddress is not null)
+                            command.Parameters.AddWithValue("@client_ip", clientIpAddress.ToString());
 
-                    if (protocol is not null)
-                        command.Parameters.AddWithValue("@protocol", (byte)protocol);
+                        if (protocol is not null)
+                            command.Parameters.AddWithValue("@protocol", (byte)protocol);
 
-                    if (responseType is not null)
-                        command.Parameters.AddWithValue("@response_type", (byte)responseType);
+                        if (responseType is not null)
+                            command.Parameters.AddWithValue("@response_type", (byte)responseType);
 
-                    if (rcode is not null)
-                        command.Parameters.AddWithValue("@rcode", (byte)rcode);
+                        if (rcode is not null)
+                            command.Parameters.AddWithValue("@rcode", (byte)rcode);
 
-                    if (qname is not null)
-                        command.Parameters.AddWithValue("@qname", qname);
+                        if (qname is not null)
+                            command.Parameters.AddWithValue("@qname", qname);
 
-                    if (qtype is not null)
-                        command.Parameters.AddWithValue("@qtype", (short)qtype);
+                        if (qtype is not null)
+                            command.Parameters.AddWithValue("@qtype", (short)qtype);
 
-                    if (qclass is not null)
-                        command.Parameters.AddWithValue("@qclass", (ushort)qclass);
+                        if (qclass is not null)
+                            command.Parameters.AddWithValue("@qclass", (short)qclass);
 
                         long rowNumber = descendingOrder ? totalEntries - offset : offset + 1;
 
-                    await using (SqlDataReader reader = await command.ExecuteReaderAsync())
-                    {
-                        while (await reader.ReadAsync())
+                        await using (SqlDataReader reader = await command.ExecuteReaderAsync())
                         {
-                            double? responseRtt;
+                            while (await reader.ReadAsync())
+                            {
+                                double? responseRtt;
 
-                            if (reader.IsDBNull(5))
-                                responseRtt = null;
-                            else
-                                responseRtt = reader.GetFloat(5);
+                                if (reader.IsDBNull(5))
+                                    responseRtt = null;
+                                else
+                                    responseRtt = reader.GetFloat(5);
 
-                            DnsQuestionRecord? question;
+                                DnsQuestionRecord? question;
 
-                            if (reader.IsDBNull(7))
-                                question = null;
-                            else
-                                question = new DnsQuestionRecord(reader.GetString(7), (DnsResourceRecordType)reader.GetInt16(8), (DnsClass)reader.GetInt16(9), false);
+                                if (reader.IsDBNull(7))
+                                    question = null;
+                                else
+                                    question = new DnsQuestionRecord(reader.GetString(7), (DnsResourceRecordType)reader.GetInt16(8), (DnsClass)reader.GetInt16(9), false);
 
-                            string? answer;
+                                string? answer;
 
-                            if (reader.IsDBNull(10))
-                                answer = null;
-                            else
-                                answer = reader.GetString(10);
+                                if (reader.IsDBNull(10))
+                                    answer = null;
+                                else
+                                    answer = reader.GetString(10);
 
-                            entries.Add(new DnsLogEntry(rowNumber, reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
+                                entries.Add(new DnsLogEntry(rowNumber, reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
 
-                            if (descendingOrder)
-                                rowNumber--;
-                            else
-                                rowNumber++;
+                                if (descendingOrder)
+                                    rowNumber--;
+                                else
+                                    rowNumber++;
+                            }
                         }
                     }
-                }
                 }
 
                 return new DnsLogPage(pageNumber, totalPages, totalEntries, entries);

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -618,7 +618,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
                     if (qclass is not null)
                         command.Parameters.AddWithValue("@qclass", (ushort)qclass);
 
-                    totalEntries = Convert.ToInt64(await command.ExecuteScalarAsync());
+                    totalEntries = Convert.ToInt64(await command.ExecuteScalarAsync() ?? 0L);
                 }
 
                 long totalPages = (totalEntries / entriesPerPage) + (totalEntries % entriesPerPage > 0 ? 1 : 0);
@@ -659,69 +659,69 @@ LIMIT @limit OFFSET @offset";
                         command.Parameters.AddWithValue("@limit", entriesPerPage);
                         command.Parameters.AddWithValue("@offset", offset);
 
-                    if (start is not null)
-                        command.Parameters.AddWithValue("@start", start);
+                        if (start is not null)
+                            command.Parameters.AddWithValue("@start", start);
 
-                    if (end is not null)
-                        command.Parameters.AddWithValue("@end", end);
+                        if (end is not null)
+                            command.Parameters.AddWithValue("@end", end);
 
-                    if (clientIpAddress is not null)
-                        command.Parameters.AddWithValue("@client_ip", clientIpAddress.ToString());
+                        if (clientIpAddress is not null)
+                            command.Parameters.AddWithValue("@client_ip", clientIpAddress.ToString());
 
-                    if (protocol is not null)
-                        command.Parameters.AddWithValue("@protocol", (byte)protocol);
+                        if (protocol is not null)
+                            command.Parameters.AddWithValue("@protocol", (byte)protocol);
 
-                    if (responseType is not null)
-                        command.Parameters.AddWithValue("@response_type", (byte)responseType);
+                        if (responseType is not null)
+                            command.Parameters.AddWithValue("@response_type", (byte)responseType);
 
-                    if (rcode is not null)
-                        command.Parameters.AddWithValue("@rcode", (byte)rcode);
+                        if (rcode is not null)
+                            command.Parameters.AddWithValue("@rcode", (byte)rcode);
 
-                    if (qname is not null)
-                        command.Parameters.AddWithValue("@qname", qname);
+                        if (qname is not null)
+                            command.Parameters.AddWithValue("@qname", qname);
 
-                    if (qtype is not null)
-                        command.Parameters.AddWithValue("@qtype", (ushort)qtype);
+                        if (qtype is not null)
+                            command.Parameters.AddWithValue("@qtype", (ushort)qtype);
 
-                    if (qclass is not null)
-                        command.Parameters.AddWithValue("@qclass", (ushort)qclass);
+                        if (qclass is not null)
+                            command.Parameters.AddWithValue("@qclass", (ushort)qclass);
 
                         long rowNumber = descendingOrder ? totalEntries - offset : offset + 1;
 
-                    await using (SqliteDataReader reader = await command.ExecuteReaderAsync())
-                    {
-                        while (await reader.ReadAsync())
+                        await using (SqliteDataReader reader = await command.ExecuteReaderAsync())
                         {
-                            double? responseRtt;
+                            while (await reader.ReadAsync())
+                            {
+                                double? responseRtt;
 
-                            if (reader.IsDBNull(5))
-                                responseRtt = null;
-                            else
-                                responseRtt = reader.GetDouble(5);
+                                if (reader.IsDBNull(5))
+                                    responseRtt = null;
+                                else
+                                    responseRtt = reader.GetDouble(5);
 
-                            DnsQuestionRecord? question;
+                                DnsQuestionRecord? question;
 
-                            if (reader.IsDBNull(7))
-                                question = null;
-                            else
-                                question = new DnsQuestionRecord(reader.GetString(7), (DnsResourceRecordType)reader.GetInt32(8), (DnsClass)reader.GetInt32(9), false);
+                                if (reader.IsDBNull(7))
+                                    question = null;
+                                else
+                                    question = new DnsQuestionRecord(reader.GetString(7), (DnsResourceRecordType)reader.GetInt32(8), (DnsClass)reader.GetInt32(9), false);
 
-                            string? answer;
+                                string? answer;
 
-                            if (reader.IsDBNull(10))
-                                answer = null;
-                            else
-                                answer = reader.GetString(10);
+                                if (reader.IsDBNull(10))
+                                    answer = null;
+                                else
+                                    answer = reader.GetString(10);
 
-                            entries.Add(new DnsLogEntry(rowNumber, reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
+                                entries.Add(new DnsLogEntry(rowNumber, reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
 
-                            if (descendingOrder)
-                                rowNumber--;
-                            else
-                                rowNumber++;
+                                if (descendingOrder)
+                                    rowNumber--;
+                                else
+                                    rowNumber++;
+                            }
                         }
                     }
-                }
                 }
 
                 return new DnsLogPage(pageNumber, totalPages, totalEntries, entries);

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -532,7 +532,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
 
         public async Task<DnsLogPage> QueryLogsAsync(long pageNumber, int entriesPerPage, bool descendingOrder, DateTime? start, DateTime? end, IPAddress clientIpAddress, DnsTransportProtocol? protocol, DnsServerResponseType? responseType, DnsResponseCode? rcode, string qname, DnsResourceRecordType? qtype, DnsClass? qclass)
         {
-            if (pageNumber == 0)
+            if (pageNumber < 1)
                 pageNumber = 1;
 
             if (qname is not null)
@@ -626,50 +626,38 @@ CREATE TABLE IF NOT EXISTS dns_logs
                 if ((pageNumber > totalPages) || (pageNumber < 0))
                     pageNumber = totalPages;
 
-                long endRowNum;
-                long startRowNum;
+                if (pageNumber < 1)
+                    pageNumber = 1;
 
-                if (descendingOrder)
-                {
-                    endRowNum = totalEntries - ((pageNumber - 1) * entriesPerPage);
-                    startRowNum = endRowNum - entriesPerPage;
-                }
-                else
-                {
-                    endRowNum = pageNumber * entriesPerPage;
-                    startRowNum = endRowNum - entriesPerPage;
-                }
+                long offset = (pageNumber - 1) * entriesPerPage;
 
                 List<DnsLogEntry> entries = new List<DnsLogEntry>(entriesPerPage);
 
-                await using (SqliteCommand command = connection.CreateCommand())
+                if (totalEntries > 0)
                 {
-                    command.CommandText = @"
-SELECT * FROM (
-    SELECT
-        ROW_NUMBER() OVER ( 
-            ORDER BY dlid
-        ) row_num,
-        timestamp,
-        client_ip,
-        protocol,
-        response_type,
-        response_rtt,
-        rcode,
-        qname,
-        qtype,
-        qclass,
-        answer
-    FROM
-        dns_logs
-" + (string.IsNullOrEmpty(whereClause) ? "" : "WHERE " + whereClause) + @"
-) t
-WHERE 
-    row_num > @start_row_num AND row_num <= @end_row_num
-ORDER BY row_num" + (descendingOrder ? " DESC" : "");
+                    await using (SqliteCommand command = connection.CreateCommand())
+                    {
+                        command.CommandText = @"
+SELECT
+    dlid,
+    timestamp,
+    client_ip,
+    protocol,
+    response_type,
+    response_rtt,
+    rcode,
+    qname,
+    qtype,
+    qclass,
+    answer
+FROM
+    dns_logs
+" + (string.IsNullOrEmpty(whereClause) ? "" : "WHERE " + whereClause + " ") + @"
+ORDER BY dlid" + (descendingOrder ? " DESC" : "") + @"
+LIMIT @limit OFFSET @offset";
 
-                    command.Parameters.AddWithValue("@start_row_num", startRowNum);
-                    command.Parameters.AddWithValue("@end_row_num", endRowNum);
+                        command.Parameters.AddWithValue("@limit", entriesPerPage);
+                        command.Parameters.AddWithValue("@offset", offset);
 
                     if (start is not null)
                         command.Parameters.AddWithValue("@start", start);
@@ -698,6 +686,8 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                     if (qclass is not null)
                         command.Parameters.AddWithValue("@qclass", (ushort)qclass);
 
+                        long rowNumber = descendingOrder ? totalEntries - offset : offset + 1;
+
                     await using (SqliteDataReader reader = await command.ExecuteReaderAsync())
                     {
                         while (await reader.ReadAsync())
@@ -723,9 +713,15 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                             else
                                 answer = reader.GetString(10);
 
-                            entries.Add(new DnsLogEntry(reader.GetInt64(0), reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
+                            entries.Add(new DnsLogEntry(rowNumber, reader.GetDateTime(1), IPAddress.Parse(reader.GetString(2)), (DnsTransportProtocol)reader.GetByte(3), (DnsServerResponseType)reader.GetByte(4), responseRtt, (DnsResponseCode)reader.GetByte(6), question, answer));
+
+                            if (descendingOrder)
+                                rowNumber--;
+                            else
+                                rowNumber++;
                         }
                     }
+                }
                 }
 
                 return new DnsLogPage(pageNumber, totalPages, totalEntries, entries);


### PR DESCRIPTION
This pull request refactors the log querying and pagination logic in the `QueryLogsAsync` method of `App.cs` to simplify and improve how paginated results are fetched from MySQL. The changes replace the previous row number-based pagination with a more efficient `LIMIT`/`OFFSET` approach, fix page number validation, and update how row numbers are assigned to log entries in the result set. Ref issue #1371.

**Pagination and Query Logic Improvements:**

* Replaced the manual calculation of start and end row numbers with a standard SQL `LIMIT` and `OFFSET` approach for pagination, simplifying the query and improving performance. [[1]](diffhunk://#diff-96533ccd6497b6cbcdcce6a0bf0c32960cf87c1bd024776a361dfe2ab16d52beL771-R784) [[2]](diffhunk://#diff-96533ccd6497b6cbcdcce6a0bf0c32960cf87c1bd024776a361dfe2ab16d52beL807-R802)
* Updated the SQL query to remove the subquery and `ROW_NUMBER()` usage, directly ordering by `dlid` and applying `LIMIT`/`OFFSET` for result pagination.

**Page Number Validation:**

* Fixed page number validation to ensure `pageNumber` is set to 1 if a value less than 1 is provided, preventing invalid page numbers. [[1]](diffhunk://#diff-96533ccd6497b6cbcdcce6a0bf0c32960cf87c1bd024776a361dfe2ab16d52beL678-R678) [[2]](diffhunk://#diff-96533ccd6497b6cbcdcce6a0bf0c32960cf87c1bd024776a361dfe2ab16d52beL771-R784)

**Row Number Assignment:**

* Adjusted row number assignment logic for each log entry to account for the new pagination approach and correctly increment or decrement the row number depending on the sort order. [[1]](diffhunk://#diff-96533ccd6497b6cbcdcce6a0bf0c32960cf87c1bd024776a361dfe2ab16d52beR831-R832) [[2]](diffhunk://#diff-96533ccd6497b6cbcdcce6a0bf0c32960cf87c1bd024776a361dfe2ab16d52beL868-R864)