### PR TITLE
Add RPM packaging support for RHEL-based systems

### DIFF
--- a/rpm/technitium.spec
+++ b/rpm/technitium.spec
@@ -1,0 +1,76 @@
+%global _enable_debug_package 0
+%define debug_package %{nil}
+
+Name:           technitium
+Version:        14.3
+Release:        1%{?dist}
+Summary:        Technitium DNS Server
+
+License:        GPL
+URL:            https://technitium.com
+Source0:        %{name}-%{version}.tar.xz
+
+BuildArch:      x86_64
+Requires:       aspnetcore-runtime-9.0
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+
+%description
+Technitium DNS Server is an open-source authoritative and recursive DNS server
+that can be installed on Linux systems using .NET runtime.
+
+%prep
+#%setup -q -n %{name}-%{version}
+%setup -q
+
+%build
+# Nothing to build
+
+%install
+rm -rf %{buildroot}
+
+# Create directories
+mkdir -p %{buildroot}/etc/technitium/dns
+
+# Copy application files
+cp -r * %{buildroot}/etc/technitium/dns/
+
+# Create systemd directory
+mkdir -p %{buildroot}/usr/lib/systemd/system
+
+# Create systemd service file
+cat > %{buildroot}/usr/lib/systemd/system/technitium.service <<EOF
+[Unit]
+Description=Technitium DNS Server
+After=network.target
+
+[Service]
+WorkingDirectory=/etc/technitium/dns
+ExecStart=/usr/bin/dotnet /etc/technitium/dns/DnsServerApp.dll /etc/dns
+Restart=always
+RestartSec=10
+SyslogIdentifier=dns-server
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+%post
+%systemd_post technitium.service
+
+%preun
+%systemd_preun technitium.service
+
+%postun
+%systemd_postun_with_restart technitium.service
+
+%files
+%dir /etc/technitium
+%dir /etc/technitium/dns
+/etc/technitium/dns/*
+/usr/lib/systemd/system/technitium.service
+
+%changelog
+* Wed Mar 11 2026 Zakir Hossain <zakirpcs@gmail.com> 14.3-1
+- Initial RPM build for Technitium DNS Server 14.3-1


### PR DESCRIPTION
Summary

This PR introduces native RPM packaging support for Technitium, enabling installation on RHEL-based distributions such as:

1. RHEL 9
2. AlmaLinux 9
3. Rocky Linux 9

The goal is to simplify deployment in enterprise environments where RPM-based lifecycle management is standard.

Changes Included

- Added RPM spec file under rpm/
- Defined proper:
   - BuildRequires
   - Runtime dependencies
   - File manifest
- Integrated systemd unit installation (if applicable)
- Verified successful build using rpmbuild on RHEL 9
- Clean build with no unpackaged file errors
- FHS-compliant file placement

Build Instructions
To build the RPM:
# dnf install rpm-build rpmdevtools
# rpmdev-setuptree
# cp rpm/technitium.spec ~/rpmbuild/SPECS/
# cp <generated-source-tarball> ~/rpmbuild/SOURCES/
# rpmbuild -ba ~/rpmbuild/SPECS/technitium.spec

The resulting RPM will be available under:
~/rpmbuild/RPMS/x86_64/

Why This Is Useful
- Many enterprise environments rely on:
- Native RPM lifecycle management
- Centralized repositories (Foreman, Satellite, Spacewalk)
- Patch governance and version control
- Configuration management via Ansible

Providing an official spec file allows:
- Clean integration into internal repositories
- Automated CI-based RPM builds
- Easier adoption in production infrastructure

Testing

- Built and tested on AlmaLinux 9
- Verified:
    - Successful installation via dnf install
    - Service start/stop behavior (if applicable)
    - Proper dependency resolution
    - Clean uninstall