### PR TITLE
Fix Loop for Quic Listener

### DIFF
--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -2030,7 +2030,8 @@ namespace DnsServerCore.Dns
                         if (ex.InnerException is OperationCanceledException)
                             continue;
 
-                        throw;
+                        _log.Write(quicListener.LocalEndPoint, DnsTransportProtocol.Quic, ex); //log errors occuring here instead when throwed out of loop where catch logs it.
+                        continue; //dont throw, continue the loop for the threat to keep listening!
                     }
                 }
             }


### PR DESCRIPTION
Use continue instead of throw, to keep the loop intact on errors to keep listening for quic packets.

Log errors in the loop instead when throwed out by the catch.