### PR TITLE
Feat: Add Rust theme and refactor theme selection in web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Technitium DNS Server Change Log
 
 ## Version 14.3
+
 Release Date: 20 December 2025
 
 - Added support for Dark Mode. Thanks to @skidoodle for the PR.
@@ -13,9 +14,10 @@ Release Date: 20 December 2025
 - Multiple other minor bug fixes and improvements.
 
 ## Version 14.2
+
 Release Date: 22 November 2025
 
-- Fixed bug in Clustering implementation which prevented using IPv4 and IPv6 addresses together. Thanks to @ruifung for the PR. 
+- Fixed bug in Clustering implementation which prevented using IPv4 and IPv6 addresses together. Thanks to @ruifung for the PR.
 - There is also a breaking change in clustering and thus all cluster nodes must be upgraded to this release to avoid issues.
 - Updated the "Allow / Block List URLs" option implementation to support comment entries.
 - Advanced Blocking App: Updated app to implement `blockingAnswerTtl` option to allow specifying the TTL value used in blocked response.
@@ -24,6 +26,7 @@ Release Date: 22 November 2025
 - Multiple other minor bug fixes and improvements.
 
 ## Version 14.1
+
 Release Date: 16 November 2025
 
 - Updated Clustering implementation to allow configuring multiple custom IP addresses. This introduces a breaking change in the API and thus all cluster nodes must be upgraded to this release for them to work together.
@@ -34,6 +37,7 @@ Release Date: 16 November 2025
 - Other minor changes and improvements.
 
 ## Version 14.0.1
+
 Release Date: 9 November 2025
 
 - Fixed bugs in the Force Update Block List and Temporary Disable Blocking API calls.
@@ -44,6 +48,7 @@ Release Date: 9 November 2025
 - Other minor changes and improvements.
 
 ## Version 14.0
+
 Release Date: 8 November 2025
 
 - Upgraded codebase to use .NET 9 runtime. If you had manually installed the DNS Server or .NET 8 Runtime earlier then you must install .NET 9 Runtime manually before upgrading the DNS server.
@@ -63,8 +68,9 @@ Release Date: 8 November 2025
 - Query Logs (SQL Server) App: Updated app to use Channels for better performance.
 - NX Domain App: Updated app to support Extended DNS Error messages.
 - Multiple other minor bug fixes and improvements.
- 
+
 ## Version 13.6
+
 Release Date: 26 April 2025
 
 - Added option to import a zone file when adding a Primary or Forwarder zone. This allows using a template zone file when creating new zones.
@@ -76,6 +82,7 @@ Release Date: 26 April 2025
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.5
+
 Release Date: 6 April 2025
 
 - Implemented [RFC 8080](https://datatracker.ietf.org/doc/rfc8080/) to add support for Ed25519 (15) and Ed448 (16) DNSSEC algorithms for both signing and validation.
@@ -94,6 +101,7 @@ Release Date: 6 April 2025
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.4.3
+
 Release Date: 23 February 2025
 
 - Fixed issue of high memory usage when "Last Year" option is used on Dashboard.
@@ -101,6 +109,7 @@ Release Date: 23 February 2025
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.4.2
+
 Release Date: 15 February 2025
 
 - Fixed issue of unhandled CD flag condition when DO flag is unset in requests for a specific case.
@@ -110,6 +119,7 @@ Release Date: 15 February 2025
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.4.1
+
 Release Date: 2 February 2025
 
 - Fixed issue of unhandled CD flag condition when DO flag is unset in requests.
@@ -119,6 +129,7 @@ Release Date: 2 February 2025
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.4
+
 Release Date: 26 January 2025
 
 - Added implementation to detect spoofed DNS responses over UDP transport and switch to TCP transport to mitigate cache poisoning attempts. This is a mitigation for RebirthDay Attack [CVE-2024-56089] reported by Xiang Li, AOSP Lab of Nankai University.
@@ -131,6 +142,7 @@ Release Date: 26 January 2025
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.3
+
 Release Date: 21 December 2024
 
 - Implemented resolver queue mechanism to avoid request timeout error issues caused when too many outbound resolutions were being processed concurrently for large deployments. A new Max Concurrent Resolutions option is now available in Settings > General section to configure the maximum number of concurrent async resolutions per CPU core.
@@ -144,11 +156,13 @@ Release Date: 21 December 2024
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.2.2
+
 Release Date: 2 December 2024
 
 - Fixed bug that caused DNS response to include bogus records even when Checking Disabled (CD) is set to false in request.
 
 ## Version 13.2.1
+
 Release Date: 30 November 2024
 
 - Updated server to allow DNS-over-HTTPS service to read X-Real-IP header from reverse proxy that are allowed by the ACL.
@@ -160,12 +174,14 @@ Release Date: 30 November 2024
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.2
+
 Release Date: 16 November 2024
 
 - Added new option in Settings to allow configuring reverse proxy network ACL to use with DNS-over-UDP-PROXY, DNS-over-TCP-PROXY, AND DNS-over-HTTP optional protocols.
 - Fixed issue in DNS-over-QUIC protocol client which caused the forwarding to fail to work with timeout error after a while in some cases.
 
 ## Version 13.1.1
+
 Release Date: 9 November 2024
 
 - Fixed issue with HTTP/3 protocol not working for both admin web service and DNS-over-HTTPS/3 service caused due to changes in how Kestrel web server uses application protocol option.
@@ -177,6 +193,7 @@ Release Date: 9 November 2024
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.1
+
 Release Date: 19 October 2024
 
 - Added new option to add Secondary Root Zone directly.
@@ -187,17 +204,20 @@ Release Date: 19 October 2024
 - Filter AAAA App: updated app to support option to explicitly specify filter domain names.
 
 ## Version 13.0.2
+
 Release Date: 28 September 2024
 
 - Fixed issue with DNS-over-TLS and DNS-over-TCP protocols that would cause the underlying connection to close if original request gets canceled.
 - Multiple other minor bug fixes and improvements.
 
 ## Version 13.0.1
+
 Release Date: 23 September 2024
 
 - Fixed issue in using proxy with forwarders that caused failure to use DNS-over-TOR with Cloudflare's hidden service.
 
 ## Version 13.0
+
 Release Date: 22 September 2024
 
 - Implemented Catalog Zones [RFC 9432](https://datatracker.ietf.org/doc/rfc9432/) support to allow automatic DNS zone provisioning to one or more secondary name servers. The implementation supports Primary, Stub, and Conditional Forwarder zones for automatic provisioning of their respective secondary zones.
@@ -218,12 +238,14 @@ Release Date: 22 September 2024
 - Multiple other minor bug fixes and improvements.
 
 ## Version 12.2.1
+
 Release Date: 15 June 2024
 
 - Fixed issue in DHCP server that caused failure to allocate lease due to hash code mismatch.
 - Fixed issue that may create empty zone files after the zone was deleted.
 
 ## Version 12.2
+
 Release Date: 15 June 2024
 
 - Added support for NAPTR record type.
@@ -240,11 +262,12 @@ Release Date: 15 June 2024
 - Multiple other minor bug fixes and improvements.
 
 ## Version 12.1
+
 Release Date: 16 March 2024
 
 - Fixed [Key Trap](https://www.athene-center.de/en/keytrap) [vulnerability](https://www.athene-center.de/fileadmin/content/PDF/Technical_Report_KeyTrap.pdf) [CVE-2023-50387] that affected DNSSEC validation which can cause DoS affecting the DNS server's ability to resolve domain names. The mitigations will allow the DNS server to work even with high CPU usage.
   - The mitigation now allows max 4 DNSKEY records with key tag collision.
-  - Limits cryptographic failures to max 16. 
+  - Limits cryptographic failures to max 16.
   - More that 8 RRSIG validation attempts per response will cause suspension of the task with max 16 suspensions allowed before the validation stops for the response.
 - Fixed vulnerability in NSEC3 closest encloser proof [CVE-2023-50868] that affected DNSSEC validation which can cause DoS affecting the DNS server's ability to resolve domain names. The mitigations will allow the DNS server to work even with high CPU usage.
   - More than 8 NSEC3 hash calculation per response will cause suspension of the task.
@@ -267,12 +290,14 @@ Release Date: 16 March 2024
 - Multiple other minor bug fixes and improvements.
 
 ## Version 12.0.1
+
 Release Date: 8 February 2024
 
 - Fixed bug in authoritative zone wildcard matching for empty non-terminal (ENT) records.
 - Fixed other minor issues.
 
 ## Version 12.0
+
 Release Date: 4 February 2024
 
 - Upgraded codebase to use .NET 8 runtime. If you had manually installed the DNS Server or .NET 7 Runtime earlier then you must install .NET 8 Runtime manually before upgrading the DNS server.
@@ -292,22 +317,26 @@ Release Date: 4 February 2024
 - Multiple other minor bug fixes and improvements.
 
 ## Version 11.5.3
+
 Release Date: 7 November 2023
 
 - Fixed bug in authoritative zone wildcard matching which caused NXDOMAIN response for some subdomain name requests.
 
 ## Version 11.5.2
+
 Release Date: 31 October 2023
 
 - Fixed bug in zone Dynamic Updates allowed IP/network addresses that caused failure to match with request IP address.
 
 ## Version 11.5.1
+
 Release Date: 30 October 2023
 
 - Fixed bug in validation code for DNS-over-TLS library that caused failure when trying to use the protocol.
 - Advanced Blocking App: Fixed minor issue in initializing the app.
 
 ## Version 11.5
+
 Release Date: 29 October 2023
 
 - Added support to import and export zones in standard RFC 1035 text file format.
@@ -329,12 +358,14 @@ Release Date: 29 October 2023
 - Multiple other minor bug fixes and improvements.
 
 ## Version 11.4.1
+
 Release Date: 13 August 2023
 
 - Fixed issue that caused backup operations to fail.
 - Fixed minor issue with incremental zone transfer which caused empty nodes to not get removed from secondary zones.
 
 ## Version 11.4
+
 Release Date: 12 August 2023
 
 - Added support for DNS over [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) version 1 and 2 for both UDP and TCP transports. This feature allows using a load balancer or reverse proxy in front of the DNS server such that the client's IP address information is passed to the DNS server. This can also be used to provide DNS-over-TLS service with a TLS terminating reverse proxy that forwards request to TCP-PROXY protocol port.
@@ -344,6 +375,7 @@ Release Date: 12 August 2023
 - Multiple other minor bug fixes and improvements.
 
 ## Version 11.3
+
 Release Date: 2 July 2023
 
 - Added support for URI record type ([RFC 7553](https://www.rfc-editor.org/rfc/rfc7553.html)).
@@ -355,6 +387,7 @@ Release Date: 2 July 2023
 - Multiple other minor bug fixes and improvements.
 
 ## Version 11.2
+
 Release Date: 27 May 2023
 
 - Added support for SVCB and HTTPS record types ([draft-ietf-dnsop-svcb-https](https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/)).
@@ -364,11 +397,13 @@ Release Date: 27 May 2023
 - Multiple other minor bug fixes and improvements.
 
 ## Version 11.1.1
+
 Release Date: 1 May 2023
 
 - Fixed issue of UDP socket pool exhaustion on Windows platform causing all outbound UDP requests to fail.
 
 ## Version 11.1
+
 Release Date: 29 April 2023
 
 - Added support for Internationalized Domain Names (IDN).
@@ -381,6 +416,7 @@ Release Date: 29 April 2023
 - Multiple other minor bug fixes and improvements.
 
 ## Version 11.0.3
+
 Release Date: 11 March 2023
 
 - Fixed DoS vulnerability reported by Xiang Li, [Network and Information Security Lab, Tsinghua University](https://netsec.ccert.edu.cn/) that an attacker can use to send bad-formatted UDP packet to cause the outbound requests to fail to resolve due to insufficient validation.
@@ -392,12 +428,14 @@ Release Date: 11 March 2023
 - Multiple other minor bug fixes and improvements.
 
 ## Version 11.0.2
+
 Release Date: 26 February 2023
 
 - Fixed issue with DNS-over-HTTP private IP check that was causing 403 response when using with reverse proxy.
 - Fixed issue with zone record pagination caused when zone has no records.
 
 ## Version 11.0.1
+
 Release Date: 25 February 2023
 
 - Changed allow list implementation to handle them separately and show allow list count on Dashboard.
@@ -412,6 +450,7 @@ Release Date: 25 February 2023
 - Multiple other minor bug fixes and improvements.
 
 ## Version 11.0
+
 Release Date: 18 February 2023
 
 - Added support for DNS-over-QUIC (DoQ) [RFC 9250](https://www.ietf.org/rfc/rfc9250.html). This allows you to run DoQ service as well as use it with Forwarders. DoQ implementation supports running over SOCKS5 proxy server that provides UDP transport.
@@ -433,6 +472,7 @@ Release Date: 18 February 2023
 - Multiple other minor bug fixes and improvements.
 
 ## Version 10.0.1
+
 Release Date: 4 December 2022
 
 - Fixed multiple issues in EDNS Client Subnet (ECS) implementation.
@@ -442,6 +482,7 @@ Release Date: 4 December 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 10.0
+
 Release Date: 26 November 2022
 
 - Added Dynamic Updates [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136) security policy support to allow updates only for specified domain names and record types. This adds breaking changes to the zone options HTTP API calls. Any implementation that uses the zone options API must test with new update before deploying to production.
@@ -464,6 +505,7 @@ Release Date: 26 November 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 9.1
+
 Release Date: 9 October 2022
 
 - Added Dynamic Updates [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136) support. This allows using tools like `nsupdate`, allow 3rd party DHCP servers to update DNS records, and use certbot [certbot-dns-rfc2136](https://certbot-dns-rfc2136.readthedocs.io/en/stable/) plugin for automatic TLS certificate renewal using DNS challenge.
@@ -472,6 +514,7 @@ Release Date: 9 October 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 9.0
+
 Release Date: 24 September 2022
 
 - Added multi-user role based access support. This allows creating multiple users and multiple role based groups with permission based access controls.
@@ -491,18 +534,24 @@ Release Date: 24 September 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 8.1.4
+
 Release Date: 3 July 2022
+
 - Fixed issue in recursive resolution that caused DNSSEC validation to fail in cases when the name server responds with out-of-bailiwick records.
 - Updated recursive resolver to update addresses async for all NS records to improve performance.
 - Multiple other minor bug fixes and improvements.
 
 ## Version 8.1.3
+
 Release Date: 11 June 2022
+
 - Added OpenDNS DoH end points to DNS Client and Forwarder quick select list.
 - Fixed issue of missing digest type support check that could cause exception to be thrown causing failure to resolve the DNSSEC signed domain name.
 
 ## Version 8.1.2
+
 Release Date: 28 May 2022
+
 - Fixed issue in Primary zone add and update record IXFR history when RRSet TTL was updated.
 - Fixed issue in DNSSEC validation for MX and SRV records caused due to incorrect comparison of record data.
 - Fixed issue in SOA record responsible person parameter parsing.
@@ -510,7 +559,9 @@ Release Date: 28 May 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 8.1.1
+
 Release Date: 21 May 2022
+
 - Added Sync Failed and Notify Failed zone status to indicate issues between primary and secondary zones synchronization.
 - Added more options in zone options to configure zone transfer and notify settings.
 - Fixed DNSSEC signed primary zone key rollover timing issues as per [RFC 7583](https://datatracker.ietf.org/doc/html/rfc7583).
@@ -518,7 +569,9 @@ Release Date: 21 May 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 8.1
+
 Release Date: 8 May 2022
+
 - Fixed two ghost domain issues, CVE-2022-30257 (V1) and CVE-2022-30258 (V2), reported by Xiang Li, [Network and Information Security Lab, Tsinghua University](https://netsec.ccert.edu.cn/). Issue V1 was fixed with some implementation changes in the NS Revalidation feature and thus having this option enabled in Settings will mitigate the issue. Issue V2 was fixed by implementing additional validation checks when caching NS records.
 - Added maximum cache entires option to limit memory usage by removing least recently used data from cache.
 - Implemented NS revalidation to revalidate parent side NS records when their TTL expires.
@@ -529,14 +582,18 @@ Release Date: 8 May 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 8.0.2
+
 Release Date: 3 April 2022
+
 - Fixed bug in Conditional Forwarder zones that would cause ServerFailure responses for some queries.
 - Fixed issue of setting minimum TTL value to NSEC & NSEC3 records in Primary signed zones when SOA value is changed.
 - Fixed issue in parsing DNS-over-HTTPS JSON response for NSEC and NSEC3 records.
 - Multiple other minor bug fixes and improvements.
 
 ## Version 8.0.1
+
 Release Date: 29 March 2022
+
 - Fixed bug in Conditional Forwarder zones due to zone cut validation causing negative cache entry for CNAME responses which resulted in partial responses.
 - Fixed issue with handling FormatError response that were missing question section for EDNS requests.
 - Fixed minor issue with DNSSEC validation for unsigned zone when forwarder returns empty NXDOMAIN responses.
@@ -545,7 +602,9 @@ Release Date: 29 March 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 8.0
+
 Release Date: 26 March 2022
+
 - Added EDNS support [RFC 6891](https://datatracker.ietf.org/doc/html/rfc6891).
 - Added Extended DNS Errors [RFC 8914](https://datatracker.ietf.org/doc/html/rfc8914).
 - Added DNSSEC validation support with RSA & ECDSA algorithms for recursive resolver, forwarders, and conditional forwarders.
@@ -561,7 +620,9 @@ Release Date: 26 March 2022
 - Multiple other minor bug fixes and improvements.
 
 ## Version 7.1
+
 Release Date: 23 October 2021
+
 - Added option in settings to automatically configure a self signed certificate for DNS web service.
 - Fixed cache poisoning vulnerability [CVE-2021-43105] reported by Xiang Li, [Network and Information Security Lab, Tsinghua University](https://netsec.ccert.edu.cn/) and Qifan Zhang, [Data-driven Security and Privacy (DSP) Lab, University of California, Irvine](https://faculty.sites.uci.edu/zhouli/research/) when a conditional forwarder zone uses a forwarder controlled by an attacker or uses UDP/TCP forwarder protocol that the attacker can perform MiTM.
 - Block Page App: Added support for automatic self signed certificate to allow showing block page for HTTPS websites.
@@ -573,7 +634,9 @@ Release Date: 23 October 2021
 - Multiple other minor bug fixes and improvements.
 
 ## Version 7.0
+
 Release Date: 2 October 2021
+
 - DNS Apps design updated to allow apps to act as authoritative zones, drop requests, and log queries in addition to the existing APP records in authoritative zones.
 - This release is a major update for DNS Apps design and thus any previously installed apps will fail to load after the update. A manual update is required to install the latest app update from the DNS App Store for these apps to work with this new release.
 - Advanced Blocking App: This new app allows blocking domain names based on IP address or subnet of the clients by creating groups. It also supports blocking using regex and also supports loading blocked domains from Adblock format lists.
@@ -588,7 +651,9 @@ Release Date: 2 October 2021
 - Multiple other minor bug fixes and improvements.
 
 ## Version 6.4.1
+
 Release Date: 21 August 2021
+
 - Implemented Delegation Revalidation [draft-ietf-dnsop-ns-revalidation-01](https://datatracker.ietf.org/doc/draft-ietf-dnsop-ns-revalidation/) in recursive resolver.
 - Fixed issues with DNS-over-TLS due to "dot" ALPN causing SSL handshake to fail when using NextDNS as forwarder.
 - Fixed issues in counting total unique clients in dashboard stats. The future data for total clients will be displayed correctly however the bad data since last release can be fixed by deleting '/etc/dns/config/stats/202108*.dstat' files manually.
@@ -597,7 +662,9 @@ Release Date: 21 August 2021
 - Multiple other minor bug fixes and improvements.
 
 ## Version 6.4
+
 Release Date: 14 August 2021
+
 - Added DNAME record [RFC 6672](https://datatracker.ietf.org/doc/html/rfc6672) support.
 - Implemented incremental zone transfer (IXFR) [RFC 1995](https://datatracker.ietf.org/doc/html/rfc1995) support.
 - Implemented secret key transaction authentication (TSIG) [RFC 8945](https://datatracker.ietf.org/doc/html/rfc8945) support for zone transfers.
@@ -612,6 +679,7 @@ Release Date: 14 August 2021
 - Updated few API calls which may cause issues in 3rd party clients if they are not updated before deploying this new version.
 
 ## Version 6.3
+
 Release Date: 6 June 2021
 
 - Added Failover App in DNS App Store.
@@ -628,6 +696,7 @@ Release Date: 6 June 2021
 - Updated few API calls which may cause issues in 3rd party clients if they are not updated before deploying this new version.
 
 ## Version 6.2.3
+
 Release Date: 2 May 2021
 
 - Improved DNS Apps interface to show if updates are available in the installed apps list.
@@ -637,6 +706,7 @@ Release Date: 2 May 2021
 - Updated DNS Apps to shuffle addresses in response to allow load balancing.
 
 ## Version 6.2.2
+
 Release Date: 24 April 2021
 
 - Fixed issues with recursive resolution.
@@ -646,6 +716,7 @@ Release Date: 24 April 2021
 - Multiple other minor bug fixes and improvements.
 
 ## Version 6.2.1
+
 Release Date: 17 April 2021
 
 - Updated DNS Cache serve stale implementation for better performance.
@@ -654,6 +725,7 @@ Release Date: 17 April 2021
 - Fixed issue in DNS client caused when response greater than the buffer size is received.
 
 ## Version 6.2
+
 Release Date: 11 April 2021
 
 - Fixed critical bug in block list condition check causing server to respond with `RCODE=Refused` when only using Blocked zone.
@@ -661,6 +733,7 @@ Release Date: 11 April 2021
 - Renamed `NameError` to `NxDomain` to make the terminology clear that the domain does not exists. Dashboard API returns JSON with new terminology so its advised to test your code before updating the server.
 
 ## Version 6.1
+
 Release Date: 10 April 2021
 
 - Added DNS App Store feature that list all available apps for quick and easy installation and update.
@@ -675,6 +748,7 @@ Release Date: 10 April 2021
 - Multiple other minor bug fixes and improvements.
 
 ## Version 6.0
+
 Release Date: 13 March 2021
 
 - Updated entire DNS code base to .NET 5 with new Windows installer. This upgrade will improve overall performance on Windows installations.
@@ -695,6 +769,7 @@ Release Date: 13 March 2021
 - Multiple other minor bug fixes and improvements.
 
 ## Version 5.6
+
 Release Date: 2 January 2021
 
 - Updated standalone console app to work on .NET 5 and removing standalone .NET Framework app support. .NET 5 update will boost performance of the DNS server on all platforms.
@@ -719,6 +794,7 @@ Release Date: 2 January 2021
 - Multiple other minor bug fixes and improvements.
 
 ## Version 5.5
+
 Release Date: 14 November 2020
 
 - Added option to specify bootfile name for PXE booting.
@@ -729,6 +805,7 @@ Release Date: 14 November 2020
 - Multiple other minor bug fixes and improvements.
 
 ## Version 5.4
+
 Release Date: 18 October 2020
 
 - Implemented QNAME randomization feature [draft-vixie-dnsext-dns0x20](https://datatracker.ietf.org/doc/html/draft-vixie-dnsext-dns0x20-00).
@@ -741,6 +818,7 @@ Release Date: 18 October 2020
 - Multiple other minor bug fixes and improvements.
 
 ## Version 5.3
+
 Release Date: 26 September 2020
 
 - Fixed issues with DHCP server that caused it to not work correctly with relay agents.
@@ -748,6 +826,7 @@ Release Date: 26 September 2020
 - Multiple other minor bug fixes and improvements.
 
 ## Version 5.2
+
 Release Date: 6 September 2020
 
 - Added feature to allow using `certbot` to renew TLS certificates automatically when using DNS-over-HTTPS and DNS-over-TLS.
@@ -757,6 +836,7 @@ Release Date: 6 September 2020
 - Multiple other minor bug fixes and improvements.
 
 ## Version 5.1
+
 Release Date: 29 August 2020
 
 - Implemented async IO to allow the DNS server handle much higher concurrent loads.
@@ -766,6 +846,7 @@ Release Date: 29 August 2020
 - Multiple other minor bug fixes and improvements.
 
 ## Version 5.0.2
+
 Release Date: 18 July 2020
 
 - Fixed issue of missing port for "This Server" in DNS Client.
@@ -775,6 +856,7 @@ Release Date: 18 July 2020
 - Multiple other minor bug fixes and improvements.
 
 ## Version 5.0.1
+
 Release Date: 6 July 2020
 
 - Fixed serialization bug for TXT records.
@@ -783,6 +865,7 @@ Release Date: 6 July 2020
 - Fixed bug in RTT calculation for DoH json Connection.
 
 ## Version 5.0
+
 Release Date: 4 July 2020
 
 - DNS Server local end points support to allow specifying alternate ports for UDP and TCP protocols.

--- a/DnsServerCore/www/css/main.css
+++ b/DnsServerCore/www/css/main.css
@@ -602,6 +602,7 @@ body.dark-mode {
     filter: invert(1) sepia(1) saturate(5) hue-rotate(30deg);
 }
 
+/* Dae Euhwa <daedaevibin@ik.me> */
 .rust-theme {
     scrollbar-width: thin;
     scrollbar-color: #d95f02 #000000;

--- a/DnsServerCore/www/css/main.css
+++ b/DnsServerCore/www/css/main.css
@@ -1,11 +1,12 @@
-﻿html, body {
+﻿html,
+body {
     height: 100% !important;
     scrollbar-gutter: stable;
 }
 
-    body.modal-open {
-        padding-right: 0 !important;
-    }
+body.modal-open {
+    padding-right: 0 !important;
+}
 
 body {
     margin: 0px !important;
@@ -16,22 +17,22 @@ a {
     color: #6699ff;
 }
 
-    a:hover {
-        color: #6699ff;
-    }
+a:hover {
+    color: #6699ff;
+}
 
-    a:visited {
-        color: #6699ff;
-    }
+a:visited {
+    color: #6699ff;
+}
 
 th a {
     color: black !important;
 }
 
-    th a:hover {
-        color: black;
-        text-decoration: none;
-    }
+th a:hover {
+    color: black;
+    text-decoration: none;
+}
 
 #header {
     background-color: #6699ff;
@@ -42,33 +43,33 @@ th a {
     min-width: 970px;
 }
 
-    #header .title {
-        margin: 0 auto;
-        color: #ffffff;
-        padding: 0px 15px 0px 15px;
-    }
+#header .title {
+    margin: 0 auto;
+    color: #ffffff;
+    padding: 0px 15px 0px 15px;
+}
 
-        #header .title img {
-            vertical-align: text-bottom;
-        }
+#header .title img {
+    vertical-align: text-bottom;
+}
 
-        #header .title .text {
-            font-size: 24px;
-            font-weight: 600;
-            font-family: Arial;
-            margin-left: 4px;
-        }
+#header .title .text {
+    font-size: 24px;
+    font-weight: 600;
+    font-family: Arial;
+    margin-left: 4px;
+}
 
-    #header .menu {
-        float: right;
-        padding: 6px;
-    }
+#header .menu {
+    float: right;
+    padding: 6px;
+}
 
-        #header .menu .menu-title {
-            color: #ffffff;
-            font-family: Arial;
-            font-size: 16px;
-        }
+#header .menu .menu-title {
+    color: #ffffff;
+    font-family: Arial;
+    font-size: 16px;
+}
 
 #content {
     min-height: 100%;
@@ -82,16 +83,16 @@ th a {
     min-width: 970px;
 }
 
-    .container .pageLogin {
-        display: none;
-        margin: auto;
-        width: 500px;
-        padding: 150px 0 0 0;
-    }
+.container .pageLogin {
+    display: none;
+    margin: auto;
+    width: 500px;
+    padding: 150px 0 0 0;
+}
 
-    .container .page {
-        display: none;
-    }
+.container .page {
+    display: none;
+}
 
 .auto-resize-img {
     max-width: 100%;
@@ -109,10 +110,10 @@ th a {
     max-height: 480px;
 }
 
-    .center-iframe iframe {
-        width: 100%;
-        height: 100%;
-    }
+.center-iframe iframe {
+    width: 100%;
+    height: 100%;
+}
 
 #footer {
     background-color: rgb(243, 243, 243);
@@ -125,32 +126,38 @@ th a {
     min-width: 970px;
 }
 
-    #footer .content {
-        margin: 0 auto;
-        color: rgb(119,119,119);
-        font-family: Arial, sans-serif;
-        font-size: 11px;
-        font-weight: 600;
-        text-align: center;
-    }
+#footer .content {
+    margin: 0 auto;
+    color: rgb(119, 119, 119);
+    font-family: Arial, sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    text-align: center;
+}
 
-        #footer .content a {
-            color: #6699ff;
-            text-decoration: none;
-        }
+#footer .content a {
+    color: #6699ff;
+    text-decoration: none;
+}
 
-            #footer .content a:hover {
-                color: #6699ff;
-            }
+#footer .content a:hover {
+    color: #6699ff;
+}
 
 @media (min-width: 992px) {
-    #header .title, .container, #footer .content {
+
+    #header .title,
+    .container,
+    #footer .content {
         width: 970px;
     }
 }
 
 @media (min-width: 1200px) {
-    #header .title, .container, #footer .content {
+
+    #header .title,
+    .container,
+    #footer .content {
         width: 1170px;
     }
 }
@@ -179,9 +186,9 @@ th a {
     font-size: 14px;
 }
 
-    .zones .zone {
-        padding: 4px;
-    }
+.zones .zone {
+    padding: 4px;
+}
 
 .zone-viewer-pane {
     float: right;
@@ -198,9 +205,9 @@ th a {
     font-size: 12px;
 }
 
-    .logs .log {
-        padding: 2px;
-    }
+.logs .log {
+    padding: 2px;
+}
 
 .log-viewer-pane {
     float: right;
@@ -217,114 +224,114 @@ th a {
     padding: 6px 0 6px 0;
 }
 
-    .stats-panel .total-queries {
-        background-color: rgba(102, 153, 255, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .total-queries {
+    background-color: rgba(102, 153, 255, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .no-error {
-        background-color: rgba(92, 184, 92, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .no-error {
+    background-color: rgba(92, 184, 92, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .server-failure {
-        background-color: rgba(217, 83, 79, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .server-failure {
+    background-color: rgba(217, 83, 79, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .nxdomain {
-        background-color: rgba(120, 120, 120, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .nxdomain {
+    background-color: rgba(120, 120, 120, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .refused {
-        background-color: rgba(91, 192, 222, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .refused {
+    background-color: rgba(91, 192, 222, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .auth-hit {
-        background-color: rgba(150, 150, 0, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .auth-hit {
+    background-color: rgba(150, 150, 0, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .cache-hit {
-        background-color: rgba(111, 84, 153, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .cache-hit {
+    background-color: rgba(111, 84, 153, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .blocked {
-        background-color: rgba(255, 165, 0, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .blocked {
+    background-color: rgba(255, 165, 0, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .dropped {
-        background-color: rgba(30, 30, 30, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .dropped {
+    background-color: rgba(30, 30, 30, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .recursions {
-        background-color: rgba(23, 162, 184, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .recursions {
+    background-color: rgba(23, 162, 184, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .clients {
-        background-color: rgba(51, 122, 183, 0.7);
-        color: #ffffff;
-    }
+.stats-panel .clients {
+    background-color: rgba(51, 122, 183, 0.7);
+    color: #ffffff;
+}
 
-    .stats-panel .stats-last-item {
-        margin-right: 0% !important;
-    }
+.stats-panel .stats-last-item {
+    margin-right: 0% !important;
+}
 
-    .stats-panel .stats-item {
-        width: 8.818%;
-        float: left;
-        padding: 4px;
-        margin-right: 0.3%;
-    }
+.stats-panel .stats-item {
+    width: 8.818%;
+    float: left;
+    padding: 4px;
+    margin-right: 0.3%;
+}
 
-        .stats-panel .stats-item .number {
-            font-size: 15px;
-            font-weight: bold;
-        }
+.stats-panel .stats-item .number {
+    font-size: 15px;
+    font-weight: bold;
+}
 
-        .stats-panel .stats-item .percentage {
-            font-size: 10px;
-            font-weight: bold;
-        }
+.stats-panel .stats-item .percentage {
+    font-size: 10px;
+    font-weight: bold;
+}
 
-        .stats-panel .stats-item .title {
-            font-size: 12px;
-            font-weight: bold;
-        }
+.stats-panel .stats-item .title {
+    font-size: 12px;
+    font-weight: bold;
+}
 
 .zone-stats-panel {
     margin-bottom: 15px;
 }
 
-    .zone-stats-panel .stats-last-item {
-        margin-right: 0% !important;
-    }
+.zone-stats-panel .stats-last-item {
+    margin-right: 0% !important;
+}
 
-    .zone-stats-panel .stats-item {
-        width: 16.125%;
-        float: left;
-        padding: 6px 4px;
-        margin-right: 0.65%;
-        background-color: rgba(51, 122, 183, 0.7);
-        color: #ffffff;
-    }
+.zone-stats-panel .stats-item {
+    width: 16.125%;
+    float: left;
+    padding: 6px 4px;
+    margin-right: 0.65%;
+    background-color: rgba(51, 122, 183, 0.7);
+    color: #ffffff;
+}
 
-        .zone-stats-panel .stats-item .number {
-            font-size: 14px;
-            font-weight: bold;
-            padding: 6px 0;
-        }
+.zone-stats-panel .stats-item .number {
+    font-size: 14px;
+    font-weight: bold;
+    padding: 6px 0;
+}
 
-        .zone-stats-panel .stats-item .title {
-            font-size: 12px;
-            font-weight: bold;
-        }
+.zone-stats-panel .stats-item .title {
+    font-size: 12px;
+    font-weight: bold;
+}
 
 .about p {
     color: rgb(119, 119, 119);
@@ -332,7 +339,7 @@ th a {
 }
 
 .about h3 a {
-    color: rgb(51,51,51) !important;
+    color: rgb(51, 51, 51) !important;
 }
 
 .cluster-node-dropdown {
@@ -347,20 +354,20 @@ th a {
     scrollbar-color: #555 #2c2c2e;
 }
 
-    .dark-mode ::-webkit-scrollbar {
-        width: 12px;
-        height: 12px;
-    }
+.dark-mode ::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+}
 
-    .dark-mode ::-webkit-scrollbar-track {
-        background: #2c2c2e;
-    }
+.dark-mode ::-webkit-scrollbar-track {
+    background: #2c2c2e;
+}
 
-    .dark-mode ::-webkit-scrollbar-thumb {
-        background-color: #555;
-        border-radius: 6px;
-        border: 3px solid #2c2c2e;
-    }
+.dark-mode ::-webkit-scrollbar-thumb {
+    background-color: #555;
+    border-radius: 6px;
+    border: 3px solid #2c2c2e;
+}
 
 body.dark-mode {
     background-color: #1a1a1a !important;
@@ -384,9 +391,9 @@ body.dark-mode {
     box-shadow: 0px 2px 15px 1px #000 !important;
 }
 
-    .dark-mode #footer .content {
-        color: #888888 !important;
-    }
+.dark-mode #footer .content {
+    color: #888888 !important;
+}
 
 .dark-mode .about h1 {
     color: #f0f0f0 !important;
@@ -427,14 +434,15 @@ body.dark-mode {
     border-color: #3a3a3c !important;
 }
 
-    .dark-mode .dropdown-menu > li > a:hover,
-    .dark-mode .dropdown-menu > li > a:focus {
-        background-color: #3a3a3c !important;
-    }
+.dark-mode .dropdown-menu>li>a:hover,
+.dark-mode .dropdown-menu>li>a:focus {
+    background-color: #3a3a3c !important;
+    color: #ffffff !important;
+}
 
-    .dark-mode .dropdown-menu li a {
-        color: #ffffff !important;
-    }
+.dark-mode .dropdown-menu li a {
+    color: #ffffff !important;
+}
 
 .dark-mode .divider {
     background-color: #3a3a3c !important;
@@ -444,134 +452,141 @@ body.dark-mode {
     border-bottom: 1px solid #007aff !important;
 }
 
-    .dark-mode .nav-tabs > li > a:hover {
-        border-color: #4a4a4c !important;
-        border-bottom-color: #007aff !important;
-        background-color: #3a3a3c;
-    }
-
-    .dark-mode .nav-tabs > li.active > a,
-    .dark-mode .nav-tabs > li.active > a:hover,
-    .dark-mode .nav-tabs > li.active > a:focus {
-        background-color: #252525;
-        border-color: #007aff !important;
-        color: #ffffff !important;
-        border-bottom-color: transparent !important;
-    }
-
-.dark-mode .table-hover > tbody > tr:hover {
-    background-color: #33373a !important;
+.dark-mode .nav-tabs>li>a:hover {
+    border-color: #4a4a4c !important;
+    border-bottom-color: #007aff !important;
+    background-color: #3a3a3c;
 }
 
-.dark-mode .table-striped > tbody > tr:nth-of-type(odd) {
+.dark-mode .nav-tabs>li.active>a,
+.dark-mode .nav-tabs>li.active>a:hover,
+.dark-mode .nav-tabs>li.active>a:focus {
+    background-color: #252525;
+    border-color: #007aff !important;
+    color: #ffffff !important;
+    border-bottom-color: transparent !important;
+}
+
+.dark-mode .table-hover>tbody>tr:hover {
+    background-color: #33373a !important;
+    color: #ffffff;
+}
+
+.dark-mode .table-striped>tbody>tr:nth-of-type(odd) {
     background-color: #28282a !important;
 }
 
-.dark-mode .table > thead > tr > th,
-.dark-mode .table > tbody > tr > td,
-.dark-mode .table > tfoot > tr > th,
-.dark-mode .table > tfoot > tr > td {
-    border-top-color: #3a3a3c !important;
-}
-
+.dark-mode .table>thead>tr>th,
+.dark-mode .table>tbody>tr>td,
+.dark-mode .table>tfoot>tr>th,
+.dark-mode .table>tfoot>tr>td,
 .dark-mode .table-bordered,
-.dark-mode .table-bordered > thead > tr > th,
-.dark-mode .table-bordered > tbody > tr > td {
-    border-color: #3a3a3c !important;
+.dark-mode .table-bordered>thead>tr>th,
+.dark-mode .table-bordered>tbody>tr>td {
+    border-color: #d95f02 !important;
 }
 
 .dark-mode .form-control {
     background-color: #3a3a3c !important;
-    border-color: #4a4a4c !important;
+    border-color: #d95f02 !important;
     color: #f5f5f7 !important;
 }
 
-    .dark-mode .form-control[disabled], .dark-mode .form-control[readonly] {
-        background-color: #2c2c2e !important;
-    }
+.dark-mode .form-control[disabled],
+.dark-mode .form-control[readonly] {
+    background-color: #2c2c2e !important;
+}
 
 .dark-mode .modal-content {
     background-color: #2c2c2e !important;
-    border-color: #3a3a3c !important;
+    border-color: #d95f02 !important;
 }
 
-.dark-mode .modal-header {
-    border-bottom-color: #3a3a3c !important;
-}
-
+.dark-mode .modal-header,
 .dark-mode .modal-footer {
-    border-top-color: #3a3a3c !important;
+    border-color: #d95f02 !important;
 }
 
 .dark-mode .well {
     background-color: #252525 !important;
-    border-color: #3a3a3c !important;
+    border-color: #d95f02 !important;
 }
 
 .dark-mode pre {
     background-color: #222 !important;
-    color: #dcdcdc !important;
-    border: 1px solid #4a4a4c !important;
+    color: #e6e6e6 !important;
+    border: 1px solid #d95f02 !important;
 }
 
 .dark-mode .btn-default {
     color: #f5f5f7 !important;
     background-color: #3a3a3c !important;
-    border-color: #4a4a4c !important;
+    border-color: #d95f02 !important;
 }
 
-    .dark-mode .btn-default:hover,
-    .dark-mode .btn-default.active {
-        background-color: #4a4a4c !important;
-        border-color: #5a5a5c !important;
-    }
+.dark-mode .btn-default:hover,
+.dark-mode .btn-default.active {
+    background-color: #d95f02 !important;
+    border-color: #b34e02 !important;
+    color: #ffffff !important;
+}
+
+.dark-mode .btn-primary {
+    background-color: #d95f02;
+    border-color: #b34e02;
+}
+
+.dark-mode .btn-primary:hover,
+.dark-mode .btn-primary:focus,
+.dark-mode .btn-primary:active {
+    background-color: #b34e02;
+    border-color: #8c3d02;
+}
 
 .dark-mode .input-group-addon {
     background-color: #3a3a3c !important;
-    border-color: #4a4a4c !important;
+    border-color: #d95f02 !important;
 }
 
-.dark-mode .stats-panel .stats-item,
-.dark-mode .zone-stats-panel .stats-item {
-    color: #fff !important;
+.dark-mode .pager li>a {
+    background-color: #3a3a3c !important;
+    border-color: #d95f02 !important;
 }
 
-.dark-mode .c3-axis-x text,
-.dark-mode .c3-axis-y text,
-.dark-mode .c3-legend-item {
-    fill: #dcdcdc !important;
+.dark-mode .pager li>a:hover {
+    background-color: #d95f02 !important;
+    color: #ffffff;
 }
 
-.dark-mode .c3-grid line {
-    stroke: #4a4a4c !important;
+.dark-mode .pagination li:not(.active) a {
+    color: white;
+    background-color: #252525;
+    border: 1px solid #d95f02;
+}
+
+.dark-mode .pagination li:not(.active) a:hover {
+    background-color: #d95f02;
+    color: #ffffff;
+}
+
+.dark-mode .pagination>.active>a,
+.dark-mode .pagination>.active>a:focus,
+.dark-mode .pagination>.active>a:hover,
+.dark-mode .pagination>.active>span,
+.dark-mode .pagination>.active>span:focus,
+.dark-mode .pagination>.active>span:hover {
+    background-color: #d95f02;
+    border-color: #d95f02;
+    color: #000000;
 }
 
 .dark-mode input[type="datetime-local"] {
     color-scheme: dark;
 }
 
-    .dark-mode input[type="datetime-local"]::-webkit-calendar-picker-indicator {
-        filter: invert(1);
-    }
-
-.dark-mode .pager li > a {
-    background-color: #3a3a3c !important;
-    border-color: #4a4a4c !important;
+.dark-mode input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+    filter: invert(1) sepia(1) saturate(5) hue-rotate(30deg);
 }
-
-    .dark-mode .pager li > a:hover {
-        background-color: #4a4a4c !important;
-    }
-
-.dark-mode .pagination li:not(.active) a {
-    color: white;
-    background-color: #252525;
-    border: 1px solid #337ab7;
-}
-
-    .dark-mode .pagination li:not(.active) a:hover {
-        background-color: #33373a;
-    }
 
 .dark-mode #dpCustomDayWiseStart,
 .dark-mode #dpCustomDayWiseEnd,
@@ -580,9 +595,297 @@ body.dark-mode {
     color-scheme: dark;
 }
 
-    .dark-mode #dpCustomDayWiseStart::-webkit-calendar-picker-indicator,
-    .dark-mode #dpCustomDayWiseEnd::-webkit-calendar-picker-indicator,
-    .dark-mode #txtQueryLogStart::-webkit-calendar-picker-indicator,
-    .dark-mode #txtQueryLogEnd::-webkit-calendar-picker-indicator {
-        filter: invert(1);
+.dark-mode #dpCustomDayWiseStart::-webkit-calendar-picker-indicator,
+.dark-mode #dpCustomDayWiseEnd::-webkit-calendar-picker-indicator,
+.dark-mode #txtQueryLogStart::-webkit-calendar-picker-indicator,
+.dark-mode #txtQueryLogEnd::-webkit-calendar-picker-indicator {
+    filter: invert(1) sepia(1) saturate(5) hue-rotate(30deg);
+}
+
+.rust-theme {
+    scrollbar-width: thin;
+    scrollbar-color: #d95f02 #000000;
+}
+
+.rust-theme ::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+}
+
+.rust-theme ::-webkit-scrollbar-track {
+    background: #000000;
+}
+
+.rust-theme ::-webkit-scrollbar-thumb {
+    background-color: #d95f02;
+    border-radius: 6px;
+    border: 3px solid #000000;
+}
+
+body.rust-theme {
+    background-color: #000000 !important;
+    color: #e6e6e6 !important;
+}
+
+.rust-theme a {
+    color: #d95f02;
+}
+
+.rust-theme a:hover,
+.rust-theme a:visited {
+    color: #ff8c00;
+}
+
+.rust-theme th a,
+.rust-theme th a:hover {
+    color: #e6e6e6 !important;
+    text-decoration: none !important;
+}
+
+.rust-theme #header {
+    background-color: #000000 !important;
+    box-shadow: 0px 1px 15px 0px #d95f02 !important;
+    border-bottom: 1px solid #d95f02;
+}
+
+.rust-theme #footer {
+    background-color: #000000 !important;
+    color: #888888 !important;
+    box-shadow: 0px -1px 15px 0px #d95f02 !important;
+    border-top: 1px solid #d95f02;
+}
+
+.rust-theme #footer .content {
+    color: #888888 !important;
+}
+
+.rust-theme .panel,
+.rust-theme .panel-default {
+    background-color: #000000 !important;
+    border-color: #d95f02 !important;
+}
+
+.rust-theme .panel-heading {
+    background-color: #d95f02 !important;
+    border-color: #d95f02 !important;
+    color: #000000 !important;
+    font-weight: bold;
+}
+
+.rust-theme .panel-body {
+    background-color: #000000 !important;
+    color: #e6e6e6 !important;
+}
+
+.rust-theme .navbar-default,
+.rust-theme .dropdown-menu {
+    background-color: #000000 !important;
+    border-color: #d95f02 !important;
+}
+
+.rust-theme .dropdown-menu>li>a:hover,
+.rust-theme .dropdown-menu>li>a:focus {
+    background-color: #d95f02 !important;
+    color: #000000 !important;
+}
+
+.rust-theme .dropdown-menu li a {
+    color: #ffffff !important;
+}
+
+.rust-theme .divider {
+    background-color: #d95f02 !important;
+}
+
+.rust-theme .nav-tabs {
+    border-bottom: 1px solid #d95f02 !important;
+}
+
+.rust-theme .nav-tabs>li>a {
+    color: #d95f02;
+    background-color: #000000;
+}
+
+.rust-theme .nav-tabs>li>a:hover {
+    border-color: #d95f02 !important;
+    background-color: #111111;
+}
+
+.rust-theme .nav-tabs>li.active>a,
+.rust-theme .nav-tabs>li.active>a:hover,
+.rust-theme .nav-tabs>li.active>a:focus {
+    background-color: #000000;
+    border-color: #d95f02 !important;
+    color: #ffffff !important;
+    border-bottom-color: transparent !important;
+}
+
+.rust-theme .table-hover>tbody>tr:hover {
+    background-color: #d95f02 !important;
+    color: #000000 !important;
+    font-weight: bold;
+}
+
+.rust-theme .table-striped>tbody>tr:nth-of-type(odd) {
+    background-color: #000000 !important;
+}
+
+.rust-theme .table>thead>tr>th,
+.rust-theme .table>tbody>tr>td,
+.rust-theme .table>tfoot>tr>th,
+.rust-theme .table>tfoot>tr>td,
+.rust-theme .table-bordered,
+.rust-theme .table-bordered>thead>tr>th,
+.rust-theme .table-bordered>tbody>tr>td {
+    border-color: #d95f02 !important;
+}
+
+.rust-theme .form-control {
+    background-color: #000000 !important;
+    border-color: #d95f02 !important;
+    color: #f5f5f7 !important;
+}
+
+.rust-theme .form-control:focus {
+    box-shadow: 0 0 10px #d95f02;
+}
+
+.rust-theme .form-control[disabled],
+.rust-theme .form-control[readonly] {
+    background-color: #000000 !important;
+}
+
+.rust-theme .modal-content {
+    background-color: #000000 !important;
+    border: 2px solid #d95f02 !important;
+}
+
+.rust-theme .modal-header,
+.rust-theme .modal-footer {
+    background-color: #000000;
+    border-color: #d95f02 !important;
+}
+
+.rust-theme .well {
+    background-color: #000000 !important;
+    border: 1px solid #d95f02 !important;
+}
+
+.rust-theme pre {
+    background-color: #000000 !important;
+    color: #e6e6e6 !important;
+    border: 1px solid #d95f02 !important;
+}
+
+.rust-theme .btn-default {
+    color: #f5f5f7 !important;
+    background-color: #000000 !important;
+    border-color: #d95f02 !important;
+}
+
+.rust-theme .btn-default:hover,
+.rust-theme .btn-default.active {
+    background-color: #d95f02 !important;
+    border-color: #b34e02 !important;
+    color: #000000 !important;
+}
+
+.rust-theme .btn-primary {
+    background-color: #d95f02;
+    border-color: #b34e02;
+    color: #000000;
+    font-weight: bold;
+}
+
+.rust-theme .btn-primary:hover,
+.rust-theme .btn-primary:focus,
+.rust-theme .btn-primary:active {
+    background-color: #b34e02;
+    border-color: #8c3d02;
+    color: #000000;
+}
+
+.rust-theme .input-group-addon {
+    background-color: #000000 !important;
+    border-color: #d95f02 !important;
+    color: #d95f02 !important;
+}
+
+.rust-theme .pagination li:not(.active) a {
+    color: #d95f02;
+    background-color: #000000;
+    border: 1px solid #d95f02;
+}
+
+.rust-theme .pagination li:not(.active) a:hover {
+    background-color: #d95f02;
+    color: #000000;
+}
+
+.rust-theme .pagination>.active>a,
+.rust-theme .pagination>.active>a:focus,
+.rust-theme .pagination>.active>a:hover,
+.rust-theme .pagination>.active>span,
+.rust-theme .pagination>.active>span:focus,
+.rust-theme .pagination>.active>span:hover {
+    background-color: #d95f02;
+    border-color: #d95f02;
+    color: #000000;
+}
+
+.rust-theme input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+    filter: invert(1) sepia(1) saturate(5) hue-rotate(30deg);
+}
+
+.rust-theme .highlight {
+    background-color: #d95f02 !important;
+    color: #000000 !important;
+
+    .dropdown-submenu {
+        position: relative;
     }
+
+    .dropdown-submenu>.dropdown-menu {
+        top: 0;
+        left: 100%;
+        margin-top: -6px;
+        margin-left: -1px;
+        -webkit-border-radius: 0 6px 6px 6px;
+        -moz-border-radius: 0 6px 6px;
+        border-radius: 0 6px 6px 6px;
+    }
+
+    .dropdown-submenu:hover>.dropdown-menu {
+        display: block;
+    }
+
+    .dropdown-submenu>a:after {
+        display: block;
+        content: " ";
+        float: right;
+        width: 0;
+        height: 0;
+        border-color: transparent;
+        border-style: solid;
+        border-width: 5px 0 5px 5px;
+        border-left-color: #ccc;
+        margin-top: 5px;
+        margin-right: -10px;
+    }
+
+    .dropdown-submenu:hover>a:after {
+        border-left-color: #fff;
+    }
+
+    .dropdown-submenu.pull-left {
+        float: none;
+    }
+
+    .dropdown-submenu.pull-left>.dropdown-menu {
+        left: -100%;
+        margin-left: 10px;
+        -webkit-border-radius: 6px 0 6px 6px;
+        -moz-border-radius: 6px 0 6px 6px;
+        border-radius: 6px 0 6px 6px;
+    }
+}

--- a/DnsServerCore/www/index.html
+++ b/DnsServerCore/www/index.html
@@ -66,6 +66,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <li><a href="#" onclick="showCreateMyApiTokenModal(); return false;">Create API Token</a></li>
                 <li><a href="#" onclick="showChangePasswordModal(); return false;">Change Password</a></li>
                 <li><a href="#" onclick="showConfigure2FAModal(); return false;">Configure 2FA</a></li>
+                <!-- Dae Euhwa <daedaevibin@ik.me> -->
                 <li class="dropdown-submenu">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                         aria-expanded="false">

--- a/DnsServerCore/www/index.html
+++ b/DnsServerCore/www/index.html
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
 <head>
     <meta charset="utf-8" />
     <meta name="robots" content="noindex, nofollow" />
@@ -48,10 +49,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="js/dhcp.js"></script>
     <script src="js/logs.js"></script>
 </head>
+
 <body style="background-color: #fafafa;">
     <div id="header">
         <div id="mnuUser" class="menu dropdown" style="display: none;">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" style="text-decoration: none;">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                aria-expanded="false" style="text-decoration: none;">
                 <span class="menu-title">
                     <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
                     <span id="mnuUserDisplayName"></span>
@@ -63,7 +66,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <li><a href="#" onclick="showCreateMyApiTokenModal(); return false;">Create API Token</a></li>
                 <li><a href="#" onclick="showChangePasswordModal(); return false;">Change Password</a></li>
                 <li><a href="#" onclick="showConfigure2FAModal(); return false;">Configure 2FA</a></li>
-                <li><a href="#" onclick="toggleTheme(); return false;">Toggle Dark Mode</a></li>
+                <li class="dropdown-submenu">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                        aria-expanded="false">
+                        <span class="menu-title">Theme</span>
+                    </a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#" onclick="setTheme('light'); return false;">Light</a></li>
+                        <li><a href="#" onclick="setTheme('dark'); return false;">Dark</a></li>
+                        <li><a href="#" onclick="setTheme('rust'); return false;">Rust</a></li>
+                    </ul>
+                </li>
                 <li role="separator" class="divider"></li>
                 <li><a href="#" onclick="logout(); return false;">Logout</a></li>
             </ul>
@@ -98,17 +111,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <div class="form-group" id="div2FAOTP">
                                 <label for="txt2FATOTP" class="col-sm-3 control-label">Enter OTP</label>
                                 <div class="col-sm-8">
-                                    <input id="txt2FATOTP" type="text" class="form-control" style="width: 100px;" placeholder="OTP" maxlength="6">
-                                    <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator app.</div>
+                                    <input id="txt2FATOTP" type="text" class="form-control" style="width: 100px;"
+                                        placeholder="OTP" maxlength="6">
+                                    <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator
+                                        app.</div>
                                 </div>
                             </div>
 
                             <div class="form-group" style="margin-bottom: 0px;">
                                 <div class="col-sm-offset-3 col-sm-4">
-                                    <button id="btnLogin" type="submit" class="btn btn-primary" data-loading-text="Working..." onclick="login(); return false;">Login</button>
+                                    <button id="btnLogin" type="submit" class="btn btn-primary"
+                                        data-loading-text="Working..." onclick="login(); return false;">Login</button>
                                 </div>
                                 <div class="col-sm-4" style="padding: 6px; text-align: right;">
-                                    <a href="#" data-toggle="modal" data-target="#modalForgotPassword">Forgot Password?</a>
+                                    <a href="#" data-toggle="modal" data-target="#modalForgotPassword">Forgot
+                                        Password?</a>
                                 </div>
                             </div>
                         </form>
@@ -123,61 +140,103 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <h3 class="panel-title">DNS Server<span id="lblDnsServerDomain"></span></h3>
                         </div>
                         <div style="float: right;">
-                            <a href="#" data-toggle="modal" data-target="#modalUpdateAvailable" id="lnkUpdateAvailable" style="display: none; color: red !important;">New Update Available!</a>
+                            <a href="#" data-toggle="modal" data-target="#modalUpdateAvailable" id="lnkUpdateAvailable"
+                                style="display: none; color: red !important;">New Update Available!</a>
                         </div>
                     </div>
 
                     <div class="panel-body" style="min-height: 500px;">
                         <div>
                             <ul class="nav nav-tabs" role="tablist">
-                                <li id="mainPanelTabListDashboard" role="presentation" class="active"><a href="#mainPanelTabPaneDashboard" aria-controls="mainPanelTabPaneDashboard" role="tab" data-toggle="tab" onclick="refreshDashboard();">Dashboard</a></li>
-                                <li id="mainPanelTabListZones" role="presentation"><a href="#mainPanelTabPaneZones" aria-controls="mainPanelTabPaneZones" role="tab" data-toggle="tab" onclick="refreshZones(true);">Zones</a></li>
-                                <li id="mainPanelTabListCachedZones" role="presentation"><a href="#mainPanelTabPaneCachedZones" aria-controls="mainPanelTabPaneCachedZones" role="tab" data-toggle="tab">Cache</a></li>
-                                <li id="mainPanelTabListAllowedZones" role="presentation"><a href="#mainPanelTabPaneAllowedZones" aria-controls="mainPanelTabPaneAllowedZones" role="tab" data-toggle="tab">Allowed</a></li>
-                                <li id="mainPanelTabListBlockedZones" role="presentation"><a href="#mainPanelTabPaneBlockedZones" aria-controls="mainPanelTabPaneBlockedZones" role="tab" data-toggle="tab">Blocked</a></li>
-                                <li id="mainPanelTabListApps" role="presentation"><a href="#mainPanelTabPaneApps" aria-controls="mainPanelTabPaneApps" role="tab" data-toggle="tab" onclick="refreshApps();">Apps</a></li>
-                                <li id="mainPanelTabListDnsClient" role="presentation"><a href="#mainPanelTabPaneDnsClient" aria-controls="mainPanelTabPaneDnsClient" role="tab" data-toggle="tab">DNS Client</a></li>
-                                <li id="mainPanelTabListSettings" role="presentation"><a href="#mainPanelTabPaneSettings" aria-controls="mainPanelTabPaneSettings" role="tab" data-toggle="tab" onclick="refreshDnsSettings();">Settings</a></li>
-                                <li id="mainPanelTabListDhcp" role="presentation"><a href="#mainPanelTabPaneDhcp" aria-controls="mainPanelTabPaneDhcp" role="tab" data-toggle="tab" onclick="refreshDhcpTab();">DHCP</a></li>
-                                <li id="mainPanelTabListAdmin" role="presentation"><a href="#mainPanelTabPaneAdmin" aria-controls="mainPanelTabPaneAdmin" role="tab" data-toggle="tab" onclick="refreshAdminTab();">Administration</a></li>
-                                <li id="mainPanelTabListLogs" role="presentation"><a href="#mainPanelTabPaneLogs" aria-controls="mainPanelTabPaneLogs" role="tab" data-toggle="tab" onclick="refreshLogsTab();">Logs</a></li>
-                                <li id="mainPanelTabListAbout" role="presentation"><a href="#mainPanelTabPaneAbout" aria-controls="mainPanelTabPaneAbout" role="tab" data-toggle="tab">About</a></li>
+                                <li id="mainPanelTabListDashboard" role="presentation" class="active"><a
+                                        href="#mainPanelTabPaneDashboard" aria-controls="mainPanelTabPaneDashboard"
+                                        role="tab" data-toggle="tab" onclick="refreshDashboard();">Dashboard</a></li>
+                                <li id="mainPanelTabListZones" role="presentation"><a href="#mainPanelTabPaneZones"
+                                        aria-controls="mainPanelTabPaneZones" role="tab" data-toggle="tab"
+                                        onclick="refreshZones(true);">Zones</a></li>
+                                <li id="mainPanelTabListCachedZones" role="presentation"><a
+                                        href="#mainPanelTabPaneCachedZones" aria-controls="mainPanelTabPaneCachedZones"
+                                        role="tab" data-toggle="tab">Cache</a></li>
+                                <li id="mainPanelTabListAllowedZones" role="presentation"><a
+                                        href="#mainPanelTabPaneAllowedZones"
+                                        aria-controls="mainPanelTabPaneAllowedZones" role="tab"
+                                        data-toggle="tab">Allowed</a></li>
+                                <li id="mainPanelTabListBlockedZones" role="presentation"><a
+                                        href="#mainPanelTabPaneBlockedZones"
+                                        aria-controls="mainPanelTabPaneBlockedZones" role="tab"
+                                        data-toggle="tab">Blocked</a></li>
+                                <li id="mainPanelTabListApps" role="presentation"><a href="#mainPanelTabPaneApps"
+                                        aria-controls="mainPanelTabPaneApps" role="tab" data-toggle="tab"
+                                        onclick="refreshApps();">Apps</a></li>
+                                <li id="mainPanelTabListDnsClient" role="presentation"><a
+                                        href="#mainPanelTabPaneDnsClient" aria-controls="mainPanelTabPaneDnsClient"
+                                        role="tab" data-toggle="tab">DNS Client</a></li>
+                                <li id="mainPanelTabListSettings" role="presentation"><a
+                                        href="#mainPanelTabPaneSettings" aria-controls="mainPanelTabPaneSettings"
+                                        role="tab" data-toggle="tab" onclick="refreshDnsSettings();">Settings</a></li>
+                                <li id="mainPanelTabListDhcp" role="presentation"><a href="#mainPanelTabPaneDhcp"
+                                        aria-controls="mainPanelTabPaneDhcp" role="tab" data-toggle="tab"
+                                        onclick="refreshDhcpTab();">DHCP</a></li>
+                                <li id="mainPanelTabListAdmin" role="presentation"><a href="#mainPanelTabPaneAdmin"
+                                        aria-controls="mainPanelTabPaneAdmin" role="tab" data-toggle="tab"
+                                        onclick="refreshAdminTab();">Administration</a></li>
+                                <li id="mainPanelTabListLogs" role="presentation"><a href="#mainPanelTabPaneLogs"
+                                        aria-controls="mainPanelTabPaneLogs" role="tab" data-toggle="tab"
+                                        onclick="refreshLogsTab();">Logs</a></li>
+                                <li id="mainPanelTabListAbout" role="presentation"><a href="#mainPanelTabPaneAbout"
+                                        aria-controls="mainPanelTabPaneAbout" role="tab" data-toggle="tab">About</a>
+                                </li>
                             </ul>
 
                             <div class="tab-content">
-                                <div id="mainPanelTabPaneDashboard" role="tabpanel" class="tab-pane active" style="padding: 10px 0 0 0;">
+                                <div id="mainPanelTabPaneDashboard" role="tabpanel" class="tab-pane active"
+                                    style="padding: 10px 0 0 0;">
                                     <div>
                                         <div class="pull-left">
                                             <div class="btn-group" data-toggle="buttons">
                                                 <label class="btn btn-default active">
-                                                    <input type="radio" name="rdStatType" value="lastHour" autocomplete="off" checked> Last Hour
+                                                    <input type="radio" name="rdStatType" value="lastHour"
+                                                        autocomplete="off" checked> Last Hour
                                                 </label>
                                                 <label class="btn btn-default">
-                                                    <input type="radio" name="rdStatType" value="lastDay" autocomplete="off"> Last Day
+                                                    <input type="radio" name="rdStatType" value="lastDay"
+                                                        autocomplete="off"> Last Day
                                                 </label>
                                                 <label class="btn btn-default">
-                                                    <input type="radio" name="rdStatType" value="lastWeek" autocomplete="off"> Last Week
+                                                    <input type="radio" name="rdStatType" value="lastWeek"
+                                                        autocomplete="off"> Last Week
                                                 </label>
                                                 <label class="btn btn-default">
-                                                    <input type="radio" name="rdStatType" value="lastMonth" autocomplete="off"> Last Month
+                                                    <input type="radio" name="rdStatType" value="lastMonth"
+                                                        autocomplete="off"> Last Month
                                                 </label>
                                                 <label class="btn btn-default">
-                                                    <input type="radio" name="rdStatType" value="lastYear" autocomplete="off"> Last Year
+                                                    <input type="radio" name="rdStatType" value="lastYear"
+                                                        autocomplete="off"> Last Year
                                                 </label>
                                                 <label class="btn btn-default">
-                                                    <input type="radio" name="rdStatType" value="custom" autocomplete="off"> Custom
+                                                    <input type="radio" name="rdStatType" value="custom"
+                                                        autocomplete="off"> Custom
                                                 </label>
                                             </div>
 
                                             <div id="divCustomDayWise" style="padding: 6px 0px 0px; display: none;">
-                                                <span style="margin-right: 6px;"><label for="dpCustomDayWiseStart">Start</label> <input type="datetime-local" id="dpCustomDayWiseStart" size="10"></span>
-                                                <span style="margin-right: 6px;"><label for="dpCustomDayWiseEnd">End</label> <input type="datetime-local" id="dpCustomDayWiseEnd" size="10"></span>
-                                                <button id="btnCustomDayWise" class="btn btn-default" type="button" style="font-size: 12px; padding: 3px 0px; width: 60px; vertical-align: top;">Show</button>
+                                                <span style="margin-right: 6px;"><label
+                                                        for="dpCustomDayWiseStart">Start</label> <input
+                                                        type="datetime-local" id="dpCustomDayWiseStart"
+                                                        size="10"></span>
+                                                <span style="margin-right: 6px;"><label
+                                                        for="dpCustomDayWiseEnd">End</label> <input
+                                                        type="datetime-local" id="dpCustomDayWiseEnd" size="10"></span>
+                                                <button id="btnCustomDayWise" class="btn btn-default" type="button"
+                                                    style="font-size: 12px; padding: 3px 0px; width: 60px; vertical-align: top;">Show</button>
                                             </div>
                                         </div>
 
                                         <div class="pull-right">
-                                            <select id="optDashboardClusterNode" class="form-control cluster-node-dropdown" style="margin-left: 0px;" onchange="refreshDashboard();"></select>
+                                            <select id="optDashboardClusterNode"
+                                                class="form-control cluster-node-dropdown" style="margin-left: 0px;"
+                                                onchange="refreshDashboard();"></select>
                                         </div>
 
                                         <div class="clearfix"></div>
@@ -195,55 +254,64 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                             <div class="stats-item no-error">
                                                 <div class="number" id="divDashboardStatsTotalNoError">70</div>
-                                                <div class="percentage" id="divDashboardStatsTotalNoErrorPercentage">0%</div>
+                                                <div class="percentage" id="divDashboardStatsTotalNoErrorPercentage">0%
+                                                </div>
                                                 <div class="title">No Error</div>
                                             </div>
 
                                             <div class="stats-item server-failure">
                                                 <div class="number" id="divDashboardStatsTotalServerFailure">5</div>
-                                                <div class="percentage" id="divDashboardStatsTotalServerFailurePercentage">0%</div>
+                                                <div class="percentage"
+                                                    id="divDashboardStatsTotalServerFailurePercentage">0%</div>
                                                 <div class="title">Server Failure</div>
                                             </div>
 
                                             <div class="stats-item nxdomain">
                                                 <div class="number" id="divDashboardStatsTotalNxDomain">5</div>
-                                                <div class="percentage" id="divDashboardStatsTotalNxDomainPercentage">0%</div>
+                                                <div class="percentage" id="divDashboardStatsTotalNxDomainPercentage">0%
+                                                </div>
                                                 <div class="title">NX Domain</div>
                                             </div>
 
                                             <div class="stats-item refused">
                                                 <div class="number" id="divDashboardStatsTotalRefused">10</div>
-                                                <div class="percentage" id="divDashboardStatsTotalRefusedPercentage">0%</div>
+                                                <div class="percentage" id="divDashboardStatsTotalRefusedPercentage">0%
+                                                </div>
                                                 <div class="title">Refused</div>
                                             </div>
 
                                             <div class="stats-item auth-hit">
                                                 <div class="number" id="divDashboardStatsTotalAuthHit">10</div>
-                                                <div class="percentage" id="divDashboardStatsTotalAuthHitPercentage">0%</div>
+                                                <div class="percentage" id="divDashboardStatsTotalAuthHitPercentage">0%
+                                                </div>
                                                 <div class="title">Authoritative</div>
                                             </div>
 
                                             <div class="stats-item recursions">
                                                 <div class="number" id="divDashboardStatsTotalRecursions">10</div>
-                                                <div class="percentage" id="divDashboardStatsTotalRecursionsPercentage">0%</div>
+                                                <div class="percentage" id="divDashboardStatsTotalRecursionsPercentage">
+                                                    0%</div>
                                                 <div class="title">Recursive</div>
                                             </div>
 
                                             <div class="stats-item cache-hit">
                                                 <div class="number" id="divDashboardStatsTotalCacheHit">10</div>
-                                                <div class="percentage" id="divDashboardStatsTotalCacheHitPercentage">0%</div>
+                                                <div class="percentage" id="divDashboardStatsTotalCacheHitPercentage">0%
+                                                </div>
                                                 <div class="title">Cached</div>
                                             </div>
 
                                             <div class="stats-item blocked">
                                                 <div class="number" id="divDashboardStatsTotalBlocked">10</div>
-                                                <div class="percentage" id="divDashboardStatsTotalBlockedPercentage">0%</div>
+                                                <div class="percentage" id="divDashboardStatsTotalBlockedPercentage">0%
+                                                </div>
                                                 <div class="title">Blocked</div>
                                             </div>
 
                                             <div class="stats-item dropped">
                                                 <div class="number" id="divDashboardStatsTotalDropped">5</div>
-                                                <div class="percentage" id="divDashboardStatsTotalDroppedPercentage">0%</div>
+                                                <div class="percentage" id="divDashboardStatsTotalDroppedPercentage">0%
+                                                </div>
                                                 <div class="title">Dropped</div>
                                             </div>
 
@@ -302,12 +370,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                     </div>
 
                                                     <div class="stats-item">
-                                                        <div class="number" id="divDashboardStatsAllowListZones">10</div>
+                                                        <div class="number" id="divDashboardStatsAllowListZones">10
+                                                        </div>
                                                         <div class="title">Allow List</div>
                                                     </div>
 
                                                     <div class="stats-item stats-last-item">
-                                                        <div class="number" id="divDashboardStatsBlockListZones">10</div>
+                                                        <div class="number" id="divDashboardStatsBlockListZones">10
+                                                        </div>
                                                         <div class="title">Block List</div>
                                                     </div>
 
@@ -316,9 +386,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                                 <div class="panel panel-default" style="margin-bottom: 0px;">
                                                     <div class="panel-heading" style="height: 41px; padding: 4px 6px;">
-                                                        <div class="pull-left" style="padding: 6px 8px;">Top Clients</div>
+                                                        <div class="pull-left" style="padding: 6px 8px;">Top Clients
+                                                        </div>
                                                         <div class="pull-right">
-                                                            <button type="button" class="btn btn-default" data-loading-text="More" onclick="showTopStats('TopClients', 1000);" style="font-size: 12px; padding: 4px 14px; margin: 2px 0px;">More</button>
+                                                            <button type="button" class="btn btn-default"
+                                                                data-loading-text="More"
+                                                                onclick="showTopStats('TopClients', 1000);"
+                                                                style="font-size: 12px; padding: 4px 14px; margin: 2px 0px;">More</button>
                                                         </div>
                                                         <div class="clearfix"></div>
                                                     </div>
@@ -343,9 +417,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                             <div style="float: left; width: 50%; padding-right: 7px;">
                                                 <div class="panel panel-default" style="margin-bottom: 0px;">
                                                     <div class="panel-heading" style="height: 41px; padding: 4px 6px;">
-                                                        <div class="pull-left" style="padding: 6px 8px;">Top Domains</div>
+                                                        <div class="pull-left" style="padding: 6px 8px;">Top Domains
+                                                        </div>
                                                         <div class="pull-right">
-                                                            <button type="button" class="btn btn-default" data-loading-text="More" onclick="showTopStats('TopDomains', 1000);" style="font-size: 12px; padding: 4px 14px; margin: 2px 0px;">More</button>
+                                                            <button type="button" class="btn btn-default"
+                                                                data-loading-text="More"
+                                                                onclick="showTopStats('TopDomains', 1000);"
+                                                                style="font-size: 12px; padding: 4px 14px; margin: 2px 0px;">More</button>
                                                         </div>
                                                         <div class="clearfix"></div>
                                                     </div>
@@ -366,9 +444,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                             <div style="float: right; width: 50%; padding-left: 7px;">
                                                 <div class="panel panel-default" style="margin-bottom: 0px;">
                                                     <div class="panel-heading" style="height: 41px; padding: 4px 6px;">
-                                                        <div class="pull-left" style="padding: 6px 8px;">Top Blocked Domains</div>
+                                                        <div class="pull-left" style="padding: 6px 8px;">Top Blocked
+                                                            Domains</div>
                                                         <div class="pull-right">
-                                                            <button type="button" class="btn btn-default" data-loading-text="More" onclick="showTopStats('TopBlockedDomains', 1000);" style="font-size: 12px; padding: 4px 14px; margin: 2px 0px;">More</button>
+                                                            <button type="button" class="btn btn-default"
+                                                                data-loading-text="More"
+                                                                onclick="showTopStats('TopBlockedDomains', 1000);"
+                                                                style="font-size: 12px; padding: 4px 14px; margin: 2px 0px;">More</button>
                                                         </div>
                                                         <div class="clearfix"></div>
                                                     </div>
@@ -391,15 +473,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     </div>
                                 </div>
 
-                                <div id="mainPanelTabPaneZones" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
-                                    <div id="divViewZonesLoader" style="display: none; margin-top: 10px; height: 400px;"></div>
+                                <div id="mainPanelTabPaneZones" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
+                                    <div id="divViewZonesLoader"
+                                        style="display: none; margin-top: 10px; height: 400px;"></div>
 
                                     <div id="divViewZones">
                                         <div class="form-inline" style="margin-bottom: 4px;">
                                             <div class="pull-right">
                                                 <div class="form-group" style="margin-right: 0px;">
-                                                    <button type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showAddZoneModal();">Add Zone</button>
-                                                    <select id="optZonesClusterNode" class="form-control cluster-node-dropdown" onchange="refreshZones();"></select>
+                                                    <button type="button" class="btn btn-primary"
+                                                        style="padding: 2px 0px; width: 100px;"
+                                                        onclick="showAddZoneModal();">Add Zone</button>
+                                                    <select id="optZonesClusterNode"
+                                                        class="form-control cluster-node-dropdown"
+                                                        onchange="refreshZones();"></select>
                                                 </div>
                                             </div>
                                             <div class="clearfix"></div>
@@ -408,14 +496,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <div class="form-inline">
                                             <form class="pull-left">
                                                 <div class="form-group">
-                                                    <input id="txtZonesEdit" class="form-control" style="width: 300px;" type="text" placeholder="example.com" />
-                                                    <button type="submit" class="btn btn-primary" onclick="showEditZone(); return false;">Edit</button>
+                                                    <input id="txtZonesEdit" class="form-control" style="width: 300px;"
+                                                        type="text" placeholder="example.com" />
+                                                    <button type="submit" class="btn btn-primary"
+                                                        onclick="showEditZone(); return false;">Edit</button>
                                                 </div>
                                             </form>
                                             <form class="pull-right">
                                                 <div class="form-group">
                                                     <label for="txtZonesPageNumber">Page Number</label>
-                                                    <input id="txtZonesPageNumber" class="form-control" style="width: 100px;" type="number" />
+                                                    <input id="txtZonesPageNumber" class="form-control"
+                                                        style="width: 100px;" type="number" />
                                                 </div>
                                                 <div class="form-group">
                                                     <label for="optZonesPerPage">Zones Per Page</label>
@@ -428,7 +519,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                         <option>500</option>
                                                     </select>
                                                 </div>
-                                                <button type="submit" class="btn btn-primary form-group" style="margin-right: 0px;" onclick="refreshZones(); return false;">Go</button>
+                                                <button type="submit" class="btn btn-primary form-group"
+                                                    style="margin-right: 0px;"
+                                                    onclick="refreshZones(); return false;">Go</button>
                                             </form>
                                             <div class="clearfix"></div>
                                         </div>
@@ -439,10 +532,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                             </div>
                                             <div class="pull-right">
                                                 <nav aria-label="Page navigation">
-                                                    <ul id="tableZonesTopPagination" class="pagination" style="margin: 0;">
-                                                        <li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
+                                                    <ul id="tableZonesTopPagination" class="pagination"
+                                                        style="margin: 0;">
+                                                        <li><a href="#" aria-label="Previous"><span
+                                                                    aria-hidden="true">&laquo;</span></a></li>
                                                         <li><a href="#">1</a></li>
-                                                        <li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+                                                        <li><a href="#" aria-label="Next"><span
+                                                                    aria-hidden="true">&raquo;</span></a></li>
                                                     </ul>
                                                 </nav>
                                             </div>
@@ -452,14 +548,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <table id="tableZones" class="table table-hover">
                                             <thead>
                                                 <tr>
-                                                    <th><a href="#" onclick="sortTable('tableZonesBody', 0); return false;">#</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableZonesBody', 1); return false;">Zone</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableZonesBody', 2); return false;">Type</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableZonesBody', 3); return false;">DNSSEC</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableZonesBody', 4); return false;">Status</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableZonesBody', 5); return false;">Serial</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableZonesBody', 6); return false;">Expiry</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableZonesBody', 7); return false;">Last Modified</a></th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableZonesBody', 0); return false;">#</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableZonesBody', 1); return false;">Zone</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableZonesBody', 2); return false;">Type</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableZonesBody', 3); return false;">DNSSEC</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableZonesBody', 4); return false;">Status</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableZonesBody', 5); return false;">Serial</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableZonesBody', 6); return false;">Expiry</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableZonesBody', 7); return false;">Last
+                                                            Modified</a></th>
                                                     <th style="width: 36px;"></th>
                                                 </tr>
                                             </thead>
@@ -473,10 +585,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             </div>
                                                             <div class="pull-right">
                                                                 <nav aria-label="Page navigation">
-                                                                    <ul id="tableZonesFooterPagination" class="pagination" style="margin: 0;">
-                                                                        <li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
+                                                                    <ul id="tableZonesFooterPagination"
+                                                                        class="pagination" style="margin: 0;">
+                                                                        <li><a href="#" aria-label="Previous"><span
+                                                                                    aria-hidden="true">&laquo;</span></a>
+                                                                        </li>
                                                                         <li><a href="#">1</a></li>
-                                                                        <li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+                                                                        <li><a href="#" aria-label="Next"><span
+                                                                                    aria-hidden="true">&raquo;</span></a>
+                                                                        </li>
                                                                     </ul>
                                                                 </nav>
                                                             </div>
@@ -492,79 +609,136 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <div>
                                             <div class="pull-left">
                                                 <ul class="pager" style="margin: 0px;">
-                                                    <li class="previous"><a href="#" onclick="refreshZones(); return false;"><span aria-hidden="true">&larr;</span> Back</a></li>
+                                                    <li class="previous"><a href="#"
+                                                            onclick="refreshZones(); return false;"><span
+                                                                aria-hidden="true">&larr;</span> Back</a></li>
                                                 </ul>
                                             </div>
 
                                             <div class="pull-right">
-                                                <select id="optEditZoneClusterNode" class="form-control cluster-node-dropdown" style="margin-left: 0px;" disabled></select>
+                                                <select id="optEditZoneClusterNode"
+                                                    class="form-control cluster-node-dropdown" style="margin-left: 0px;"
+                                                    disabled></select>
                                             </div>
 
                                             <div class="clearfix"></div>
                                         </div>
 
                                         <div style="padding: 10px 0px;">
-                                            <h3 style="margin: 4px 0;"><span id="titleEditZone" style="margin-right: 10px;">example.com</span><a href="#" onclick="showEditZone($('#titleEditZone').attr('data-zone'), $('#txtEditZonePageNumber').val(), $('#txtEditZoneFilterName').val(), $('#txtEditZoneFilterType').val()); return false;"><span class="glyphicon glyphicon-refresh" style="font-size: 20px;" aria-hidden="true"></span></a></h3>
+                                            <h3 style="margin: 4px 0;"><span id="titleEditZone"
+                                                    style="margin-right: 10px;">example.com</span><a href="#"
+                                                    onclick="showEditZone($('#titleEditZone').attr('data-zone'), $('#txtEditZonePageNumber').val(), $('#txtEditZoneFilterName').val(), $('#txtEditZoneFilterType').val()); return false;"><span
+                                                        class="glyphicon glyphicon-refresh" style="font-size: 20px;"
+                                                        aria-hidden="true"></span></a></h3>
                                             <div style="float: left;">
                                                 <span id="titleEditZoneType" class="label label-default">Primary</span>
-                                                <span id="titleEditZoneDnssecStatus" class="label label-default">DNSSEC</span>
-                                                <span id="titleEditZoneStatus" class="label label-success">Enabled</span>
-                                                <span id="titleEditZoneCatalog" class="label label-default">catalog</span>
-                                                <div id="titleEditZoneExpiry" style="padding-top: 4px; font-size: 10px; font-weight: bold;">Expiry: 01 Jan 2020 00:00:00</div>
+                                                <span id="titleEditZoneDnssecStatus"
+                                                    class="label label-default">DNSSEC</span>
+                                                <span id="titleEditZoneStatus"
+                                                    class="label label-success">Enabled</span>
+                                                <span id="titleEditZoneCatalog"
+                                                    class="label label-default">catalog</span>
+                                                <div id="titleEditZoneExpiry"
+                                                    style="padding-top: 4px; font-size: 10px; font-weight: bold;">
+                                                    Expiry: 01 Jan 2020 00:00:00</div>
                                             </div>
                                             <div style="float: right; padding: 2px 0px;">
-                                                <button id="btnEditZoneAddRecord" type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showAddRecordModal();">Add Record</button>
-                                                <button id="btnEnableZoneEditZone" type="button" class="btn btn-default" style="padding: 2px 0px; width: 100px;" onclick="enableZone(this);">Enable Zone</button>
-                                                <button id="btnDisableZoneEditZone" type="button" class="btn btn-warning" style="padding: 2px 0px; width: 100px;" onclick="disableZone(this);">Disable Zone</button>
-                                                <button id="btnEditZoneDeleteZone" type="button" class="btn btn-danger" style="padding: 2px 0px; width: 100px;" onclick="deleteZone(this);">Delete Zone</button>
-                                                <button id="btnZoneResync" type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="resyncZone(this, $('#titleEditZone').attr('data-zone'));" data-loading-text="Resyncing...">Resync</button>
+                                                <button id="btnEditZoneAddRecord" type="button" class="btn btn-primary"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    onclick="showAddRecordModal();">Add Record</button>
+                                                <button id="btnEnableZoneEditZone" type="button" class="btn btn-default"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    onclick="enableZone(this);">Enable Zone</button>
+                                                <button id="btnDisableZoneEditZone" type="button"
+                                                    class="btn btn-warning" style="padding: 2px 0px; width: 100px;"
+                                                    onclick="disableZone(this);">Disable Zone</button>
+                                                <button id="btnEditZoneDeleteZone" type="button" class="btn btn-danger"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    onclick="deleteZone(this);">Delete Zone</button>
+                                                <button id="btnZoneResync" type="button" class="btn btn-primary"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    onclick="resyncZone(this, $('#titleEditZone').attr('data-zone'));"
+                                                    data-loading-text="Resyncing...">Resync</button>
                                                 <div id="divOptionsMenu" class="btn-group">
-                                                    <button type="button" class="btn btn-primary dropdown-toggle" style="padding: 2px 0px; width: 100px;" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                    <button type="button" class="btn btn-primary dropdown-toggle"
+                                                        style="padding: 2px 0px; width: 100px;" data-toggle="dropdown"
+                                                        aria-haspopup="true" aria-expanded="false">
                                                         Options <span class="caret"></span>
                                                     </button>
                                                     <ul class="dropdown-menu">
-                                                        <li id="lnkImportZone"><a href="#" onclick="showImportZoneModal($('#titleEditZone').attr('data-zone')); return false;">Import Zone</a></li>
-                                                        <li id="lnkExportZone"><a href="#" onclick="exportZone($('#titleEditZone').attr('data-zone')); return false;">Export Zone</a></li>
-                                                        <li id="lnkZoneConvert"><a href="#" onclick="showConvertZoneModal($('#titleEditZone').attr('data-zone'), $('#titleEditZone').attr('data-zone-type')); return false;">Convert Zone</a></li>
-                                                        <li id="lnkCloneZone"><a href="#" onclick="showCloneZoneModal($('#titleEditZone').attr('data-zone')); return false;">Clone Zone</a></li>
-                                                        <li id="lnkZoneOptions"><a href="#" onclick="$('#btnSaveZoneOptions').attr('data-zones-row-id', null); showZoneOptionsModal($('#titleEditZone').attr('data-zone')); return false;">Zone Options</a></li>
+                                                        <li id="lnkImportZone"><a href="#"
+                                                                onclick="showImportZoneModal($('#titleEditZone').attr('data-zone')); return false;">Import
+                                                                Zone</a></li>
+                                                        <li id="lnkExportZone"><a href="#"
+                                                                onclick="exportZone($('#titleEditZone').attr('data-zone')); return false;">Export
+                                                                Zone</a></li>
+                                                        <li id="lnkZoneConvert"><a href="#"
+                                                                onclick="showConvertZoneModal($('#titleEditZone').attr('data-zone'), $('#titleEditZone').attr('data-zone-type')); return false;">Convert
+                                                                Zone</a></li>
+                                                        <li id="lnkCloneZone"><a href="#"
+                                                                onclick="showCloneZoneModal($('#titleEditZone').attr('data-zone')); return false;">Clone
+                                                                Zone</a></li>
+                                                        <li id="lnkZoneOptions"><a href="#"
+                                                                onclick="$('#btnSaveZoneOptions').attr('data-zones-row-id', null); showZoneOptionsModal($('#titleEditZone').attr('data-zone')); return false;">Zone
+                                                                Options</a></li>
                                                     </ul>
                                                 </div>
-                                                <button id="btnZonePermissions" type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showZonePermissionsModal($('#titleEditZone').attr('data-zone'));">Permissions</button>
+                                                <button id="btnZonePermissions" type="button" class="btn btn-primary"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    onclick="showZonePermissionsModal($('#titleEditZone').attr('data-zone'));">Permissions</button>
                                                 <div id="divZoneDnssecOptions" class="btn-group">
-                                                    <button type="button" class="btn btn-primary dropdown-toggle" style="padding: 2px 0px; width: 100px;" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                    <button type="button" class="btn btn-primary dropdown-toggle"
+                                                        style="padding: 2px 0px; width: 100px;" data-toggle="dropdown"
+                                                        aria-haspopup="true" aria-expanded="false">
                                                         DNSSEC <span class="caret"></span>
                                                     </button>
                                                     <ul class="dropdown-menu">
-                                                        <li id="lnkZoneDnssecSignZone"><a href="#" onclick="showSignZoneModal($('#titleEditZone').attr('data-zone')); return false;">Sign Zone</a></li>
-                                                        <li id="lnkZoneDnssecHideRecords"><a href="#" onclick="toggleHideDnssecRecords(true); return false;">Hide DNSSEC Records</a></li>
-                                                        <li id="lnkZoneDnssecShowRecords"><a href="#" onclick="toggleHideDnssecRecords(false); return false;">Show DNSSEC Records</a></li>
-                                                        <li id="lnkZoneDnssecViewDsRecords"><a href="#" onclick="showViewDsModal($('#titleEditZone').attr('data-zone')); return false;">View DS Info</a></li>
-                                                        <li id="lnkZoneDnssecProperties"><a href="#" onclick="showDnssecPropertiesModal($('#titleEditZone').attr('data-zone')); return false;">Properties</a></li>
-                                                        <li id="lnkZoneDnssecUnsignZone"><a href="#" onclick="showUnsignZoneModal($('#titleEditZone').attr('data-zone')); return false;">Unsign Zone</a></li>
+                                                        <li id="lnkZoneDnssecSignZone"><a href="#"
+                                                                onclick="showSignZoneModal($('#titleEditZone').attr('data-zone')); return false;">Sign
+                                                                Zone</a></li>
+                                                        <li id="lnkZoneDnssecHideRecords"><a href="#"
+                                                                onclick="toggleHideDnssecRecords(true); return false;">Hide
+                                                                DNSSEC Records</a></li>
+                                                        <li id="lnkZoneDnssecShowRecords"><a href="#"
+                                                                onclick="toggleHideDnssecRecords(false); return false;">Show
+                                                                DNSSEC Records</a></li>
+                                                        <li id="lnkZoneDnssecViewDsRecords"><a href="#"
+                                                                onclick="showViewDsModal($('#titleEditZone').attr('data-zone')); return false;">View
+                                                                DS Info</a></li>
+                                                        <li id="lnkZoneDnssecProperties"><a href="#"
+                                                                onclick="showDnssecPropertiesModal($('#titleEditZone').attr('data-zone')); return false;">Properties</a>
+                                                        </li>
+                                                        <li id="lnkZoneDnssecUnsignZone"><a href="#"
+                                                                onclick="showUnsignZoneModal($('#titleEditZone').attr('data-zone')); return false;">Unsign
+                                                                Zone</a></li>
                                                     </ul>
                                                 </div>
                                             </div>
                                             <div style="clear: both;"></div>
                                         </div>
 
-                                        <div class="form-inline well" style="padding: 10px 10px 0 10px;margin-bottom: 10px;">
+                                        <div class="form-inline well"
+                                            style="padding: 10px 10px 0 10px;margin-bottom: 10px;">
                                             <form>
                                                 <div class="pull-left">
                                                     <div class="form-group">
                                                         <label for="txtEditZoneFilterName">Name</label>
-                                                        <input id="txtEditZoneFilterName" class="form-control" style="width: 300px;" type="text" placeholder="abc or a* or *b* or a?c" />
+                                                        <input id="txtEditZoneFilterName" class="form-control"
+                                                            style="width: 300px;" type="text"
+                                                            placeholder="abc or a* or *b* or a?c" />
                                                     </div>
                                                     <div class="form-group">
                                                         <label for="txtEditZoneFilterType">Type</label>
-                                                        <input id="txtEditZoneFilterType" class="form-control" style="width: 130px;" type="text" />
+                                                        <input id="txtEditZoneFilterType" class="form-control"
+                                                            style="width: 130px;" type="text" />
                                                     </div>
                                                 </div>
 
                                                 <div class="pull-right">
                                                     <div class="form-group">
                                                         <label for="txtEditZonePageNumber">Page Number</label>
-                                                        <input id="txtEditZonePageNumber" class="form-control" style="width: 100px;" type="number" />
+                                                        <input id="txtEditZonePageNumber" class="form-control"
+                                                            style="width: 100px;" type="number" />
                                                     </div>
                                                     <div class="form-group">
                                                         <label for="optEditZoneRecordsPerPage">Records Per Page</label>
@@ -577,7 +751,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <option>500</option>
                                                         </select>
                                                     </div>
-                                                    <button type="submit" class="btn btn-primary form-group" style="margin-right: 0px;" onclick="showEditZonePage(); return false;">Go</button>
+                                                    <button type="submit" class="btn btn-primary form-group"
+                                                        style="margin-right: 0px;"
+                                                        onclick="showEditZonePage(); return false;">Go</button>
                                                 </div>
 
                                                 <div class="clearfix"></div>
@@ -590,10 +766,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                             </div>
                                             <div class="pull-right">
                                                 <nav aria-label="Page navigation">
-                                                    <ul id="tableEditZoneTopPagination" class="pagination" style="margin: 0;">
-                                                        <li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
+                                                    <ul id="tableEditZoneTopPagination" class="pagination"
+                                                        style="margin: 0;">
+                                                        <li><a href="#" aria-label="Previous"><span
+                                                                    aria-hidden="true">&laquo;</span></a></li>
                                                         <li><a href="#">1</a></li>
-                                                        <li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+                                                        <li><a href="#" aria-label="Next"><span
+                                                                    aria-hidden="true">&raquo;</span></a></li>
                                                     </ul>
                                                 </nav>
                                             </div>
@@ -603,11 +782,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <table id="tableEditZone" class="table table-hover">
                                             <thead>
                                                 <tr>
-                                                    <th><a href="#" onclick="sortTable('tableEditZoneBody', 0); return false;">#</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableEditZoneBody', 1); return false;">Name</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableEditZoneBody', 2); return false;">Type</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableEditZoneBody', 3); return false;">TTL</a></th>
-                                                    <th><a href="#" onclick="sortTable('tableEditZoneBody', 4); return false;">Data</a></th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableEditZoneBody', 0); return false;">#</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableEditZoneBody', 1); return false;">Name</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableEditZoneBody', 2); return false;">Type</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableEditZoneBody', 3); return false;">TTL</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tableEditZoneBody', 4); return false;">Data</a>
+                                                    </th>
                                                     <th></th>
                                                 </tr>
                                             </thead>
@@ -622,10 +811,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             </div>
                                                             <div class="pull-right">
                                                                 <nav aria-label="Page navigation">
-                                                                    <ul id="tableEditZoneFooterPagination" class="pagination" style="margin: 0;">
-                                                                        <li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
+                                                                    <ul id="tableEditZoneFooterPagination"
+                                                                        class="pagination" style="margin: 0;">
+                                                                        <li><a href="#" aria-label="Previous"><span
+                                                                                    aria-hidden="true">&laquo;</span></a>
+                                                                        </li>
                                                                         <li><a href="#">1</a></li>
-                                                                        <li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+                                                                        <li><a href="#" aria-label="Next"><span
+                                                                                    aria-hidden="true">&raquo;</span></a>
+                                                                        </li>
                                                                     </ul>
                                                                 </nav>
                                                             </div>
@@ -638,15 +832,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     </div>
                                 </div>
 
-                                <div id="mainPanelTabPaneCachedZones" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
+                                <div id="mainPanelTabPaneCachedZones" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
 
                                     <div class="well well-sm zone-list-pane">
                                         <form class="form-inline">
                                             <div class="form-group" style="width: 100%">
-                                                <input type="text" class="form-control" style="width: inherit;" id="txtCacheZone" placeholder="example.com">
+                                                <input type="text" class="form-control" style="width: inherit;"
+                                                    id="txtCacheZone" placeholder="example.com">
                                             </div>
                                             <div class="form-group">
-                                                <button id="btnBrowseCacheZone" type="submit" class="btn btn-primary" data-loading-text="Browse" onclick="refreshCachedZonesList($('#txtCacheZone').val()); return false;">Browse</button>
+                                                <button id="btnBrowseCacheZone" type="submit" class="btn btn-primary"
+                                                    data-loading-text="Browse"
+                                                    onclick="refreshCachedZonesList($('#txtCacheZone').val()); return false;">Browse</button>
                                             </div>
                                         </form>
 
@@ -657,11 +855,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     <div id="divCachedZoneViewer" class="zone-viewer-pane">
                                         <div class="panel panel-default">
                                             <div class="panel-heading" style="height: 36px; padding: 4px 6px;">
-                                                <div id="txtCachedZoneViewerTitle" class="pull-left" style="padding: 4px;">technitium.com</div>
+                                                <div id="txtCachedZoneViewerTitle" class="pull-left"
+                                                    style="padding: 4px;">technitium.com</div>
                                                 <div class="form-inline pull-right">
-                                                    <button id="btnDeleteCachedZone" type="button" class="btn btn-warning" data-loading-text="Delete" onclick="deleteCachedZone();" style="font-size: 12px; padding: 4px 6px; width: 50px;">Delete</button>
-                                                    <button type="button" class="btn btn-danger" data-loading-text="Delete" onclick="flushDnsCache(this, $('#optCachedZonesClusterNode').val());" style="font-size: 12px; padding: 4px 6px; width: 50px;">Flush</button>
-                                                    <select id="optCachedZonesClusterNode" class="form-control cluster-node-dropdown" style="margin-left: 2px;" onchange="refreshCachedZonesList();"></select>
+                                                    <button id="btnDeleteCachedZone" type="button"
+                                                        class="btn btn-warning" data-loading-text="Delete"
+                                                        onclick="deleteCachedZone();"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Delete</button>
+                                                    <button type="button" class="btn btn-danger"
+                                                        data-loading-text="Delete"
+                                                        onclick="flushDnsCache(this, $('#optCachedZonesClusterNode').val());"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Flush</button>
+                                                    <select id="optCachedZonesClusterNode"
+                                                        class="form-control cluster-node-dropdown"
+                                                        style="margin-left: 2px;"
+                                                        onchange="refreshCachedZonesList();"></select>
                                                 </div>
                                                 <div class="clearfix"></div>
                                             </div>
@@ -676,16 +884,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                 </div>
 
-                                <div id="mainPanelTabPaneAllowedZones" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
+                                <div id="mainPanelTabPaneAllowedZones" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
 
                                     <div class="well well-sm zone-list-pane">
                                         <form class="form-inline">
                                             <div class="form-group" style="width: 100%">
-                                                <input type="text" class="form-control" style="width: inherit;" id="txtAllowZone" placeholder="example.com">
+                                                <input type="text" class="form-control" style="width: inherit;"
+                                                    id="txtAllowZone" placeholder="example.com">
                                             </div>
                                             <div class="form-group">
-                                                <button id="btnAllowZone" type="submit" class="btn btn-primary" data-loading-text="Allow" onclick="allowZone(); return false;">Allow</button>
-                                                <button id="btnBrowseAllowZone" type="button" class="btn btn-default" data-loading-text="Browse" onclick="refreshAllowedZonesList($('#txtAllowZone').val());">Browse</button>
+                                                <button id="btnAllowZone" type="submit" class="btn btn-primary"
+                                                    data-loading-text="Allow"
+                                                    onclick="allowZone(); return false;">Allow</button>
+                                                <button id="btnBrowseAllowZone" type="button" class="btn btn-default"
+                                                    data-loading-text="Browse"
+                                                    onclick="refreshAllowedZonesList($('#txtAllowZone').val());">Browse</button>
                                             </div>
                                         </form>
 
@@ -696,12 +910,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     <div id="divAllowedZoneViewer" class="zone-viewer-pane">
                                         <div class="panel panel-default">
                                             <div class="panel-heading" style="height: 36px; padding: 4px 6px;">
-                                                <div id="txtAllowedZoneViewerTitle" class="pull-left" style="padding: 4px;">technitium.com</div>
+                                                <div id="txtAllowedZoneViewerTitle" class="pull-left"
+                                                    style="padding: 4px;">technitium.com</div>
                                                 <div class="form-inline pull-right">
-                                                    <button type="button" class="btn btn-default" data-loading-text="Import" onclick="resetImportAllowedZonesModal();" data-toggle="modal" data-target="#modalImportAllowedZones" style="font-size: 12px; padding: 4px 6px; width: 50px;">Import</button>
-                                                    <button type="button" class="btn btn-default" data-loading-text="Export" onclick="exportAllowedZones();" style="font-size: 12px; padding: 4px 6px; width: 50px;">Export</button>
-                                                    <button id="btnDeleteAllowedZone" type="button" class="btn btn-warning" data-loading-text="Delete" onclick="deleteAllowedZone();" style="font-size: 12px; padding: 4px 6px; width: 50px;">Delete</button>
-                                                    <button id="btnFlushAllowedZone" type="button" class="btn btn-danger" data-loading-text="Flush" onclick="flushAllowedZone();" style="font-size: 12px; padding: 4px 6px; width: 50px;">Flush</button>
+                                                    <button type="button" class="btn btn-default"
+                                                        data-loading-text="Import"
+                                                        onclick="resetImportAllowedZonesModal();" data-toggle="modal"
+                                                        data-target="#modalImportAllowedZones"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Import</button>
+                                                    <button type="button" class="btn btn-default"
+                                                        data-loading-text="Export" onclick="exportAllowedZones();"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Export</button>
+                                                    <button id="btnDeleteAllowedZone" type="button"
+                                                        class="btn btn-warning" data-loading-text="Delete"
+                                                        onclick="deleteAllowedZone();"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Delete</button>
+                                                    <button id="btnFlushAllowedZone" type="button"
+                                                        class="btn btn-danger" data-loading-text="Flush"
+                                                        onclick="flushAllowedZone();"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Flush</button>
                                                 </div>
                                                 <div class="clearfix"></div>
                                             </div>
@@ -716,16 +943,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                 </div>
 
-                                <div id="mainPanelTabPaneBlockedZones" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
+                                <div id="mainPanelTabPaneBlockedZones" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
 
                                     <div class="well well-sm zone-list-pane">
                                         <form class="form-inline">
                                             <div class="form-group" style="width: 100%">
-                                                <input type="text" class="form-control" style="width: inherit;" id="txtBlockZone" placeholder="example.com">
+                                                <input type="text" class="form-control" style="width: inherit;"
+                                                    id="txtBlockZone" placeholder="example.com">
                                             </div>
                                             <div class="form-group">
-                                                <button id="btnBlockZone" type="submit" class="btn btn-primary" data-loading-text="Block" onclick="blockZone(); return false;">Block</button>
-                                                <button id="btnBrowseBlockZone" type="button" class="btn btn-default" data-loading-text="Browse" onclick="refreshBlockedZonesList($('#txtBlockZone').val());">Browse</button>
+                                                <button id="btnBlockZone" type="submit" class="btn btn-primary"
+                                                    data-loading-text="Block"
+                                                    onclick="blockZone(); return false;">Block</button>
+                                                <button id="btnBrowseBlockZone" type="button" class="btn btn-default"
+                                                    data-loading-text="Browse"
+                                                    onclick="refreshBlockedZonesList($('#txtBlockZone').val());">Browse</button>
                                             </div>
                                         </form>
 
@@ -736,12 +969,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     <div id="divBlockedZoneViewer" class="zone-viewer-pane">
                                         <div class="panel panel-default">
                                             <div class="panel-heading" style="height: 36px; padding: 4px 6px;">
-                                                <div id="txtBlockedZoneViewerTitle" class="pull-left" style="padding: 4px;">technitium.com</div>
+                                                <div id="txtBlockedZoneViewerTitle" class="pull-left"
+                                                    style="padding: 4px;">technitium.com</div>
                                                 <div class="form-inline pull-right">
-                                                    <button id="btnImportBlockedZone" type="button" class="btn btn-default" data-loading-text="Import" onclick="resetImportBlockedZonesModal();" data-toggle="modal" data-target="#modalImportBlockedZones" style="font-size: 12px; padding: 4px 6px; width: 50px;">Import</button>
-                                                    <button id="btnExportBlockedZone" type="button" class="btn btn-default" data-loading-text="Export" onclick="exportBlockedZones();" style="font-size: 12px; padding: 4px 6px; width: 50px;">Export</button>
-                                                    <button id="btnDeleteBlockedZone" type="button" class="btn btn-warning" data-loading-text="Delete" onclick="deleteBlockedZone();" style="font-size: 12px; padding: 4px 6px; width: 50px;">Delete</button>
-                                                    <button id="btnFlushBlockedZone" type="button" class="btn btn-danger" data-loading-text="Flush" onclick="flushBlockedZone();" style="font-size: 12px; padding: 4px 6px; width: 50px;">Flush</button>
+                                                    <button id="btnImportBlockedZone" type="button"
+                                                        class="btn btn-default" data-loading-text="Import"
+                                                        onclick="resetImportBlockedZonesModal();" data-toggle="modal"
+                                                        data-target="#modalImportBlockedZones"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Import</button>
+                                                    <button id="btnExportBlockedZone" type="button"
+                                                        class="btn btn-default" data-loading-text="Export"
+                                                        onclick="exportBlockedZones();"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Export</button>
+                                                    <button id="btnDeleteBlockedZone" type="button"
+                                                        class="btn btn-warning" data-loading-text="Delete"
+                                                        onclick="deleteBlockedZone();"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Delete</button>
+                                                    <button id="btnFlushBlockedZone" type="button"
+                                                        class="btn btn-danger" data-loading-text="Flush"
+                                                        onclick="flushBlockedZone();"
+                                                        style="font-size: 12px; padding: 4px 6px; width: 50px;">Flush</button>
                                                 </div>
                                                 <div class="clearfix"></div>
                                             </div>
@@ -756,14 +1003,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                 </div>
 
-                                <div id="mainPanelTabPaneApps" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
-                                    <div id="divViewAppsLoader" style=" display: none; margin-top: 10px; height: 400px;"></div>
+                                <div id="mainPanelTabPaneApps" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
+                                    <div id="divViewAppsLoader"
+                                        style=" display: none; margin-top: 10px; height: 400px;"></div>
 
                                     <div id="divViewApps">
                                         <div class="form-inline">
                                             <div style="float: right;">
-                                                <button type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showStoreAppsModal();">App Store</button>
-                                                <button type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showInstallAppModal();">Install</button>
+                                                <button type="button" class="btn btn-primary"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    onclick="showStoreAppsModal();">App Store</button>
+                                                <button type="button" class="btn btn-primary"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    onclick="showInstallAppModal();">Install</button>
                                             </div>
                                             <div style="clear: both;"></div>
                                         </div>
@@ -771,41 +1024,54 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <table id="tableApps" class="table table-hover">
                                             <thead>
                                                 <tr>
-                                                    <th style="min-width: 100px;"><a href="#" onclick="sortTable('tableAppsBody', 0); return false;">Installed Apps</a></th>
+                                                    <th style="min-width: 100px;"><a href="#"
+                                                            onclick="sortTable('tableAppsBody', 0); return false;">Installed
+                                                            Apps</a></th>
                                                     <th style="width: 96px;"></th>
                                                 </tr>
                                             </thead>
                                             <tbody id="tableAppsBody">
                                             </tbody>
                                             <tfoot id="tableAppsFooter">
-                                                <tr><td colspan="3"><b>Total Apps: 0</b></td></tr>
+                                                <tr>
+                                                    <td colspan="3"><b>Total Apps: 0</b></td>
+                                                </tr>
                                             </tfoot>
                                         </table>
                                     </div>
                                 </div>
 
-                                <div id="mainPanelTabPaneDnsClient" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
+                                <div id="mainPanelTabPaneDnsClient" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
 
                                     <form class="form-inline well" style="padding-bottom: 6px; margin-bottom: 15px;">
                                         <div>
                                             <div class="form-group">
                                                 <label for="txtDnsClientNameServer">Server</label>
                                                 <div class="input-group dropdown">
-                                                    <input type="text" class="form-control dropdown-toggle" style="min-width: 270px; border-right: 0px;" id="txtDnsClientNameServer" value="This Server {this-server}">
-                                                    <ul id="optDnsClientNameServers" class="dropdown-menu" style="max-height: 500px; overflow-y: scroll;">
+                                                    <input type="text" class="form-control dropdown-toggle"
+                                                        style="min-width: 270px; border-right: 0px;"
+                                                        id="txtDnsClientNameServer" value="This Server {this-server}">
+                                                    <ul id="optDnsClientNameServers" class="dropdown-menu"
+                                                        style="max-height: 500px; overflow-y: scroll;">
                                                     </ul>
-                                                    <span role="button" class="input-group-addon dropdown-toggle" style="background-color: white;" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="caret"></span></span>
+                                                    <span role="button" class="input-group-addon dropdown-toggle"
+                                                        style="background-color: white;" data-toggle="dropdown"
+                                                        aria-haspopup="true" aria-expanded="false"><span
+                                                            class="caret"></span></span>
                                                 </div>
                                             </div>
 
                                             <div class="form-group">
                                                 <label for="txtDnsClientDomain">Domain</label>
-                                                <input type="text" class="form-control" style="min-width: 295px;" id="txtDnsClientDomain" placeholder="example.com">
+                                                <input type="text" class="form-control" style="min-width: 295px;"
+                                                    id="txtDnsClientDomain" placeholder="example.com">
                                             </div>
 
                                             <div class="form-group">
                                                 <label for="optDnsClientType">Type</label>
-                                                <select class="form-control" id="optDnsClientType" style="padding-left: 6px; padding-right: 0px;">
+                                                <select class="form-control" id="optDnsClientType"
+                                                    style="padding-left: 6px; padding-right: 0px;">
                                                     <option>A</option>
                                                     <option>NS</option>
                                                     <option>CNAME</option>
@@ -839,7 +1105,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                             <div class="form-group">
                                                 <label for="optDnsClientProtocol">DNS-over-</label>
-                                                <select class="form-control" id="optDnsClientProtocol" style="padding-left: 6px; padding-right: 0px;">
+                                                <select class="form-control" id="optDnsClientProtocol"
+                                                    style="padding-left: 6px; padding-right: 0px;">
                                                     <option>UDP</option>
                                                     <option>TCP</option>
                                                     <option>TLS</option>
@@ -850,40 +1117,56 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                             <div class="form-group">
                                                 <label for="txtDnsClientEDnsClientSubnet">EDNS Client Subnet</label>
-                                                <input type="text" class="form-control" style="min-width: 240px;" id="txtDnsClientEDnsClientSubnet">
+                                                <input type="text" class="form-control" style="min-width: 240px;"
+                                                    id="txtDnsClientEDnsClientSubnet">
                                             </div>
 
                                             <div class="form-group">
                                                 <div class="checkbox">
                                                     <label>
-                                                        <input type="checkbox" id="chkDnsClientDnssecValidation"> Enable DNSSEC Validation
+                                                        <input type="checkbox" id="chkDnsClientDnssecValidation"> Enable
+                                                        DNSSEC Validation
                                                     </label>
                                                 </div>
                                             </div>
                                         </div>
                                         <div>
                                             <div class="form-group">
-                                                <button type="submit" class="btn btn-primary" id="btnDnsClientResolve" style="padding: 2px 0px; width: 100px;" data-loading-text="Resolving..." onclick="resolveQuery(); return false;">Resolve</button>
-                                                <button type="button" class="btn btn-warning" id="btnDnsClientImport" style="padding: 2px 0px; width: 100px;" data-loading-text="Importing..." onclick="resolveQuery(true);">Import</button>
-                                                <select id="optDnsClientClusterNode" class="form-control cluster-node-dropdown"></select>
+                                                <button type="submit" class="btn btn-primary" id="btnDnsClientResolve"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    data-loading-text="Resolving..."
+                                                    onclick="resolveQuery(); return false;">Resolve</button>
+                                                <button type="button" class="btn btn-warning" id="btnDnsClientImport"
+                                                    style="padding: 2px 0px; width: 100px;"
+                                                    data-loading-text="Importing..."
+                                                    onclick="resolveQuery(true);">Import</button>
+                                                <select id="optDnsClientClusterNode"
+                                                    class="form-control cluster-node-dropdown"></select>
                                             </div>
                                         </div>
                                     </form>
 
                                     <div id="divDnsClientLoader" style="margin-top: 15px; height: 300px;"></div>
 
-                                    <div id="divDnsClientOutputAccordion" style="margin-bottom: 0px; display: none;" class="panel-group" role="tablist" aria-multiselectable="true">
+                                    <div id="divDnsClientOutputAccordion" style="margin-bottom: 0px; display: none;"
+                                        class="panel-group" role="tablist" aria-multiselectable="true">
                                         <div class="panel panel-default">
                                             <div class="panel-heading" role="tab" id="divDnsClientFinalResponseHeading">
                                                 <h4 class="panel-title">
-                                                    <a role="button" data-toggle="collapse" data-parent="#divDnsClientOutputAccordion" href="#divDnsClientFinalResponseCollapse" aria-expanded="true" aria-controls="divDnsClientFinalResponseCollapse">
+                                                    <a role="button" data-toggle="collapse"
+                                                        data-parent="#divDnsClientOutputAccordion"
+                                                        href="#divDnsClientFinalResponseCollapse" aria-expanded="true"
+                                                        aria-controls="divDnsClientFinalResponseCollapse">
                                                         Response
                                                     </a>
                                                 </h4>
                                             </div>
-                                            <div id="divDnsClientFinalResponseCollapse" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="divDnsClientFinalResponseHeading">
+                                            <div id="divDnsClientFinalResponseCollapse"
+                                                class="panel-collapse collapse in" role="tabpanel"
+                                                aria-labelledby="divDnsClientFinalResponseHeading">
                                                 <div class="panel-body">
-                                                    <pre id="preDnsClientFinalResponse" style="margin-bottom: 0px;"></pre>
+                                                    <pre id="preDnsClientFinalResponse"
+                                                        style="margin-bottom: 0px;"></pre>
                                                 </div>
                                             </div>
                                         </div>
@@ -891,12 +1174,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <div id="divDnsClientRawResponsePanel" class="panel panel-default">
                                             <div class="panel-heading" role="tab" id="divDnsClientRawResponsesHeading">
                                                 <h4 class="panel-title">
-                                                    <a class="collapsed" role="button" data-toggle="collapse" data-parent="#divDnsClientOutputAccordion" href="#divDnsClientRawResponsesCollapse" aria-expanded="false" aria-controls="divDnsClientRawResponsesCollapse">
-                                                        Raw Responses (<span id="spanDnsClientRawResponsesCount"></span>)
+                                                    <a class="collapsed" role="button" data-toggle="collapse"
+                                                        data-parent="#divDnsClientOutputAccordion"
+                                                        href="#divDnsClientRawResponsesCollapse" aria-expanded="false"
+                                                        aria-controls="divDnsClientRawResponsesCollapse">
+                                                        Raw Responses (<span
+                                                            id="spanDnsClientRawResponsesCount"></span>)
                                                     </a>
                                                 </h4>
                                             </div>
-                                            <div id="divDnsClientRawResponsesCollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="divDnsClientRawResponsesHeading">
+                                            <div id="divDnsClientRawResponsesCollapse" class="panel-collapse collapse"
+                                                role="tabpanel" aria-labelledby="divDnsClientRawResponsesHeading">
                                                 <ul id="ulDnsClientRawResponsesList" class="list-group">
                                                 </ul>
                                             </div>
@@ -912,96 +1200,202 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <form style="margin-top: 10px;" onsubmit="return false;">
 
                                             <ul class="nav nav-tabs" role="tablist">
-                                                <li id="settingsTabListGeneral" role="presentation" class="active"><a href="#settingsTabPaneGeneral" aria-controls="settingsTabPaneGeneral" role="tab" data-toggle="tab">General</a></li>
-                                                <li id="settingsTabListWebService" role="presentation"><a href="#settingsTabPaneWebService" aria-controls="settingsTabPaneWebService" role="tab" data-toggle="tab">Web Service</a></li>
-                                                <li id="settingsTabListOptionalProtocols" role="presentation"><a href="#settingsTabPaneOptionalProtocols" aria-controls="settingsTabPaneOptionalProtocols" role="tab" data-toggle="tab">Optional Protocols</a></li>
-                                                <li id="settingsTabListTsig" role="presentation"><a href="#settingsTabPaneTsig" aria-controls="settingsTabPaneTsig" role="tab" data-toggle="tab">TSIG</a></li>
-                                                <li id="settingsTabListRecursion" role="presentation"><a href="#settingsTabPaneRecursion" aria-controls="settingsTabPaneRecursion" role="tab" data-toggle="tab">Recursion</a></li>
-                                                <li id="settingsTabListCache" role="presentation"><a href="#settingsTabPaneCache" aria-controls="settingsTabPaneCache" role="tab" data-toggle="tab">Cache</a></li>
-                                                <li id="settingsTabListBlocking" role="presentation"><a href="#settingsTabPaneBlocking" aria-controls="settingsTabPaneBlocking" role="tab" data-toggle="tab">Blocking</a></li>
-                                                <li id="settingsTabListProxyForwarders" role="presentation"><a href="#settingsTabPaneProxyForwarders" aria-controls="settingsTabPaneProxyForwarders" role="tab" data-toggle="tab">Proxy &amp; Forwarders</a></li>
-                                                <li id="settingsTabListLogging" role="presentation"><a href="#settingsTabPaneLogging" aria-controls="settingsTabPaneLogging" role="tab" data-toggle="tab">Logging</a></li>
+                                                <li id="settingsTabListGeneral" role="presentation" class="active"><a
+                                                        href="#settingsTabPaneGeneral"
+                                                        aria-controls="settingsTabPaneGeneral" role="tab"
+                                                        data-toggle="tab">General</a></li>
+                                                <li id="settingsTabListWebService" role="presentation"><a
+                                                        href="#settingsTabPaneWebService"
+                                                        aria-controls="settingsTabPaneWebService" role="tab"
+                                                        data-toggle="tab">Web Service</a></li>
+                                                <li id="settingsTabListOptionalProtocols" role="presentation"><a
+                                                        href="#settingsTabPaneOptionalProtocols"
+                                                        aria-controls="settingsTabPaneOptionalProtocols" role="tab"
+                                                        data-toggle="tab">Optional Protocols</a></li>
+                                                <li id="settingsTabListTsig" role="presentation"><a
+                                                        href="#settingsTabPaneTsig" aria-controls="settingsTabPaneTsig"
+                                                        role="tab" data-toggle="tab">TSIG</a></li>
+                                                <li id="settingsTabListRecursion" role="presentation"><a
+                                                        href="#settingsTabPaneRecursion"
+                                                        aria-controls="settingsTabPaneRecursion" role="tab"
+                                                        data-toggle="tab">Recursion</a></li>
+                                                <li id="settingsTabListCache" role="presentation"><a
+                                                        href="#settingsTabPaneCache"
+                                                        aria-controls="settingsTabPaneCache" role="tab"
+                                                        data-toggle="tab">Cache</a></li>
+                                                <li id="settingsTabListBlocking" role="presentation"><a
+                                                        href="#settingsTabPaneBlocking"
+                                                        aria-controls="settingsTabPaneBlocking" role="tab"
+                                                        data-toggle="tab">Blocking</a></li>
+                                                <li id="settingsTabListProxyForwarders" role="presentation"><a
+                                                        href="#settingsTabPaneProxyForwarders"
+                                                        aria-controls="settingsTabPaneProxyForwarders" role="tab"
+                                                        data-toggle="tab">Proxy &amp; Forwarders</a></li>
+                                                <li id="settingsTabListLogging" role="presentation"><a
+                                                        href="#settingsTabPaneLogging"
+                                                        aria-controls="settingsTabPaneLogging" role="tab"
+                                                        data-toggle="tab">Logging</a></li>
 
                                                 <li class="pull-right">
-                                                    <select id="optSettingsClusterNode" class="form-control pull-right cluster-node-dropdown" style="margin-left: 0px;" onchange="refreshDnsSettings();"></select>
+                                                    <select id="optSettingsClusterNode"
+                                                        class="form-control pull-right cluster-node-dropdown"
+                                                        style="margin-left: 0px;"
+                                                        onchange="refreshDnsSettings();"></select>
                                                 </li>
                                             </ul>
 
                                             <div class="tab-content" style="min-height: 350px; padding-top: 15px;">
-                                                <div id="settingsTabPaneGeneral" role="tabpanel" class="tab-pane active">
-                                                    <div id="divSettingsGeneralLocalParameters" class="well well-sm form-horizontal">
+                                                <div id="settingsTabPaneGeneral" role="tabpanel"
+                                                    class="tab-pane active">
+                                                    <div id="divSettingsGeneralLocalParameters"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDnsServerDomain" class="col-sm-3 control-label">DNS Server Domain</label>
+                                                            <label for="txtDnsServerDomain"
+                                                                class="col-sm-3 control-label">DNS Server Domain</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDnsServerDomain" placeholder="domain name" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDnsServerDomain" placeholder="domain name"
+                                                                    maxlength="255">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The primary fully qualified domain name used by this DNS Server to identify itself.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The primary fully qualified
+                                                                domain name used by this DNS Server to identify itself.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsServerLocalEndPoints" class="col-sm-3 control-label">DNS Server Local End Points</label>
+                                                            <label for="txtDnsServerLocalEndPoints"
+                                                                class="col-sm-3 control-label">DNS Server Local End
+                                                                Points</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtDnsServerLocalEndPoints" class="form-control" rows="3" spellcheck="false"></textarea>
+                                                                <textarea id="txtDnsServerLocalEndPoints"
+                                                                    class="form-control" rows="3"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Local end points are the network interface IP addresses and ports you want the DNS Server to listen for requests. The default values work for Windows but on Linux when you have multiple network adapters, you must explicitly specify the network adapter IP addresses here as the local end points.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Local end points are the
+                                                                network interface IP addresses and ports you want the
+                                                                DNS Server to listen for requests. The default values
+                                                                work for Windows but on Linux when you have multiple
+                                                                network adapters, you must explicitly specify the
+                                                                network adapter IP addresses here as the local end
+                                                                points.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsServerIPv4SourceAddresses" class="col-sm-3 control-label">DNS Server IPv4 Source Addresses</label>
+                                                            <label for="txtDnsServerIPv4SourceAddresses"
+                                                                class="col-sm-3 control-label">DNS Server IPv4 Source
+                                                                Addresses</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtDnsServerIPv4SourceAddresses" class="form-control" rows="3" spellcheck="false"></textarea>
+                                                                <textarea id="txtDnsServerIPv4SourceAddresses"
+                                                                    class="form-control" rows="3"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The IPv4 source addresses that the DNS server must use for making all outbound DNS requests when the server is connected to two or more networks. Network addresses are also accepted.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The IPv4 source addresses that
+                                                                the DNS server must use for making all outbound DNS
+                                                                requests when the server is connected to two or more
+                                                                networks. Network addresses are also accepted.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsServerIPv6SourceAddresses" class="col-sm-3 control-label">DNS Server IPv6 Source Addresses</label>
+                                                            <label for="txtDnsServerIPv6SourceAddresses"
+                                                                class="col-sm-3 control-label">DNS Server IPv6 Source
+                                                                Addresses</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtDnsServerIPv6SourceAddresses" class="form-control" rows="3" spellcheck="false"></textarea>
+                                                                <textarea id="txtDnsServerIPv6SourceAddresses"
+                                                                    class="form-control" rows="3"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The IPv6 source addresses that the DNS server must use for making all outbound DNS requests when the server is connected to two or more networks. Network addresses are also accepted. Note that this option will be used only when <code>Prefer IPv6</code> option is enabled.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The IPv6 source addresses that
+                                                                the DNS server must use for making all outbound DNS
+                                                                requests when the server is connected to two or more
+                                                                networks. Network addresses are also accepted. Note that
+                                                                this option will be used only when
+                                                                <code>Prefer IPv6</code> option is enabled.
+                                                            </div>
                                                         </div>
 
                                                         <div>
-                                                            <p>Note! The DNS Server local end point changes will be automatically applied and so you do not need to manually restart the main service.</p>
-                                                            <p>Note! The source adddresses configured above must be the IP addresses that are configured on the local system's network interface. When using source addresses option, its also necessary to ensure that the system has a default route or a specific route for the source address to be able to reach the destination network. When source addresses are not configured, the IP address of the interface with a default route will be used as the source address.</p>
+                                                            <p>Note! The DNS Server local end point changes will be
+                                                                automatically applied and so you do not need to manually
+                                                                restart the main service.</p>
+                                                            <p>Note! The source adddresses configured above must be the
+                                                                IP addresses that are configured on the local system's
+                                                                network interface. When using source addresses option,
+                                                                its also necessary to ensure that the system has a
+                                                                default route or a specific route for the source address
+                                                                to be able to reach the destination network. When source
+                                                                addresses are not configured, the IP address of the
+                                                                interface with a default route will be used as the
+                                                                source address.</p>
                                                         </div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralDefaultParameters" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralDefaultParameters"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDefaultRecordTtl" class="col-sm-3 control-label">Default Record TTL</label>
+                                                            <label for="txtDefaultRecordTtl"
+                                                                class="col-sm-3 control-label">Default Record
+                                                                TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDefaultRecordTtl" placeholder="TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDefaultRecordTtl" placeholder="TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (default 3600/1h)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The default TTL value to use if not specified when adding or updating records in a Zone.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The default TTL value to use
+                                                                if not specified when adding or updating records in a
+                                                                Zone.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDefaultNsRecordTtl" class="col-sm-3 control-label">Default NS Record TTL</label>
+                                                            <label for="txtDefaultNsRecordTtl"
+                                                                class="col-sm-3 control-label">Default NS Record
+                                                                TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDefaultNsRecordTtl" placeholder="TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDefaultNsRecordTtl" placeholder="TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (default 14400/4h)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The default TTL value to use if not specified when adding or updating NS records in a Primary Zone.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The default TTL value to use
+                                                                if not specified when adding or updating NS records in a
+                                                                Primary Zone.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDefaultSoaRecordTtl" class="col-sm-3 control-label">Default SOA Record TTL</label>
+                                                            <label for="txtDefaultSoaRecordTtl"
+                                                                class="col-sm-3 control-label">Default SOA Record
+                                                                TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDefaultSoaRecordTtl" placeholder="TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDefaultSoaRecordTtl" placeholder="TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (default 900/15m)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The default TTL value to use if not specified when adding or updating SOA records in a Primary Zone.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The default TTL value to use
+                                                                if not specified when adding or updating SOA records in
+                                                                a Primary Zone.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDefaultResponsiblePerson" class="col-sm-3 control-label">Default Responsible Person</label>
+                                                            <label for="txtDefaultResponsiblePerson"
+                                                                class="col-sm-3 control-label">Default Responsible
+                                                                Person</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDefaultResponsiblePerson" placeholder="email address" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDefaultResponsiblePerson"
+                                                                    placeholder="email address" maxlength="255">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The default SOA Responsible Person email address to use when adding a Primary Zone.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The default SOA Responsible
+                                                                Person email address to use when adding a Primary Zone.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
@@ -1009,318 +1403,579 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkUseSoaSerialDateScheme" type="checkbox"> Use SOA Serial Date Scheme
+                                                                        <input id="chkUseSoaSerialDateScheme"
+                                                                            type="checkbox"> Use SOA Serial Date Scheme
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">The default SOA Serial option to use if not specified when adding a Primary Zone.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">The
+                                                                    default SOA Serial option to use if not specified
+                                                                    when adding a Primary Zone.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtMinSoaRefresh" class="col-sm-3 control-label">Minimum SOA Refresh</label>
+                                                            <label for="txtMinSoaRefresh"
+                                                                class="col-sm-3 control-label">Minimum SOA
+                                                                Refresh</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtMinSoaRefresh" placeholder="TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtMinSoaRefresh" placeholder="TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (default 300/5m)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The minimum Refresh interval to be used by Secondary, Stub, Secondary Forwarder, and Secondary Catalog zones. This minimum value will be used if a zone's SOA Refresh value is less than it.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The minimum Refresh interval
+                                                                to be used by Secondary, Stub, Secondary Forwarder, and
+                                                                Secondary Catalog zones. This minimum value will be used
+                                                                if a zone's SOA Refresh value is less than it.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtMinSoaRetry" class="col-sm-3 control-label">Minimum SOA Retry</label>
+                                                            <label for="txtMinSoaRetry"
+                                                                class="col-sm-3 control-label">Minimum SOA Retry</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtMinSoaRetry" placeholder="TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtMinSoaRetry" placeholder="TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (default 300/5m)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The minimum Retry interval to be used by Secondary, Stub, Secondary Forwarder, and Secondary Catalog zones zones. This minimum value will be used if a zone's SOA Retry value is less than it.</div>
-                                                        </div>
-
-                                                        <div class="form-group">
-                                                            <label for="txtZoneTransferAllowedNetworks" class="col-sm-3 control-label">Zone Transfer Allowed Networks</label>
-                                                            <div class="col-sm-6">
-                                                                <textarea id="txtZoneTransferAllowedNetworks" class="form-control" rows="3" spellcheck="false"></textarea>
-                                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses one below another that are allowed to perform zone transfer for all zones without any TSIG authentication.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The minimum Retry interval to
+                                                                be used by Secondary, Stub, Secondary Forwarder, and
+                                                                Secondary Catalog zones zones. This minimum value will
+                                                                be used if a zone's SOA Retry value is less than it.
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtNotifyAllowedNetworks" class="col-sm-3 control-label">Notify Allowed Networks</label>
+                                                            <label for="txtZoneTransferAllowedNetworks"
+                                                                class="col-sm-3 control-label">Zone Transfer Allowed
+                                                                Networks</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtNotifyAllowedNetworks" class="form-control" rows="3" spellcheck="false"></textarea>
-                                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses one below another that are allowed to Notify all Secondary Zones.</div>
+                                                                <textarea id="txtZoneTransferAllowedNetworks"
+                                                                    class="form-control" rows="3"
+                                                                    spellcheck="false"></textarea>
+                                                                <div style="padding-top: 5px;">Enter IP addresses or
+                                                                    network addresses one below another that are allowed
+                                                                    to perform zone transfer for all zones without any
+                                                                    TSIG authentication.</div>
+                                                            </div>
+                                                        </div>
+
+                                                        <div class="form-group">
+                                                            <label for="txtNotifyAllowedNetworks"
+                                                                class="col-sm-3 control-label">Notify Allowed
+                                                                Networks</label>
+                                                            <div class="col-sm-6">
+                                                                <textarea id="txtNotifyAllowedNetworks"
+                                                                    class="form-control" rows="3"
+                                                                    spellcheck="false"></textarea>
+                                                                <div style="padding-top: 5px;">Enter IP addresses or
+                                                                    network addresses one below another that are allowed
+                                                                    to Notify all Secondary Zones.</div>
                                                             </div>
                                                         </div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralDnsApps" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralDnsApps"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDefaultRecordTtl" class="col-sm-3 control-label">DNS Apps</label>
+                                                            <label for="txtDefaultRecordTtl"
+                                                                class="col-sm-3 control-label">DNS Apps</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkDnsAppsEnableAutomaticUpdate" type="checkbox"> Enable Automatic Update
+                                                                        <input id="chkDnsAppsEnableAutomaticUpdate"
+                                                                            type="checkbox"> Enable Automatic Update
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">DNS server will check for DNS Apps update every day and will automatically download and install the updates.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">DNS
+                                                                    server will check for DNS Apps update every day and
+                                                                    will automatically download and install the updates.
+                                                                </div>
                                                             </div>
                                                         </div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralIpv6" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralIpv6"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
                                                             <label class="col-sm-3 control-label">IPv6 Support</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkPreferIPv6" type="checkbox"> Prefer IPv6
+                                                                        <input id="chkPreferIPv6" type="checkbox">
+                                                                        Prefer IPv6
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">The DNS Server will use IPv6 for querying whenever possible with this option enabled.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">The
+                                                                    DNS Server will use IPv6 for querying whenever
+                                                                    possible with this option enabled.</div>
                                                             </div>
                                                         </div>
 
-                                                        <div>Warning! Use this option only if this DNS server has native IPv6 Internet access otherwise it will affect performance. There are many name servers on the Internet that do not respond over IPv6 and thus enabling this option when you are running DNS server in recursive resolver mode (i.e. without any forwarders) may cause frequent operational issues with resolution that may result increase in Server Failure responses.</div>
+                                                        <div>Warning! Use this option only if this DNS server has native
+                                                            IPv6 Internet access otherwise it will affect performance.
+                                                            There are many name servers on the Internet that do not
+                                                            respond over IPv6 and thus enabling this option when you are
+                                                            running DNS server in recursive resolver mode (i.e. without
+                                                            any forwarders) may cause frequent operational issues with
+                                                            resolution that may result increase in Server Failure
+                                                            responses.</div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralUdpSocketPool" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralUdpSocketPool"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">UDP Socket Pool</label>
+                                                            <label class="col-sm-3 control-label">UDP Socket
+                                                                Pool</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableUdpSocketPool" type="checkbox"> Enable UDP Socket Pool
+                                                                        <input id="chkEnableUdpSocketPool"
+                                                                            type="checkbox"> Enable UDP Socket Pool
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">The DNS Server will use UDP socket pool for all outbound DNS-over-UDP requests when enabled.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">The
+                                                                    DNS Server will use UDP socket pool for all outbound
+                                                                    DNS-over-UDP requests when enabled.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtUdpSocketPoolExcludedPorts" class="col-sm-3 control-label">UDP Socket Pool Excluded Ports</label>
+                                                            <label for="txtUdpSocketPoolExcludedPorts"
+                                                                class="col-sm-3 control-label">UDP Socket Pool Excluded
+                                                                Ports</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtUdpSocketPoolExcludedPorts" class="form-control" rows="5" spellcheck="false"></textarea>
-                                                                <div style="padding-top: 5px;">Enter port numbers one below other to be excluded from being used by the UDP socket pool.</div>
+                                                                <textarea id="txtUdpSocketPoolExcludedPorts"
+                                                                    class="form-control" rows="5"
+                                                                    spellcheck="false"></textarea>
+                                                                <div style="padding-top: 5px;">Enter port numbers one
+                                                                    below other to be excluded from being used by the
+                                                                    UDP socket pool.</div>
                                                             </div>
                                                         </div>
 
-                                                        <div>Note! Enabling UDP socket pool provides port randomization for all outbound DNS-over-UDP requests to mitigate spoofing attacks. It is recommended to enable UDP socket pool on Windows platform. On Linux, ports are fairly random and thus socket pool may be enabled if more randomization is desired. The DNS server can detect DNS spoofing attack attempts based on ID mismatch and switch to TCP protocol automatically.</div>
+                                                        <div>Note! Enabling UDP socket pool provides port randomization
+                                                            for all outbound DNS-over-UDP requests to mitigate spoofing
+                                                            attacks. It is recommended to enable UDP socket pool on
+                                                            Windows platform. On Linux, ports are fairly random and thus
+                                                            socket pool may be enabled if more randomization is desired.
+                                                            The DNS server can detect DNS spoofing attack attempts based
+                                                            on ID mismatch and switch to TCP protocol automatically.
+                                                        </div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralEDns" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralEDns"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtEdnsUdpPayloadSize" class="col-sm-3 control-label">EDNS UDP Payload Size</label>
+                                                            <label for="txtEdnsUdpPayloadSize"
+                                                                class="col-sm-3 control-label">EDNS UDP Payload
+                                                                Size</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtEdnsUdpPayloadSize" placeholder="size" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtEdnsUdpPayloadSize" placeholder="size"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>bytes (valid range 512-4096; default 1232)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum UDP payload size that can be used to avoid IP fragmentation.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum UDP payload size
+                                                                that can be used to avoid IP fragmentation.</div>
                                                         </div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralDnssec" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralDnssec"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
                                                             <label class="col-sm-3 control-label">DNSSEC</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkDnssecValidation" type="checkbox" checked> Enable DNSSEC Validation
+                                                                        <input id="chkDnssecValidation" type="checkbox"
+                                                                            checked> Enable DNSSEC Validation
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">The DNS Server will validate all responses from name servers or forwarders when this option is enabled.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">The
+                                                                    DNS Server will validate all responses from name
+                                                                    servers or forwarders when this option is enabled.
+                                                                </div>
                                                             </div>
                                                         </div>
 
                                                         <div>
-                                                            <p>Warning! Devices that do not have a real-time clock and rely on NTP when booting (e.g. Raspberry Pi), enabling DNSSEC validation will cause failure to resolve the NTP server domain name thus causing the DNS server to fail to validate all other domain names too due to invalid system date/time. To fix this issue, just create a Conditional Forwarder zone for the NTP server domain name (e.g. ntp.org) with forwarder set to <code>this-server</code> and Enable DNSSEC Validation option unchecked. This conditional forwarder zone will disable DNSSEC validation for the NTP server domain name and allow the device to update its system data/time on boot.</p>
-                                                            <p>Warning! When forwarders are configured, DNSSEC validation will work only if the forwarders are security aware i.e. can respond to DNSSEC requests correctly.</p>
-                                                            <p>Note! Enabling DNSSEC may increase delays in resolving domain names when the cache is initially empty. As the cache fills up, the performance will be normal as expected.</p>
+                                                            <p>Warning! Devices that do not have a real-time clock and
+                                                                rely on NTP when booting (e.g. Raspberry Pi), enabling
+                                                                DNSSEC validation will cause failure to resolve the NTP
+                                                                server domain name thus causing the DNS server to fail
+                                                                to validate all other domain names too due to invalid
+                                                                system date/time. To fix this issue, just create a
+                                                                Conditional Forwarder zone for the NTP server domain
+                                                                name (e.g. ntp.org) with forwarder set to
+                                                                <code>this-server</code> and Enable DNSSEC Validation
+                                                                option unchecked. This conditional forwarder zone will
+                                                                disable DNSSEC validation for the NTP server domain name
+                                                                and allow the device to update its system data/time on
+                                                                boot.
+                                                            </p>
+                                                            <p>Warning! When forwarders are configured, DNSSEC
+                                                                validation will work only if the forwarders are security
+                                                                aware i.e. can respond to DNSSEC requests correctly.</p>
+                                                            <p>Note! Enabling DNSSEC may increase delays in resolving
+                                                                domain names when the cache is initially empty. As the
+                                                                cache fills up, the performance will be normal as
+                                                                expected.</p>
                                                         </div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralEDnsClientSubnet" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralEDnsClientSubnet"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">EDNS Client Subnet (ECS)</label>
+                                                            <label class="col-sm-3 control-label">EDNS Client Subnet
+                                                                (ECS)</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEDnsClientSubnet" type="checkbox"> Enable EDNS Client Subnet
+                                                                        <input id="chkEDnsClientSubnet" type="checkbox">
+                                                                        Enable EDNS Client Subnet
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">The DNS Server will use the public IP address of the request with a prefix length, or the existing Client Subnet option from the request.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">The
+                                                                    DNS Server will use the public IP address of the
+                                                                    request with a prefix length, or the existing Client
+                                                                    Subnet option from the request.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtEDnsClientSubnetIPv4PrefixLength" class="col-sm-3 control-label">ECS IPv4 Prefix Length</label>
+                                                            <label for="txtEDnsClientSubnetIPv4PrefixLength"
+                                                                class="col-sm-3 control-label">ECS IPv4 Prefix
+                                                                Length</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtEDnsClientSubnetIPv4PrefixLength" placeholder="prefix" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtEDnsClientSubnetIPv4PrefixLength"
+                                                                    placeholder="prefix"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(valid range 0-32; default 24)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The IPv4 prefix length to define the client subnet.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The IPv4 prefix length to
+                                                                define the client subnet.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtEDnsClientSubnetIPv6PrefixLength" class="col-sm-3 control-label">ECS IPv6 Prefix Length</label>
+                                                            <label for="txtEDnsClientSubnetIPv6PrefixLength"
+                                                                class="col-sm-3 control-label">ECS IPv6 Prefix
+                                                                Length</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtEDnsClientSubnetIPv6PrefixLength" placeholder="prefix" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtEDnsClientSubnetIPv6PrefixLength"
+                                                                    placeholder="prefix"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(valid range 0-64; default 56)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The IPv6 prefix length to define the client subnet.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The IPv6 prefix length to
+                                                                define the client subnet.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtEDnsClientSubnetIpv4Override" class="col-sm-3 control-label">ECS IPv4 Override</label>
+                                                            <label for="txtEDnsClientSubnetIpv4Override"
+                                                                class="col-sm-3 control-label">ECS IPv4 Override</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtEDnsClientSubnetIpv4Override" placeholder="network address">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtEDnsClientSubnetIpv4Override"
+                                                                    placeholder="network address">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The IPv4 network address that must be used as ECS for all outbound requests overriding client's actual subnet.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The IPv4 network address that
+                                                                must be used as ECS for all outbound requests overriding
+                                                                client's actual subnet.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtEDnsClientSubnetIpv6Override" class="col-sm-3 control-label">ECS IPv6 Override</label>
+                                                            <label for="txtEDnsClientSubnetIpv6Override"
+                                                                class="col-sm-3 control-label">ECS IPv6 Override</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtEDnsClientSubnetIpv6Override" placeholder="network address">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtEDnsClientSubnetIpv6Override"
+                                                                    placeholder="network address">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The IPv6 network address that must be used as ECS for all outbound requests overriding client's actual subnet.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The IPv6 network address that
+                                                                must be used as ECS for all outbound requests overriding
+                                                                client's actual subnet.</div>
                                                         </div>
 
                                                         <div>
-                                                            <p>Warning! EDNS Client Subnet (ECS) option when enabled will compromises user's privacy since the DNS server will send the user's public IP network subnet to name servers or forwarders when resolving requests. When not using encrypted DNS protocols, this information can also be read passively by anyone on the network.</p>
-                                                            <p>Note! EDNS Client Subnet (ECS) option allows passing the user's client subnet information to name servers or forwarders so that the response may contain IP addresses of servers closer to the user's geographic region. EDNS Client Subnet (ECS) option thus is only useful when the DNS server is hosted in a geographically different region compared to the users that are configured to use it.</p>
-                                                            <p>Note! Enabling EDNS Client Subnet (ECS) option will significantly increase the DNS server's memory usage since the server will have to cache data for each client subnet separately. It will also increase cache misses since DNS server will have to resolve requests and cache them for each client subnet separately.</p>
+                                                            <p>Warning! EDNS Client Subnet (ECS) option when enabled
+                                                                will compromises user's privacy since the DNS server
+                                                                will send the user's public IP network subnet to name
+                                                                servers or forwarders when resolving requests. When not
+                                                                using encrypted DNS protocols, this information can also
+                                                                be read passively by anyone on the network.</p>
+                                                            <p>Note! EDNS Client Subnet (ECS) option allows passing the
+                                                                user's client subnet information to name servers or
+                                                                forwarders so that the response may contain IP addresses
+                                                                of servers closer to the user's geographic region. EDNS
+                                                                Client Subnet (ECS) option thus is only useful when the
+                                                                DNS server is hosted in a geographically different
+                                                                region compared to the users that are configured to use
+                                                                it.</p>
+                                                            <p>Note! Enabling EDNS Client Subnet (ECS) option will
+                                                                significantly increase the DNS server's memory usage
+                                                                since the server will have to cache data for each client
+                                                                subnet separately. It will also increase cache misses
+                                                                since DNS server will have to resolve requests and cache
+                                                                them for each client subnet separately.</p>
                                                         </div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralRateLimiting" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralRateLimiting"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Queries Per Minute (QPM) Limits (IPv4)</label>
+                                                            <label class="col-sm-3 control-label">Queries Per Minute
+                                                                (QPM) Limits (IPv4)</label>
                                                             <div class="col-sm-6">
-                                                                <table class="table table-hover" style="margin-bottom: 0px;">
+                                                                <table class="table table-hover"
+                                                                    style="margin-bottom: 0px;">
                                                                     <thead>
                                                                         <tr>
                                                                             <th style="width: 100px;">IPv4 Prefix</th>
                                                                             <th>UDP Limit</th>
                                                                             <th>TCP Limit</th>
-                                                                            <th style="width: 84px;"><button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addQpmPrefixLimitsIPv4Row('', '', '');">Add</button></th>
+                                                                            <th style="width: 84px;"><button
+                                                                                    type="button"
+                                                                                    class="btn btn-default"
+                                                                                    style="padding: 0px 20px;"
+                                                                                    onclick="addQpmPrefixLimitsIPv4Row('', '', '');">Add</button>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody id="tableQpmPrefixLimitsIPv4"></tbody>
                                                                 </table>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum queries an IPv4 client subnet can make to DNS-over-UDP and DNS-over-TCP protocol services per minute on average based on the sample size. Set limit value to <code>0</code> to allow unlimited queries.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum queries an IPv4
+                                                                client subnet can make to DNS-over-UDP and DNS-over-TCP
+                                                                protocol services per minute on average based on the
+                                                                sample size. Set limit value to <code>0</code> to allow
+                                                                unlimited queries.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Queries Per Minute (QPM) Limits (IPv6)</label>
+                                                            <label class="col-sm-3 control-label">Queries Per Minute
+                                                                (QPM) Limits (IPv6)</label>
                                                             <div class="col-sm-6">
-                                                                <table class="table table-hover" style="margin-bottom: 0px;">
+                                                                <table class="table table-hover"
+                                                                    style="margin-bottom: 0px;">
                                                                     <thead>
                                                                         <tr>
                                                                             <th style="width: 100px;">IPv6 Prefix</th>
                                                                             <th>UDP Limit</th>
                                                                             <th>TCP Limit</th>
-                                                                            <th style="width: 84px;"><button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addQpmPrefixLimitsIPv6Row('', '', '');">Add</button></th>
+                                                                            <th style="width: 84px;"><button
+                                                                                    type="button"
+                                                                                    class="btn btn-default"
+                                                                                    style="padding: 0px 20px;"
+                                                                                    onclick="addQpmPrefixLimitsIPv6Row('', '', '');">Add</button>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody id="tableQpmPrefixLimitsIPv6"></tbody>
                                                                 </table>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum queries an IPv6 client subnet can make to DNS-over-UDP and DNS-over-TCP protocol services per minute on average based on the sample size. Set limit value to <code>0</code> to allow unlimited queries.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum queries an IPv6
+                                                                client subnet can make to DNS-over-UDP and DNS-over-TCP
+                                                                protocol services per minute on average based on the
+                                                                sample size. Set limit value to <code>0</code> to allow
+                                                                unlimited queries.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtQpmLimitSampleMinutes" class="col-sm-3 control-label">QPM Sample Size</label>
+                                                            <label for="txtQpmLimitSampleMinutes"
+                                                                class="col-sm-3 control-label">QPM Sample Size</label>
                                                             <div class="col-sm-8">
-                                                                <input type="number" class="form-control" id="txtQpmLimitSampleMinutes" placeholder="sample" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtQpmLimitSampleMinutes" placeholder="sample"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>minutes (valid range 1-60; default 5)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The sample size in minutes to be used for limiting queries per client.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The sample size in minutes to
+                                                                be used for limiting queries per client.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtQpmLimitUdpTruncation" class="col-sm-3 control-label">QPM Limit UDP Truncation</label>
+                                                            <label for="txtQpmLimitUdpTruncation"
+                                                                class="col-sm-3 control-label">QPM Limit UDP
+                                                                Truncation</label>
                                                             <div class="col-sm-8">
-                                                                <input type="number" class="form-control" id="txtQpmLimitUdpTruncation" placeholder="%" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtQpmLimitUdpTruncation" placeholder="%"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>% (valid range 0-100; default 50)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The percentage of requests that are responded with a truncation (TC) response when QPM limit exceeds for DNS-over-UDP protocol service while the rest of the requests are dropped. A TC response will cause a real client to retry to DNS-over-TCP protocol service.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The percentage of requests
+                                                                that are responded with a truncation (TC) response when
+                                                                QPM limit exceeds for DNS-over-UDP protocol service
+                                                                while the rest of the requests are dropped. A TC
+                                                                response will cause a real client to retry to
+                                                                DNS-over-TCP protocol service.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtQpmLimitBypassList" class="col-sm-3 control-label">QPM Limit Bypass List</label>
+                                                            <label for="txtQpmLimitBypassList"
+                                                                class="col-sm-3 control-label">QPM Limit Bypass
+                                                                List</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtQpmLimitBypassList" class="form-control" rows="5" spellcheck="false"></textarea>
-                                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses one below another that are allowed to bypass the QPM limit.</div>
+                                                                <textarea id="txtQpmLimitBypassList"
+                                                                    class="form-control" rows="5"
+                                                                    spellcheck="false"></textarea>
+                                                                <div style="padding-top: 5px;">Enter IP addresses or
+                                                                    network addresses one below another that are allowed
+                                                                    to bypass the QPM limit.</div>
                                                             </div>
                                                         </div>
 
                                                         <div>
-                                                            <p>Note! Queries Per Minute (QPM) feature will limit requests from a client subnet based on its IP address and the specified subnet prefix lengths except for loopback IP addresses. The QPM limit configured will be compared with the average count from the sample size which means a client may exceed the QPM limit for a given minute but won't exceed for the given sample size in minutes. Rate limited clients will be listed in orange color on the dashboard top clients table.</p>
-                                                            <p>Note! The configured TCP limits apply to the DNS-over-TCP protocol service as well as to the DNS-over-TLS, DNS-over-HTTPS and DNS-over-QUIC optional protocol services.</p>
+                                                            <p>Note! Queries Per Minute (QPM) feature will limit
+                                                                requests from a client subnet based on its IP address
+                                                                and the specified subnet prefix lengths except for
+                                                                loopback IP addresses. The QPM limit configured will be
+                                                                compared with the average count from the sample size
+                                                                which means a client may exceed the QPM limit for a
+                                                                given minute but won't exceed for the given sample size
+                                                                in minutes. Rate limited clients will be listed in
+                                                                orange color on the dashboard top clients table.</p>
+                                                            <p>Note! The configured TCP limits apply to the DNS-over-TCP
+                                                                protocol service as well as to the DNS-over-TLS,
+                                                                DNS-over-HTTPS and DNS-over-QUIC optional protocol
+                                                                services.</p>
                                                         </div>
                                                     </div>
 
-                                                    <div id="divSettingsGeneralAdvancedOptions" class="well well-sm form-horizontal">
+                                                    <div id="divSettingsGeneralAdvancedOptions"
+                                                        class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtClientTimeout" class="col-sm-3 control-label">Client Timeout</label>
+                                                            <label for="txtClientTimeout"
+                                                                class="col-sm-3 control-label">Client Timeout</label>
                                                             <div class="col-sm-7">
-                                                                <input type="number" class="form-control" id="txtClientTimeout" placeholder="timeout" style="width: 100px; display: inline;">
-                                                                <span>milliseconds (valid range 1000-10000; default 2000)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtClientTimeout" placeholder="timeout"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>milliseconds (valid range 1000-10000; default
+                                                                    2000)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The amount of time the DNS server must wait before responding with a <code>ServerFailure</code> response to a client request when no answer is available.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The amount of time the DNS
+                                                                server must wait before responding with a
+                                                                <code>ServerFailure</code> response to a client request
+                                                                when no answer is available.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtTcpSendTimeout" class="col-sm-3 control-label">TCP Send Timeout</label>
+                                                            <label for="txtTcpSendTimeout"
+                                                                class="col-sm-3 control-label">TCP Send Timeout</label>
                                                             <div class="col-sm-7">
-                                                                <input type="number" class="form-control" id="txtTcpSendTimeout" placeholder="timeout" style="width: 100px; display: inline;">
-                                                                <span>milliseconds (valid range 1000-90000; default 10000)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtTcpSendTimeout" placeholder="timeout"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>milliseconds (valid range 1000-90000; default
+                                                                    10000)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum amount of time the DNS Server will wait for the response to be sent. This option will apply for DNS requests being received by the DNS Server over TCP, TLS, TcpProxy, or HTTPS transports.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum amount of time the
+                                                                DNS Server will wait for the response to be sent. This
+                                                                option will apply for DNS requests being received by the
+                                                                DNS Server over TCP, TLS, TcpProxy, or HTTPS transports.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtTcpReceiveTimeout" class="col-sm-3 control-label">TCP Receive Timeout</label>
+                                                            <label for="txtTcpReceiveTimeout"
+                                                                class="col-sm-3 control-label">TCP Receive
+                                                                Timeout</label>
                                                             <div class="col-sm-7">
-                                                                <input type="number" class="form-control" id="txtTcpReceiveTimeout" placeholder="timeout" style="width: 100px; display: inline;">
-                                                                <span>milliseconds (valid range 1000-90000; default 10000)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtTcpReceiveTimeout" placeholder="timeout"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>milliseconds (valid range 1000-90000; default
+                                                                    10000)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum amount of time the DNS Server will wait for receiving data. This option will apply for DNS requests being received by the DNS Server over TCP, TLS, TcpProxy, or HTTPS transports.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum amount of time the
+                                                                DNS Server will wait for receiving data. This option
+                                                                will apply for DNS requests being received by the DNS
+                                                                Server over TCP, TLS, TcpProxy, or HTTPS transports.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtQuicIdleTimeout" class="col-sm-3 control-label">QUIC Idle Timeout</label>
+                                                            <label for="txtQuicIdleTimeout"
+                                                                class="col-sm-3 control-label">QUIC Idle Timeout</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtQuicIdleTimeout" placeholder="timeout" style="width: 100px; display: inline;">
-                                                                <span>milliseconds (valid range 1000-90000; default 60000)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtQuicIdleTimeout" placeholder="timeout"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>milliseconds (valid range 1000-90000; default
+                                                                    60000)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The time interval after which an idle QUIC connection will be closed. This option applies only to QUIC transport protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The time interval after which
+                                                                an idle QUIC connection will be closed. This option
+                                                                applies only to QUIC transport protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtQuicMaxInboundStreams" class="col-sm-3 control-label">QUIC Max Inbound Streams</label>
+                                                            <label for="txtQuicMaxInboundStreams"
+                                                                class="col-sm-3 control-label">QUIC Max Inbound
+                                                                Streams</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtQuicMaxInboundStreams" placeholder="100" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtQuicMaxInboundStreams" placeholder="100"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(valid range 1-1000; default 100)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The max number of inbound bidirectional streams that can be accepted per QUIC connection. This option applies only to QUIC transport protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The max number of inbound
+                                                                bidirectional streams that can be accepted per QUIC
+                                                                connection. This option applies only to QUIC transport
+                                                                protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtListenBacklog" class="col-sm-3 control-label">Listen Backlog</label>
+                                                            <label for="txtListenBacklog"
+                                                                class="col-sm-3 control-label">Listen Backlog</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtListenBacklog" placeholder="100" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtListenBacklog" placeholder="100"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 100)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum number of pending inbound connections. This option applies to TCP, TLS, TcpProxy, and QUIC transport protocols.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum number of pending
+                                                                inbound connections. This option applies to TCP, TLS,
+                                                                TcpProxy, and QUIC transport protocols.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtMaxConcurrentResolutionsPerCore" class="col-sm-3 control-label">Max Concurrent Resolutions</label>
+                                                            <label for="txtMaxConcurrentResolutionsPerCore"
+                                                                class="col-sm-3 control-label">Max Concurrent
+                                                                Resolutions</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtMaxConcurrentResolutionsPerCore" placeholder="100" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtMaxConcurrentResolutionsPerCore"
+                                                                    placeholder="100"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>per CPU core (default 100)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum number of concurrent async outbound resolutions that should be done per CPU core.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum number of
+                                                                concurrent async outbound resolutions that should be
+                                                                done per CPU core.</div>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -1328,20 +1983,42 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                 <div id="settingsTabPaneWebService" role="tabpanel" class="tab-pane">
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtWebServiceLocalAddresses" class="col-sm-3 control-label">Web Service Local Addresses</label>
+                                                            <label for="txtWebServiceLocalAddresses"
+                                                                class="col-sm-3 control-label">Web Service Local
+                                                                Addresses</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtWebServiceLocalAddresses" class="form-control" rows="3" spellcheck="false"></textarea>
+                                                                <textarea id="txtWebServiceLocalAddresses"
+                                                                    class="form-control" rows="3"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Local addresses are the network interface IP addresses you want the web service to listen for requests. ANY addresses (0.0.0.0 &amp; [::]) cannot be used together with unicast IP addresses. The web server uses dual-mode sockets by default so the IPv6 ANY address ([::]) works for IPv4 too. The default values work for most scenarios so, do not change these defaults unless you have a requirement for the web service to listen on specific networks. Configured unicast IP addresses will be included as Subject Alternative Name (SAN) in the self signed TLS certificate.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Local addresses are the
+                                                                network interface IP addresses you want the web service
+                                                                to listen for requests. ANY addresses (0.0.0.0 &amp;
+                                                                [::]) cannot be used together with unicast IP addresses.
+                                                                The web server uses dual-mode sockets by default so the
+                                                                IPv6 ANY address ([::]) works for IPv4 too. The default
+                                                                values work for most scenarios so, do not change these
+                                                                defaults unless you have a requirement for the web
+                                                                service to listen on specific networks. Configured
+                                                                unicast IP addresses will be included as Subject
+                                                                Alternative Name (SAN) in the self signed TLS
+                                                                certificate.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtWebServiceHttpPort" class="col-sm-3 control-label">Web Service HTTP Port</label>
+                                                            <label for="txtWebServiceHttpPort"
+                                                                class="col-sm-3 control-label">Web Service HTTP
+                                                                Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtWebServiceHttpPort" placeholder="port" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtWebServiceHttpPort" placeholder="port"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 5380)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify the TCP port number for this web console over HTTP protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify the TCP port number
+                                                                for this web console over HTTP protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
@@ -1349,255 +2026,497 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkWebServiceEnableTls" type="checkbox"> Enable HTTPS
+                                                                        <input id="chkWebServiceEnableTls"
+                                                                            type="checkbox"> Enable HTTPS
                                                                     </label>
                                                                 </div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkWebServiceEnableHttp3" type="checkbox"> Enable HTTP/3
+                                                                        <input id="chkWebServiceEnableHttp3"
+                                                                            type="checkbox"> Enable HTTP/3
                                                                     </label>
                                                                 </div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkWebServiceHttpToTlsRedirect" type="checkbox"> Enable HTTP to HTTPS Redirection
+                                                                        <input id="chkWebServiceHttpToTlsRedirect"
+                                                                            type="checkbox"> Enable HTTP to HTTPS
+                                                                        Redirection
                                                                     </label>
                                                                 </div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkWebServiceUseSelfSignedTlsCertificate" type="checkbox"> Use A Self Signed TLS Certificate When TLS Certificate File Path Is Unspecified
+                                                                        <input
+                                                                            id="chkWebServiceUseSelfSignedTlsCertificate"
+                                                                            type="checkbox"> Use A Self Signed TLS
+                                                                        Certificate When TLS Certificate File Path Is
+                                                                        Unspecified
                                                                     </label>
                                                                 </div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtWebServiceTlsPort" class="col-sm-3 control-label">Web Service HTTPS Port</label>
+                                                            <label for="txtWebServiceTlsPort"
+                                                                class="col-sm-3 control-label">Web Service HTTPS
+                                                                Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtWebServiceTlsPort" placeholder="port" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtWebServiceTlsPort" placeholder="port"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 53443)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify the TCP port number for this web console over TLS protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify the TCP port number
+                                                                for this web console over TLS protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtWebServiceTlsCertificatePath" class="col-sm-3 control-label">TLS Certificate File Path</label>
+                                                            <label for="txtWebServiceTlsCertificatePath"
+                                                                class="col-sm-3 control-label">TLS Certificate File
+                                                                Path</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtWebServiceTlsCertificatePath" placeholder="Web Service TLS Certificate File Path On Server" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtWebServiceTlsCertificatePath"
+                                                                    placeholder="Web Service TLS Certificate File Path On Server"
+                                                                    maxlength="255">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify a PKCS #12 certificate (.pfx or .p12) file path on the server. The path can be relative to the DNS server's config folder. The certificate must contain private key.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify a PKCS #12 certificate
+                                                                (.pfx or .p12) file path on the server. The path can be
+                                                                relative to the DNS server's config folder. The
+                                                                certificate must contain private key.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtWebServiceTlsCertificatePassword" class="col-sm-3 control-label">TLS Certificate Password</label>
+                                                            <label for="txtWebServiceTlsCertificatePassword"
+                                                                class="col-sm-3 control-label">TLS Certificate
+                                                                Password</label>
                                                             <div class="col-sm-6">
-                                                                <input type="password" class="form-control" id="txtWebServiceTlsCertificatePassword" placeholder="Web Service TLS Certificate Password" maxlength="255">
+                                                                <input type="password" class="form-control"
+                                                                    id="txtWebServiceTlsCertificatePassword"
+                                                                    placeholder="Web Service TLS Certificate Password"
+                                                                    maxlength="255">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Enter the certificate (.pfx) password, if any.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Enter the certificate (.pfx)
+                                                                password, if any.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtWebServiceRealIpHeader" class="col-sm-3 control-label">Real IP Header</label>
+                                                            <label for="txtWebServiceRealIpHeader"
+                                                                class="col-sm-3 control-label">Real IP Header</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtWebServiceRealIpHeader" placeholder="X-Real-IP" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtWebServiceRealIpHeader"
+                                                                    placeholder="X-Real-IP" maxlength="255">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The HTTP header that must be used to read client's actual IP address when the request comes from a reverse proxy with a private IP address.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The HTTP header that must be
+                                                                used to read client's actual IP address when the request
+                                                                comes from a reverse proxy with a private IP address.
+                                                            </div>
                                                         </div>
 
                                                         <div>
-                                                            <p>Note! The web service port changes will be automatically applied and so you do not need to manually restart the main service. The TLS certificate too will be automatically reloaded when the certificate file's date modified property on disk changes. This web page will be automatically redirected to the new web console URL after saving settings. The HTTPS protocol will be enabled only when a TLS certificate is configured.</p>
-                                                            <p>When using a reverse proxy with the Web Service, you need to add <code id="lblWebServiceRealIpHeader">X-Real-IP</code> header to the proxy request with the IP address of the client to allow the Web server to know the real IP address of the client originating the request. For example, if you are using nginx as the reverse proxy, you can add <code id="lblWebServiceRealIpNginx">proxy_set_header X-Real-IP $remote_addr;</code> to make it work.</p>
-                                                            <p>The web service uses Kestrel web server which supports both HTTP/2 and HTTP/3 protocols when TLS certificate is configured. HTTP/3 protocol support is not available on all platforms. On Windows, it is available only on Windows 11 (build 22000 or later) and Windows Server 2022. On Linux, it requires <code>libmsquic</code> to be installed.</p>
-                                                            <p>Note! The web service will always bind to <code>[::]</code> local address for HTTP/3 protocol since this is how the <code>libmsquic</code> library is designed to work.</p>
-                                                            <p>Use the following openssl command to convert your TLS certificate that is in PEM format to PKCS #12 certificate (.pfx) format:</p>
+                                                            <p>Note! The web service port changes will be automatically
+                                                                applied and so you do not need to manually restart the
+                                                                main service. The TLS certificate too will be
+                                                                automatically reloaded when the certificate file's date
+                                                                modified property on disk changes. This web page will be
+                                                                automatically redirected to the new web console URL
+                                                                after saving settings. The HTTPS protocol will be
+                                                                enabled only when a TLS certificate is configured.</p>
+                                                            <p>When using a reverse proxy with the Web Service, you need
+                                                                to add <code
+                                                                    id="lblWebServiceRealIpHeader">X-Real-IP</code>
+                                                                header to the proxy request with the IP address of the
+                                                                client to allow the Web server to know the real IP
+                                                                address of the client originating the request. For
+                                                                example, if you are using nginx as the reverse proxy,
+                                                                you can add <code
+                                                                    id="lblWebServiceRealIpNginx">proxy_set_header X-Real-IP $remote_addr;</code>
+                                                                to make it work.</p>
+                                                            <p>The web service uses Kestrel web server which supports
+                                                                both HTTP/2 and HTTP/3 protocols when TLS certificate is
+                                                                configured. HTTP/3 protocol support is not available on
+                                                                all platforms. On Windows, it is available only on
+                                                                Windows 11 (build 22000 or later) and Windows Server
+                                                                2022. On Linux, it requires <code>libmsquic</code> to be
+                                                                installed.</p>
+                                                            <p>Note! The web service will always bind to
+                                                                <code>[::]</code> local address for HTTP/3 protocol
+                                                                since this is how the <code>libmsquic</code> library is
+                                                                designed to work.
+                                                            </p>
+                                                            <p>Use the following openssl command to convert your TLS
+                                                                certificate that is in PEM format to PKCS #12
+                                                                certificate (.pfx) format:</p>
                                                             <pre>openssl pkcs12 -export -out "example.com.pfx" -inkey "privkey.pem" -in "cert.pem" -certfile "chain.pem"</pre>
                                                         </div>
 
-                                                        <div style="margin-top: 10px;"><a href="https://blog.technitium.com/2023/02/configuring-dns-over-quic-and-https3.html" target="_blank">Help: Configuring DNS-over-QUIC and HTTPS/3 For Technitium DNS Server</a></div>
+                                                        <div style="margin-top: 10px;"><a
+                                                                href="https://blog.technitium.com/2023/02/configuring-dns-over-quic-and-https3.html"
+                                                                target="_blank">Help: Configuring DNS-over-QUIC and
+                                                                HTTPS/3 For Technitium DNS Server</a></div>
                                                     </div>
                                                 </div>
 
-                                                <div id="settingsTabPaneOptionalProtocols" role="tabpanel" class="tab-pane">
+                                                <div id="settingsTabPaneOptionalProtocols" role="tabpanel"
+                                                    class="tab-pane">
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Optional DNS Server Protocols</label>
+                                                            <label class="col-sm-3 control-label">Optional DNS Server
+                                                                Protocols</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableDnsOverUdpProxy" type="checkbox"> Enable DNS-over-UDP-PROXY
+                                                                        <input id="chkEnableDnsOverUdpProxy"
+                                                                            type="checkbox"> Enable DNS-over-UDP-PROXY
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to accept DNS-over-UDP-PROXY requests. It implements the <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt" target="_blank">PROXY Protocol</a> for both version 1 &amp; 2 over UDP datagram. It is mandatory to configure <b>Reverse Proxy Network ACL</b> below to allow requests coming from your reverse proxy server.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to accept DNS-over-UDP-PROXY
+                                                                    requests. It implements the <a
+                                                                        href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt"
+                                                                        target="_blank">PROXY Protocol</a> for both
+                                                                    version 1 &amp; 2 over UDP datagram. It is mandatory
+                                                                    to configure <b>Reverse Proxy Network ACL</b> below
+                                                                    to allow requests coming from your reverse proxy
+                                                                    server.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableDnsOverTcpProxy" type="checkbox"> Enable DNS-over-TCP-PROXY
+                                                                        <input id="chkEnableDnsOverTcpProxy"
+                                                                            type="checkbox"> Enable DNS-over-TCP-PROXY
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to accept DNS-over-TCP-PROXY requests. It implements the <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt" target="_blank">PROXY Protocol</a> for both version 1 &amp; 2 over TCP connection. It is mandatory to configure <b>Reverse Proxy Network ACL</b> below to allow requests coming from your reverse proxy server.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to accept DNS-over-TCP-PROXY
+                                                                    requests. It implements the <a
+                                                                        href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt"
+                                                                        target="_blank">PROXY Protocol</a> for both
+                                                                    version 1 &amp; 2 over TCP connection. It is
+                                                                    mandatory to configure <b>Reverse Proxy Network
+                                                                        ACL</b> below to allow requests coming from your
+                                                                    reverse proxy server.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableDnsOverHttp" type="checkbox"> Enable DNS-over-HTTP
+                                                                        <input id="chkEnableDnsOverHttp"
+                                                                            type="checkbox"> Enable DNS-over-HTTP
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to accept DNS-over-HTTP requests. It must be used with a TLS terminating reverse proxy like nginx. It is mandatory to configure <b>Reverse Proxy Network ACL</b> below to allow requests coming from your reverse proxy server. Enabling this option also allows automatic TLS certificate renewal with HTTP challenge (webroot) for DNS-over-HTTPS service when DNS-over-HTTP port is set to 80.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to accept DNS-over-HTTP requests.
+                                                                    It must be used with a TLS terminating reverse proxy
+                                                                    like nginx. It is mandatory to configure <b>Reverse
+                                                                        Proxy Network ACL</b> below to allow requests
+                                                                    coming from your reverse proxy server. Enabling this
+                                                                    option also allows automatic TLS certificate renewal
+                                                                    with HTTP challenge (webroot) for DNS-over-HTTPS
+                                                                    service when DNS-over-HTTP port is set to 80.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableDnsOverTls" type="checkbox"> Enable DNS-over-TLS
+                                                                        <input id="chkEnableDnsOverTls" type="checkbox">
+                                                                        Enable DNS-over-TLS
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to accept DNS-over-TLS requests.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to accept DNS-over-TLS requests.
+                                                                </div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableDnsOverHttps" type="checkbox"> Enable DNS-over-HTTPS
+                                                                        <input id="chkEnableDnsOverHttps"
+                                                                            type="checkbox"> Enable DNS-over-HTTPS
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to accept DNS-over-HTTPS requests.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to accept DNS-over-HTTPS
+                                                                    requests.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableDnsOverHttp3" type="checkbox"> Enable DNS-over-HTTP/3
+                                                                        <input id="chkEnableDnsOverHttp3"
+                                                                            type="checkbox"> Enable DNS-over-HTTP/3
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to accept DNS-over-HTTP/3 requests.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to accept DNS-over-HTTP/3
+                                                                    requests.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableDnsOverQuic" type="checkbox"> Enable DNS-over-QUIC
+                                                                        <input id="chkEnableDnsOverQuic"
+                                                                            type="checkbox"> Enable DNS-over-QUIC
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to accept DNS-over-QUIC requests.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to accept DNS-over-QUIC requests.
+                                                                </div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsOverUdpProxyPort" class="col-sm-3 control-label">DNS-over-UDP-PROXY Port</label>
+                                                            <label for="txtDnsOverUdpProxyPort"
+                                                                class="col-sm-3 control-label">DNS-over-UDP-PROXY
+                                                                Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtDnsOverUdpProxyPort" placeholder="port" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtDnsOverUdpProxyPort" placeholder="port"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 538)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify the UDP port number for DNS-over-UDP-PROXY protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify the UDP port number
+                                                                for DNS-over-UDP-PROXY protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsOverTcpProxyPort" class="col-sm-3 control-label">DNS-over-TCP-PROXY Port</label>
+                                                            <label for="txtDnsOverTcpProxyPort"
+                                                                class="col-sm-3 control-label">DNS-over-TCP-PROXY
+                                                                Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtDnsOverTcpProxyPort" placeholder="port" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtDnsOverTcpProxyPort" placeholder="port"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 538)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify the TCP port number for DNS-over-TCP-PROXY protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify the TCP port number
+                                                                for DNS-over-TCP-PROXY protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsOverHttpPort" class="col-sm-3 control-label">DNS-over-HTTP Port</label>
+                                                            <label for="txtDnsOverHttpPort"
+                                                                class="col-sm-3 control-label">DNS-over-HTTP
+                                                                Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtDnsOverHttpPort" placeholder="port" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtDnsOverHttpPort" placeholder="port"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 80)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify the TCP port number for DNS-over-HTTP protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify the TCP port number
+                                                                for DNS-over-HTTP protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsOverTlsPort" class="col-sm-3 control-label">DNS-over-TLS Port</label>
+                                                            <label for="txtDnsOverTlsPort"
+                                                                class="col-sm-3 control-label">DNS-over-TLS Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtDnsOverTlsPort" placeholder="port" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtDnsOverTlsPort" placeholder="port"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 853)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify the TCP port number for DNS-over-TLS protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify the TCP port number
+                                                                for DNS-over-TLS protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsOverHttpsPort" class="col-sm-3 control-label">DNS-over-HTTPS Port</label>
+                                                            <label for="txtDnsOverHttpsPort"
+                                                                class="col-sm-3 control-label">DNS-over-HTTPS
+                                                                Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtDnsOverHttpsPort" placeholder="port" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtDnsOverHttpsPort" placeholder="port"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 443)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify the TCP port number for DNS-over-HTTPS protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify the TCP port number
+                                                                for DNS-over-HTTPS protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsOverQuicPort" class="col-sm-3 control-label">DNS-over-QUIC Port</label>
+                                                            <label for="txtDnsOverQuicPort"
+                                                                class="col-sm-3 control-label">DNS-over-QUIC
+                                                                Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtDnsOverQuicPort" placeholder="port" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtDnsOverQuicPort" placeholder="port"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(default 853)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify the UDP port number for DNS-over-QUIC protocol.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify the UDP port number
+                                                                for DNS-over-QUIC protocol.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtReverseProxyNetworkACL" class="col-sm-3 control-label">Reverse Proxy Network ACL</label>
+                                                            <label for="txtReverseProxyNetworkACL"
+                                                                class="col-sm-3 control-label">Reverse Proxy Network
+                                                                ACL</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtReverseProxyNetworkACL" class="form-control" rows="5" spellcheck="false"></textarea>
+                                                                <textarea id="txtReverseProxyNetworkACL"
+                                                                    class="form-control" rows="5"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Configure the ACL above to allow requests coming from your reverse proxy server for DNS-over-UDP-PROXY, DNS-over-TCP-PROXY, and DNS-over-HTTP protocols. Enter IP addresses or network addresses one below another to allow access. Add <code>!</code> character at the start to deny access, e.g. <code>!192.168.10.0/24</code> will deny entire subnet. The ACL is processed in the same order its listed. If no networks match, the default policy is to deny all.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Configure the ACL above to
+                                                                allow requests coming from your reverse proxy server for
+                                                                DNS-over-UDP-PROXY, DNS-over-TCP-PROXY, and
+                                                                DNS-over-HTTP protocols. Enter IP addresses or network
+                                                                addresses one below another to allow access. Add
+                                                                <code>!</code> character at the start to deny access,
+                                                                e.g. <code>!192.168.10.0/24</code> will deny entire
+                                                                subnet. The ACL is processed in the same order its
+                                                                listed. If no networks match, the default policy is to
+                                                                deny all.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsTlsCertificatePath" class="col-sm-3 control-label">TLS Certificate File Path</label>
+                                                            <label for="txtDnsTlsCertificatePath"
+                                                                class="col-sm-3 control-label">TLS Certificate File
+                                                                Path</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDnsTlsCertificatePath" placeholder="DNS Service TLS Certificate File Path On Server" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDnsTlsCertificatePath"
+                                                                    placeholder="DNS Service TLS Certificate File Path On Server"
+                                                                    maxlength="255">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Specify a PKCS #12 certificate (.pfx or .p12) file path on the server. The path can be relative to the DNS server's config folder. The certificate must contain private key.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Specify a PKCS #12 certificate
+                                                                (.pfx or .p12) file path on the server. The path can be
+                                                                relative to the DNS server's config folder. The
+                                                                certificate must contain private key.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsTlsCertificatePassword" class="col-sm-3 control-label">TLS Certificate Password</label>
+                                                            <label for="txtDnsTlsCertificatePassword"
+                                                                class="col-sm-3 control-label">TLS Certificate
+                                                                Password</label>
                                                             <div class="col-sm-6">
-                                                                <input type="password" class="form-control" id="txtDnsTlsCertificatePassword" placeholder="DNS Service TLS Certificate Password" maxlength="255">
+                                                                <input type="password" class="form-control"
+                                                                    id="txtDnsTlsCertificatePassword"
+                                                                    placeholder="DNS Service TLS Certificate Password"
+                                                                    maxlength="255">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Enter the certificate (.pfx) password, if any.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Enter the certificate (.pfx)
+                                                                password, if any.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDnsOverHttpRealIpHeader" class="col-sm-3 control-label">Real IP Header</label>
+                                                            <label for="txtDnsOverHttpRealIpHeader"
+                                                                class="col-sm-3 control-label">Real IP Header</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDnsOverHttpRealIpHeader" placeholder="X-Real-IP" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDnsOverHttpRealIpHeader"
+                                                                    placeholder="X-Real-IP" maxlength="255">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The HTTP header that must be used to read client's actual IP address when the request comes from a reverse proxy. The specified header will be read only when the request IP address is allowed by the <b>Reverse Proxy Network ACL</b>.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The HTTP header that must be
+                                                                used to read client's actual IP address when the request
+                                                                comes from a reverse proxy. The specified header will be
+                                                                read only when the request IP address is allowed by the
+                                                                <b>Reverse Proxy Network ACL</b>.
+                                                            </div>
                                                         </div>
 
                                                         <div>
-                                                            <p>Note! These optional DNS server protocol changes will be automatically applied and so you do not need to manually restart the main service. The TLS certificate too will be automatically reloaded when the certificate file's date modified property on disk changes. The DNS-over-TLS, DNS-over-QUIC, and DNS-over-HTTPS protocols will be enabled only when a TLS certificate is configured.</p>
-                                                            <p>These optional DNS server protocols are used to host these as a service. You do not need to enable these optional protocols to use them with Forwarders or Conditional Forwarder Zones.</p>
-                                                            <p>For DNS-over-HTTP, use <code>http://<span id="lblDoHHost">localhost:8053</span>/dns-query</code> with a TLS terminating reverse proxy like nginx. For DNS-over-TLS, use <code id="lblDoTHost">tls-certificate-domain:853</code>, for DNS-over-QUIC, use <code id="lblDoQHost">tls-certificate-domain:853</code>, and for DNS-over-HTTPS use <code>https://<span id="lblDoHsHost">tls-certificate-domain</span>/dns-query</code> to configure supported DNS clients.</p>
-                                                            <p>When using a reverse proxy with the DNS-over-HTTP service, you need to add <code id="lblDnsOverHttpRealIpHeader">X-Real-IP</code> header to the proxy request with the IP address of the client to allow the DNS server to know the real IP address of the client originating the request. For example, if you are using nginx as the reverse proxy, you can add <code id="lblDnsOverHttpRealIpNginx">proxy_set_header X-Real-IP $remote_addr;</code> to make it work.</p>
-                                                            <p>DNS-over-QUIC protocol support is not available on all platforms. On Windows, it is available only on Windows 11 (build 22000 or later) and Windows Server 2022. On Linux, it requires <code>libmsquic</code> to be installed.</p>
-                                                            <p>Note! The DNS-over-HTTP/3 protocol will always bind to <code>[::]</code> local address since this is how the <code>libmsquic</code> library is designed to work.</p>
-                                                            <p>Use the following openssl command to convert your TLS certificate that is in PEM format to PKCS #12 certificate (.pfx) format:</p>
+                                                            <p>Note! These optional DNS server protocol changes will be
+                                                                automatically applied and so you do not need to manually
+                                                                restart the main service. The TLS certificate too will
+                                                                be automatically reloaded when the certificate file's
+                                                                date modified property on disk changes. The
+                                                                DNS-over-TLS, DNS-over-QUIC, and DNS-over-HTTPS
+                                                                protocols will be enabled only when a TLS certificate is
+                                                                configured.</p>
+                                                            <p>These optional DNS server protocols are used to host
+                                                                these as a service. You do not need to enable these
+                                                                optional protocols to use them with Forwarders or
+                                                                Conditional Forwarder Zones.</p>
+                                                            <p>For DNS-over-HTTP, use
+                                                                <code>http://<span id="lblDoHHost">localhost:8053</span>/dns-query</code>
+                                                                with a TLS terminating reverse proxy like nginx. For
+                                                                DNS-over-TLS, use <code
+                                                                    id="lblDoTHost">tls-certificate-domain:853</code>,
+                                                                for DNS-over-QUIC, use <code
+                                                                    id="lblDoQHost">tls-certificate-domain:853</code>,
+                                                                and for DNS-over-HTTPS use
+                                                                <code>https://<span id="lblDoHsHost">tls-certificate-domain</span>/dns-query</code>
+                                                                to configure supported DNS clients.
+                                                            </p>
+                                                            <p>When using a reverse proxy with the DNS-over-HTTP
+                                                                service, you need to add <code
+                                                                    id="lblDnsOverHttpRealIpHeader">X-Real-IP</code>
+                                                                header to the proxy request with the IP address of the
+                                                                client to allow the DNS server to know the real IP
+                                                                address of the client originating the request. For
+                                                                example, if you are using nginx as the reverse proxy,
+                                                                you can add <code
+                                                                    id="lblDnsOverHttpRealIpNginx">proxy_set_header X-Real-IP $remote_addr;</code>
+                                                                to make it work.</p>
+                                                            <p>DNS-over-QUIC protocol support is not available on all
+                                                                platforms. On Windows, it is available only on Windows
+                                                                11 (build 22000 or later) and Windows Server 2022. On
+                                                                Linux, it requires <code>libmsquic</code> to be
+                                                                installed.</p>
+                                                            <p>Note! The DNS-over-HTTP/3 protocol will always bind to
+                                                                <code>[::]</code> local address since this is how the
+                                                                <code>libmsquic</code> library is designed to work.
+                                                            </p>
+                                                            <p>Use the following openssl command to convert your TLS
+                                                                certificate that is in PEM format to PKCS #12
+                                                                certificate (.pfx) format:</p>
                                                             <pre>openssl pkcs12 -export -out "example.com.pfx" -inkey "privkey.pem" -in "cert.pem" -certfile "chain.pem"</pre>
                                                         </div>
 
-                                                        <div style="margin-top: 10px;"><a href="https://blog.technitium.com/2020/07/how-to-host-your-own-dns-over-https-and.html" target="_blank">Help: How To Host Your Own DNS-over-HTTPS, DNS-over-TLS, And DNS-over-QUIC Services</a></div>
-                                                        <div style="margin-top: 10px;"><a href="https://blog.technitium.com/2023/02/configuring-dns-over-quic-and-https3.html" target="_blank">Help: Configuring DNS-over-QUIC and HTTPS/3 For Technitium DNS Server</a></div>
+                                                        <div style="margin-top: 10px;"><a
+                                                                href="https://blog.technitium.com/2020/07/how-to-host-your-own-dns-over-https-and.html"
+                                                                target="_blank">Help: How To Host Your Own
+                                                                DNS-over-HTTPS, DNS-over-TLS, And DNS-over-QUIC
+                                                                Services</a></div>
+                                                        <div style="margin-top: 10px;"><a
+                                                                href="https://blog.technitium.com/2023/02/configuring-dns-over-quic-and-https3.html"
+                                                                target="_blank">Help: Configuring DNS-over-QUIC and
+                                                                HTTPS/3 For Technitium DNS Server</a></div>
                                                     </div>
                                                 </div>
 
                                                 <div id="settingsTabPaneTsig" role="tabpanel" class="tab-pane">
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="tableTsigKeys" class="col-sm-2 control-label">TSIG Keys</label>
+                                                            <label for="tableTsigKeys"
+                                                                class="col-sm-2 control-label">TSIG Keys</label>
                                                             <div class="col-sm-10">
-                                                                <table class="table table-hover" style="margin-bottom: 0px;">
+                                                                <table class="table table-hover"
+                                                                    style="margin-bottom: 0px;">
                                                                     <thead>
                                                                         <tr>
                                                                             <th>Key Name</th>
                                                                             <th>Shared Secret</th>
                                                                             <th>Algorithm</th>
-                                                                            <th style="width: 84px;"><button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addTsigKeyRow('', '', 'hmac-sha256');">Add</button></th>
+                                                                            <th style="width: 84px;"><button
+                                                                                    type="button"
+                                                                                    class="btn btn-default"
+                                                                                    style="padding: 0px 20px;"
+                                                                                    onclick="addTsigKeyRow('', '', 'hmac-sha256');">Add</button>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody id="tableTsigKeys"></tbody>
                                                                 </table>
                                                             </div>
-                                                            <div class="col-sm-offset-2 col-sm-10" style="padding-top: 5px;">The shared secret can be a base64 string or a literal string. Keep the shared secret empty if you want to auto generate a strong key.</div>
+                                                            <div class="col-sm-offset-2 col-sm-10"
+                                                                style="padding-top: 5px;">The shared secret can be a
+                                                                base64 string or a literal string. Keep the shared
+                                                                secret empty if you want to auto generate a strong key.
+                                                            </div>
                                                         </div>
 
-                                                        <div>Note! You will need to configure these TSIG keys names for zone transfer in the zone options and in the secondary zone SOA record options separately.</div>
+                                                        <div>Note! You will need to configure these TSIG keys names for
+                                                            zone transfer in the zone options and in the secondary zone
+                                                            SOA record options separately.</div>
                                                     </div>
                                                 </div>
 
@@ -1608,105 +2527,189 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <div class="col-sm-8">
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdRecursion" id="rdRecursionDeny" value="Deny">
+                                                                        <input type="radio" name="rdRecursion"
+                                                                            id="rdRecursionDeny" value="Deny">
                                                                         Deny Recursion
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Disables recursion so that this DNS Server works as authoritative only.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Disables recursion so that this DNS Server works
+                                                                        as authoritative only.</div>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdRecursion" id="rdRecursionAllow" value="Allow">
+                                                                        <input type="radio" name="rdRecursion"
+                                                                            id="rdRecursionAllow" value="Allow">
                                                                         Allow Recursion
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Enables recursion to allow this DNS Server to resolve any domain name.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Enables recursion to allow this DNS Server to
+                                                                        resolve any domain name.</div>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdRecursion" id="rdRecursionAllowOnlyForPrivateNetworks" value="AllowOnlyForPrivateNetworks" checked>
-                                                                        Allow Recursion Only For Private Networks (default)
+                                                                        <input type="radio" name="rdRecursion"
+                                                                            id="rdRecursionAllowOnlyForPrivateNetworks"
+                                                                            value="AllowOnlyForPrivateNetworks" checked>
+                                                                        Allow Recursion Only For Private Networks
+                                                                        (default)
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Select this option if you want to support recursion only on private networks. Any recursive request from a public network will be refused.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Select this option if you want to support
+                                                                        recursion only on private networks. Any
+                                                                        recursive request from a public network will be
+                                                                        refused.</div>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdRecursion" id="rdRecursionUseSpecifiedNetworkACL" value="UseSpecifiedNetworkACL">
+                                                                        <input type="radio" name="rdRecursion"
+                                                                            id="rdRecursionUseSpecifiedNetworkACL"
+                                                                            value="UseSpecifiedNetworkACL">
                                                                         Use Specified Network Access Control List (ACL)
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Select this option to specify networks that must be allowed or denied recursion.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Select this option to specify networks that must
+                                                                        be allowed or denied recursion.</div>
                                                                 </div>
                                                             </div>
                                                             <div class="col-sm-offset-3 col-sm-6">
-                                                                <label for="txtRecursionNetworkACL" class="control-label">Network Access Control List (ACL)</label>
-                                                                <textarea id="txtRecursionNetworkACL" class="form-control" rows="5" spellcheck="false"></textarea>
-                                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses one below another to allow access. Add <code>!</code> character at the start to deny access, e.g. <code>!192.168.10.0/24</code> will deny entire subnet. The ACL is processed in the same order its listed. If no networks match, the default policy is to deny all except loopback.</div>
+                                                                <label for="txtRecursionNetworkACL"
+                                                                    class="control-label">Network Access Control List
+                                                                    (ACL)</label>
+                                                                <textarea id="txtRecursionNetworkACL"
+                                                                    class="form-control" rows="5"
+                                                                    spellcheck="false"></textarea>
+                                                                <div style="padding-top: 5px;">Enter IP addresses or
+                                                                    network addresses one below another to allow access.
+                                                                    Add <code>!</code> character at the start to deny
+                                                                    access, e.g. <code>!192.168.10.0/24</code> will deny
+                                                                    entire subnet. The ACL is processed in the same
+                                                                    order its listed. If no networks match, the default
+                                                                    policy is to deny all except loopback.</div>
                                                             </div>
                                                         </div>
 
-                                                        <div>Note! Disable recursion if you wish this server to act only as authoritative name server for the configured zones.</div>
+                                                        <div>Note! Disable recursion if you wish this server to act only
+                                                            as authoritative name server for the configured zones.</div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Recursive Resolver</label>
+                                                            <label class="col-sm-3 control-label">Recursive
+                                                                Resolver</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkRandomizeName" type="checkbox"> Randomize Name
+                                                                        <input id="chkRandomizeName" type="checkbox">
+                                                                        Randomize Name
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enables <a href="https://datatracker.ietf.org/doc/draft-vixie-dnsext-dns0x20/" target="_blank">QNAME case randomization</a> when using UDP as the transport protocol to improve security.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enables <a
+                                                                        href="https://datatracker.ietf.org/doc/draft-vixie-dnsext-dns0x20/"
+                                                                        target="_blank">QNAME case randomization</a>
+                                                                    when using UDP as the transport protocol to improve
+                                                                    security.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkQnameMinimization" type="checkbox"> QNAME Minimization
+                                                                        <input id="chkQnameMinimization"
+                                                                            type="checkbox"> QNAME Minimization
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enables <a href="https://datatracker.ietf.org/doc/rfc9156/" target="_blank">QNAME minimization</a> for recursive resolution to improve privacy.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enables <a
+                                                                        href="https://datatracker.ietf.org/doc/rfc9156/"
+                                                                        target="_blank">QNAME minimization</a> for
+                                                                    recursive resolution to improve privacy.</div>
                                                             </div>
                                                         </div>
 
-                                                        <div>Warning! Enabling the <b>Randomize Name</b> option may cause some domain names to fail to resolve due to their name servers dropping the requests or sending the QNAME in response with a different case causing mismatch. The DNS server can already detect DNS spoofing attack attempts and switch to TCP protocol automatically so its safe to not use this feature.</div>
+                                                        <div>Warning! Enabling the <b>Randomize Name</b> option may
+                                                            cause some domain names to fail to resolve due to their name
+                                                            servers dropping the requests or sending the QNAME in
+                                                            response with a different case causing mismatch. The DNS
+                                                            server can already detect DNS spoofing attack attempts and
+                                                            switch to TCP protocol automatically so its safe to not use
+                                                            this feature.</div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtResolverRetries" class="col-sm-3 control-label">Resolver Retries</label>
+                                                            <label for="txtResolverRetries"
+                                                                class="col-sm-3 control-label">Resolver Retries</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtResolverRetries" placeholder="retries" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtResolverRetries" placeholder="retries"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(valid range 1-10; default 2)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The total number of retries the recursive resolver must do per name server.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The total number of retries
+                                                                the recursive resolver must do per name server.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtResolverTimeout" class="col-sm-3 control-label">Resolver Timeout</label>
+                                                            <label for="txtResolverTimeout"
+                                                                class="col-sm-3 control-label">Resolver Timeout</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtResolverTimeout" placeholder="timeout" style="width: 100px; display: inline;">
-                                                                <span>milliseconds (valid range 1000-10000; default 1500)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtResolverTimeout" placeholder="timeout"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>milliseconds (valid range 1000-10000; default
+                                                                    1500)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The amount of time the recursive resolver must wait between retries.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The amount of time the
+                                                                recursive resolver must wait between retries.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtResolverConcurrency" class="col-sm-3 control-label">Resolver Concurrency</label>
+                                                            <label for="txtResolverConcurrency"
+                                                                class="col-sm-3 control-label">Resolver
+                                                                Concurrency</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtResolverConcurrency" placeholder="count" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtResolverConcurrency" placeholder="count"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(valid range 1-4; default 2)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The number of concurrent requests that should be sent by the recursive resolver to the name servers.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The number of concurrent
+                                                                requests that should be sent by the recursive resolver
+                                                                to the name servers.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtResolverMaxStackCount" class="col-sm-3 control-label">Resolver Max Stack Count</label>
+                                                            <label for="txtResolverMaxStackCount"
+                                                                class="col-sm-3 control-label">Resolver Max Stack
+                                                                Count</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtResolverMaxStackCount" placeholder="count" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtResolverMaxStackCount" placeholder="count"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(valid range 10-30; default 16)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum stack count the recursive resolver must use for resolving a domain name.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum stack count the
+                                                                recursive resolver must use for resolving a domain name.
+                                                            </div>
                                                         </div>
 
-                                                        <div style="margin-top: 10px;">Note! The DNS Server supports EDNS and thus all outbound recursive resolution requests will have an OPT record for it in the additional section. If a name server does not respond to a request containing OPT record, the recursive resolver will retry again without the OPT record when possible. This means that the number of retries attempted per name server can be Resolver Retries value multiplied by two for certain cases.</div>
-                                                        <div style="margin-top: 10px;">Note! The DNS server uses Epsilon-Greedy machine learning algorithm and will automatically learn which of the name servers are answering faster without errors and will use those name servers most of the time. Since each domain name has a different set of name servers, it may take a while before the algorithm learns about them.</div>
+                                                        <div style="margin-top: 10px;">Note! The DNS Server supports
+                                                            EDNS and thus all outbound recursive resolution requests
+                                                            will have an OPT record for it in the additional section. If
+                                                            a name server does not respond to a request containing OPT
+                                                            record, the recursive resolver will retry again without the
+                                                            OPT record when possible. This means that the number of
+                                                            retries attempted per name server can be Resolver Retries
+                                                            value multiplied by two for certain cases.</div>
+                                                        <div style="margin-top: 10px;">Note! The DNS server uses
+                                                            Epsilon-Greedy machine learning algorithm and will
+                                                            automatically learn which of the name servers are answering
+                                                            faster without errors and will use those name servers most
+                                                            of the time. Since each domain name has a different set of
+                                                            name servers, it may take a while before the algorithm
+                                                            learns about them.</div>
                                                     </div>
                                                 </div>
 
@@ -1717,14 +2720,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkSaveCache" type="checkbox"> Save Cache To Disk
+                                                                        <input id="chkSaveCache" type="checkbox"> Save
+                                                                        Cache To Disk
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to save DNS cache on disk when the DNS server stops. The saved cache will be loaded next time the DNS server starts.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to save DNS cache on disk when
+                                                                    the DNS server stops. The saved cache will be loaded
+                                                                    next time the DNS server starts.</div>
                                                             </div>
                                                         </div>
 
-                                                        <div>Note! The DNS server will attempt to save cache to disk when it stops which may take time depending on the cache size. If the DNS server takes a lot of time to stop then it may lead to the OS killing the DNS server process causing an incomplete cache to be stored on disk.</div>
+                                                        <div>Note! The DNS server will attempt to save cache to disk
+                                                            when it stops which may take time depending on the cache
+                                                            size. If the DNS server takes a lot of time to stop then it
+                                                            may lead to the OS killing the DNS server process causing an
+                                                            incomplete cache to be stored on disk.</div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
@@ -1733,135 +2744,270 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkServeStale" type="checkbox"> Enable Serve Stale
+                                                                        <input id="chkServeStale" type="checkbox">
+                                                                        Enable Serve Stale
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable the <a href="https://datatracker.ietf.org/doc/rfc8767/" target="_blank">Serve Stale</a> feature to improve resiliency by using expired or stale records in cache to respond when the DNS server is unable to reach the upstream or authoritative name servers to refresh the expired records before the Max Wait Time configured below.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable the <a
+                                                                        href="https://datatracker.ietf.org/doc/rfc8767/"
+                                                                        target="_blank">Serve Stale</a> feature to
+                                                                    improve resiliency by using expired or stale records
+                                                                    in cache to respond when the DNS server is unable to
+                                                                    reach the upstream or authoritative name servers to
+                                                                    refresh the expired records before the Max Wait Time
+                                                                    configured below.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtServeStaleTtl" class="col-sm-3 control-label">Serve Stale TTL</label>
+                                                            <label for="txtServeStaleTtl"
+                                                                class="col-sm-3 control-label">Serve Stale TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtServeStaleTtl" placeholder="seconds" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtServeStaleTtl" placeholder="seconds"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (recommended 259200/3d)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The TTL value in seconds which should be used for cached records that are expired. When the serve stale TTL too expires for a stale record, it gets removed from the cache. Recommended value is between 1-3 days and maximum supported value is 7 days.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The TTL value in seconds which
+                                                                should be used for cached records that are expired. When
+                                                                the serve stale TTL too expires for a stale record, it
+                                                                gets removed from the cache. Recommended value is
+                                                                between 1-3 days and maximum supported value is 7 days.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtServeStaleAnswerTtl" class="col-sm-3 control-label">Serve Stale Answer TTL</label>
+                                                            <label for="txtServeStaleAnswerTtl"
+                                                                class="col-sm-3 control-label">Serve Stale Answer
+                                                                TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtServeStaleAnswerTtl" placeholder="seconds" style="width: 100px; display: inline;">
-                                                                <span>seconds (valid range 0-300/5m; recommended 30)</span>
+                                                                <input type="text" class="form-control"
+                                                                    id="txtServeStaleAnswerTtl" placeholder="seconds"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>seconds (valid range 0-300/5m; recommended
+                                                                    30)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The TTL value in seconds which should be used for the records in a stale response. This is the TTL value that the client will be using to cache the stale records.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The TTL value in seconds which
+                                                                should be used for the records in a stale response. This
+                                                                is the TTL value that the client will be using to cache
+                                                                the stale records.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtServeStaleResetTtl" class="col-sm-3 control-label">Serve Stale Reset TTL</label>
+                                                            <label for="txtServeStaleResetTtl"
+                                                                class="col-sm-3 control-label">Serve Stale Reset
+                                                                TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtServeStaleResetTtl" placeholder="seconds" style="width: 100px; display: inline;">
-                                                                <span>seconds (valid range 10-900/15m; recommended 30)</span>
+                                                                <input type="text" class="form-control"
+                                                                    id="txtServeStaleResetTtl" placeholder="seconds"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>seconds (valid range 10-900/15m; recommended
+                                                                    30)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The TTL value in seconds which should be used to reset the stale record's TTL value in the cache when the resolver fails to refresh the data. The TTL reset causes the stale records to become valid again so that they can be used to serve requests normally. This reset effectively prevents the resolver from attempting to frequently update the stale records.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The TTL value in seconds which
+                                                                should be used to reset the stale record's TTL value in
+                                                                the cache when the resolver fails to refresh the data.
+                                                                The TTL reset causes the stale records to become valid
+                                                                again so that they can be used to serve requests
+                                                                normally. This reset effectively prevents the resolver
+                                                                from attempting to frequently update the stale records.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtServeStaleMaxWaitTime" class="col-sm-3 control-label">Serve Stale Max Wait Time</label>
+                                                            <label for="txtServeStaleMaxWaitTime"
+                                                                class="col-sm-3 control-label">Serve Stale Max Wait
+                                                                Time</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtServeStaleMaxWaitTime" placeholder="milliseconds" style="width: 100px; display: inline;">
-                                                                <span>milliseconds (valid range 0-1800; default 1800)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtServeStaleMaxWaitTime"
+                                                                    placeholder="milliseconds"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>milliseconds (valid range 0-1800; default
+                                                                    1800)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The time in milliseconds that the DNS server must wait for the resolver before serving stale records from the cache. Lower value will ensure faster response at the expense of not getting updated data from the upstream. Setting value to 0 will instantly return stale answer without waiting for the resolver to fetch updates from the upstream.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The time in milliseconds that
+                                                                the DNS server must wait for the resolver before serving
+                                                                stale records from the cache. Lower value will ensure
+                                                                faster response at the expense of not getting updated
+                                                                data from the upstream. Setting value to 0 will
+                                                                instantly return stale answer without waiting for the
+                                                                resolver to fetch updates from the upstream.</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtCacheMaximumEntries" class="col-sm-3 control-label">Cache Maximum Entries</label>
+                                                            <label for="txtCacheMaximumEntries"
+                                                                class="col-sm-3 control-label">Cache Maximum
+                                                                Entries</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtCacheMaximumEntries" placeholder="entries" style="width: 125px; display: inline;">
-                                                                <span>(default 10000; set 0 for unlimited entries)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtCacheMaximumEntries" placeholder="entries"
+                                                                    style="width: 125px; display: inline;">
+                                                                <span>(default 10000; set 0 for unlimited
+                                                                    entries)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum number of entries that the cache can store. A relevant value should be configured by monitoring the Cache entries value on Dashboard and the server's memory usage to limit the amount of RAM used by the DNS server. A cache entry is a complete Resource Record Set (RR Set) which is a group of records with the same type for a given domain name. When a value is configured, the DNS server will trigger a clean up operation every few minutes and remove least recently used entries to maintain the maximum allowed entries in cache.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum number of entries
+                                                                that the cache can store. A relevant value should be
+                                                                configured by monitoring the Cache entries value on
+                                                                Dashboard and the server's memory usage to limit the
+                                                                amount of RAM used by the DNS server. A cache entry is a
+                                                                complete Resource Record Set (RR Set) which is a group
+                                                                of records with the same type for a given domain name.
+                                                                When a value is configured, the DNS server will trigger
+                                                                a clean up operation every few minutes and remove least
+                                                                recently used entries to maintain the maximum allowed
+                                                                entries in cache.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtCacheMinimumRecordTtl" class="col-sm-3 control-label">Cache Minimum TTL</label>
+                                                            <label for="txtCacheMinimumRecordTtl"
+                                                                class="col-sm-3 control-label">Cache Minimum TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtCacheMinimumRecordTtl" placeholder="min TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtCacheMinimumRecordTtl" placeholder="min TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (recommended 10)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The minimum TTL value that a record can have in the cache. Set a value to make sure that the records with TTL value less than that stays in cache for a minimum duration.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The minimum TTL value that a
+                                                                record can have in the cache. Set a value to make sure
+                                                                that the records with TTL value less than that stays in
+                                                                cache for a minimum duration.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtCacheMaximumRecordTtl" class="col-sm-3 control-label">Cache Maximum TTL</label>
+                                                            <label for="txtCacheMaximumRecordTtl"
+                                                                class="col-sm-3 control-label">Cache Maximum TTL</label>
                                                             <div class="col-sm-8">
-                                                                <input type="text" class="form-control" id="txtCacheMaximumRecordTtl" placeholder="max TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtCacheMaximumRecordTtl" placeholder="max TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (default 604800/1w)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum TTL value that a record can have in the cache. Set a lower value to allow the records to expire early.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum TTL value that a
+                                                                record can have in the cache. Set a lower value to allow
+                                                                the records to expire early.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtCacheNegativeRecordTtl" class="col-sm-3 control-label">Cache Negative TTL</label>
+                                                            <label for="txtCacheNegativeRecordTtl"
+                                                                class="col-sm-3 control-label">Cache Negative
+                                                                TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtCacheNegativeRecordTtl" placeholder="-ve TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtCacheNegativeRecordTtl" placeholder="-ve TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (recommended 300/5m)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The negative TTL value to use when there is no SOA MINIMUM value available. Negative caching stores records in cache for <code>NXDOMAIN</code> and <code>NODATA</code> responses.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The negative TTL value to use
+                                                                when there is no SOA MINIMUM value available. Negative
+                                                                caching stores records in cache for
+                                                                <code>NXDOMAIN</code> and <code>NODATA</code> responses.
+                                                            </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtCacheFailureRecordTtl" class="col-sm-3 control-label">Cache Failure TTL</label>
+                                                            <label for="txtCacheFailureRecordTtl"
+                                                                class="col-sm-3 control-label">Cache Failure TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtCacheFailureRecordTtl" placeholder="fail TTL" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtCacheFailureRecordTtl" placeholder="fail TTL"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (recommended 10)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The failure TTL value to be used for caching failure responses. This allows storing failure record in cache and prevent frequent recursive resolution requests to the name servers that are responding with <code>ServerFailure</code> or failing to respond.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The failure TTL value to be
+                                                                used for caching failure responses. This allows storing
+                                                                failure record in cache and prevent frequent recursive
+                                                                resolution requests to the name servers that are
+                                                                responding with <code>ServerFailure</code> or failing to
+                                                                respond.</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtCachePrefetchEligibility" class="col-sm-3 control-label">Prefetch Eligibility</label>
+                                                            <label for="txtCachePrefetchEligibility"
+                                                                class="col-sm-3 control-label">Prefetch
+                                                                Eligibility</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtCachePrefetchEligibility" placeholder="eligibility" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtCachePrefetchEligibility"
+                                                                    placeholder="eligibility"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (recommended 2)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The minimum initial TTL value of a record needed to be eligible for prefetching.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The minimum initial TTL value
+                                                                of a record needed to be eligible for prefetching.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtCachePrefetchTrigger" class="col-sm-3 control-label">Prefetch Trigger</label>
+                                                            <label for="txtCachePrefetchTrigger"
+                                                                class="col-sm-3 control-label">Prefetch Trigger</label>
                                                             <div class="col-sm-8">
-                                                                <input type="number" class="form-control" id="txtCachePrefetchTrigger" placeholder="trigger" style="width: 100px; display: inline;">
-                                                                <span>seconds (recommended 9; set 0 to disable prefetching &amp; auto prefetching)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtCachePrefetchTrigger" placeholder="trigger"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>seconds (recommended 9; set 0 to disable
+                                                                    prefetching &amp; auto prefetching)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">A record with TTL value less than trigger value will initiate prefetch operation immediately for itself.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">A record with TTL value less
+                                                                than trigger value will initiate prefetch operation
+                                                                immediately for itself.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtCachePrefetchSampleIntervalInMinutes" class="col-sm-3 control-label">Auto Prefetch Sampling</label>
+                                                            <label for="txtCachePrefetchSampleIntervalInMinutes"
+                                                                class="col-sm-3 control-label">Auto Prefetch
+                                                                Sampling</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtCachePrefetchSampleIntervalInMinutes" placeholder="interval" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtCachePrefetchSampleIntervalInMinutes"
+                                                                    placeholder="interval"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>minutes (valid range 1-60; default 5)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The interval to sample eligible domain names from last hour stats for auto prefetch.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The interval to sample
+                                                                eligible domain names from last hour stats for auto
+                                                                prefetch.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtCachePrefetchSampleEligibilityHitsPerHour" class="col-sm-3 control-label">Auto Prefetch Eligibility</label>
+                                                            <label for="txtCachePrefetchSampleEligibilityHitsPerHour"
+                                                                class="col-sm-3 control-label">Auto Prefetch
+                                                                Eligibility</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtCachePrefetchSampleEligibilityHitsPerHour" placeholder="hits" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtCachePrefetchSampleEligibilityHitsPerHour"
+                                                                    placeholder="hits"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>hits/hour (default 30)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Minimum required hits per hour for a domain name to be eligible for auto prefetch.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Minimum required hits per hour
+                                                                for a domain name to be eligible for auto prefetch.
+                                                            </div>
                                                         </div>
 
-                                                        <div>The DNS Server cache auto prefetch option can keep eligible domain names from last hour stats "hot" in cache. Auto prefetch eligibility value can be decided by keeping an eye on the hits shown for last hour on the dashboard. Experiment with auto prefetch sampling interval and eligibility to get best results.</div>
+                                                        <div>The DNS Server cache auto prefetch option can keep eligible
+                                                            domain names from last hour stats "hot" in cache. Auto
+                                                            prefetch eligibility value can be decided by keeping an eye
+                                                            on the hits shown for last hour on the dashboard. Experiment
+                                                            with auto prefetch sampling interval and eligibility to get
+                                                            best results.</div>
                                                     </div>
                                                 </div>
 
@@ -1872,39 +3018,64 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableBlocking" type="checkbox"> Enable Blocking
+                                                                        <input id="chkEnableBlocking" type="checkbox">
+                                                                        Enable Blocking
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Sets the DNS server to block domain names using Blocked Zone and Block List Zone.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">Sets
+                                                                    the DNS server to block domain names using Blocked
+                                                                    Zone and Block List Zone.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkAllowTxtBlockingReport" type="checkbox"> Allow TXT Blocking Report
+                                                                        <input id="chkAllowTxtBlockingReport"
+                                                                            type="checkbox"> Allow TXT Blocking Report
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Specifies if the DNS Server should respond with TXT records containing a blocked domain report for TXT type requests. This option also enables Extended DNS Error blocked domain report in response for requests that support EDNS.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Specifies if the DNS Server should respond with TXT
+                                                                    records containing a blocked domain report for TXT
+                                                                    type requests. This option also enables Extended DNS
+                                                                    Error blocked domain report in response for requests
+                                                                    that support EDNS.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Blocking Temporarily Disabled Till</label>
+                                                            <label class="col-sm-3 control-label">Blocking Temporarily
+                                                                Disabled Till</label>
                                                             <div class="col-sm-8">
-                                                                <div id="lblTemporaryDisableBlockingTill" style="padding-top: 7px;"></div>
+                                                                <div id="lblTemporaryDisableBlockingTill"
+                                                                    style="padding-top: 7px;"></div>
                                                                 <div style="padding-top: 12px;">
-                                                                    <input type="number" class="form-control" id="txtTemporaryDisableBlockingMinutes" placeholder="minutes" style="width: 100px; display: inline;">
+                                                                    <input type="number" class="form-control"
+                                                                        id="txtTemporaryDisableBlockingMinutes"
+                                                                        placeholder="minutes"
+                                                                        style="width: 100px; display: inline;">
                                                                     <span>minutes</span>
                                                                 </div>
                                                                 <div style="padding-top: 6px;">
-                                                                    <button id="btnTemporaryDisableBlockingNow" type="button" class="btn btn-default" style="padding: 2px 0; width: 170px;" data-loading-text="Disabling..." onclick="temporaryDisableBlockingNow();">Temporary Disable Now</button>
+                                                                    <button id="btnTemporaryDisableBlockingNow"
+                                                                        type="button" class="btn btn-default"
+                                                                        style="padding: 2px 0; width: 170px;"
+                                                                        data-loading-text="Disabling..."
+                                                                        onclick="temporaryDisableBlockingNow();">Temporary
+                                                                        Disable Now</button>
                                                                 </div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtBlockingBypassList" class="col-sm-3 control-label">Blocking Bypass List</label>
+                                                            <label for="txtBlockingBypassList"
+                                                                class="col-sm-3 control-label">Blocking Bypass
+                                                                List</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtBlockingBypassList" class="form-control" rows="3" spellcheck="false"></textarea>
-                                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses one below another that are allowed to bypass blocking.</div>
+                                                                <textarea id="txtBlockingBypassList"
+                                                                    class="form-control" rows="3"
+                                                                    spellcheck="false"></textarea>
+                                                                <div style="padding-top: 5px;">Enter IP addresses or
+                                                                    network addresses one below another that are allowed
+                                                                    to bypass blocking.</div>
                                                             </div>
                                                         </div>
 
@@ -1913,103 +3084,182 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <div class="col-sm-8">
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdBlockingType" id="rdBlockingTypeAnyAddress" value="AnyAddress">
+                                                                        <input type="radio" name="rdBlockingType"
+                                                                            id="rdBlockingTypeAnyAddress"
+                                                                            value="AnyAddress">
                                                                         ANY Address
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses <code>0.0.0.0</code> and <code>::</code> IP addresses for blocked domain names.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Uses <code>0.0.0.0</code> and <code>::</code> IP
+                                                                        addresses for blocked domain names.</div>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdBlockingType" id="rdBlockingTypeNxDomain" value="NxDomain">
+                                                                        <input type="radio" name="rdBlockingType"
+                                                                            id="rdBlockingTypeNxDomain"
+                                                                            value="NxDomain">
                                                                         NX Domain (recommended)
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses <code>NX Domain</code> response for blocked domain names.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Uses <code>NX Domain</code> response for blocked
+                                                                        domain names.</div>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdBlockingType" id="rdBlockingTypeCustomAddress" value="CustomAddress">
+                                                                        <input type="radio" name="rdBlockingType"
+                                                                            id="rdBlockingTypeCustomAddress"
+                                                                            value="CustomAddress">
                                                                         Custom Address
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses custom IP addresses provided below for blocked domain names.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Uses custom IP addresses provided below for
+                                                                        blocked domain names.</div>
                                                                 </div>
                                                             </div>
 
-                                                            <div class="col-sm-offset-3 col-sm-6" style="margin-bottom: 10px;">
-                                                                <label for="txtCustomBlockingAddresses" class="control-label">Custom Blocking Addresses (IP Address)</label>
-                                                                <textarea id="txtCustomBlockingAddresses" class="form-control" rows="3" spellcheck="false"></textarea>
+                                                            <div class="col-sm-offset-3 col-sm-6"
+                                                                style="margin-bottom: 10px;">
+                                                                <label for="txtCustomBlockingAddresses"
+                                                                    class="control-label">Custom Blocking Addresses (IP
+                                                                    Address)</label>
+                                                                <textarea id="txtCustomBlockingAddresses"
+                                                                    class="form-control" rows="3"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtBlockingAnswerTtl" class="col-sm-3 control-label">Blocking Answer TTL</label>
+                                                            <label for="txtBlockingAnswerTtl"
+                                                                class="col-sm-3 control-label">Blocking Answer
+                                                                TTL</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtBlockingAnswerTtl" placeholder="ttl" style="width: 100px; display: inline;">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtBlockingAnswerTtl" placeholder="ttl"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>seconds (default 30)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The TTL value in seconds that must be used for the records in a blocking response. This is the TTL value that the client will use to cache the blocking response.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The TTL value in seconds that
+                                                                must be used for the records in a blocking response.
+                                                                This is the TTL value that the client will use to cache
+                                                                the blocking response.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtBlockListUrls" class="col-sm-3 control-label">Allow / Block List URLs</label>
+                                                            <label for="txtBlockListUrls"
+                                                                class="col-sm-3 control-label">Allow / Block List
+                                                                URLs</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtBlockListUrls" class="form-control" rows="7" spellcheck="false"></textarea>
+                                                                <textarea id="txtBlockListUrls" class="form-control"
+                                                                    rows="7" spellcheck="false"></textarea>
 
-                                                                <label for="optQuickBlockList" class="control-label">Quick Add</label>
-                                                                <select id="optQuickBlockList" class="form-control" style="width: 100%;">
+                                                                <label for="optQuickBlockList"
+                                                                    class="control-label">Quick Add</label>
+                                                                <select id="optQuickBlockList" class="form-control"
+                                                                    style="width: 100%;">
                                                                 </select>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">
-                                                                <p>Enter block list URL one below another in the above text field or use the Quick Add list to add known block list URLs.</p>
-                                                                <p>For directly using block list files saved on this server, use the <code>file://</code> formatted URL path. For example, on Linux the URL should look like <code>file:///home/folder/myblocklist.txt</code> and on Windows it should look like <code>file:///c:/folder/myblocklist.txt</code>.</p>
-                                                                <p>Add <code>!</code> character at the start of an URL to make it an allow list URL. This option must not be used with allow lists that use <code>Adblock Plus</code> format.</p>
-                                                                <p>Begin a line with <code>#</code> character at the start to use it for comments.</p>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">
+                                                                <p>Enter block list URL one below another in the above
+                                                                    text field or use the Quick Add list to add known
+                                                                    block list URLs.</p>
+                                                                <p>For directly using block list files saved on this
+                                                                    server, use the <code>file://</code> formatted URL
+                                                                    path. For example, on Linux the URL should look like
+                                                                    <code>file:///home/folder/myblocklist.txt</code> and
+                                                                    on Windows it should look like
+                                                                    <code>file:///c:/folder/myblocklist.txt</code>.
+                                                                </p>
+                                                                <p>Add <code>!</code> character at the start of an URL
+                                                                    to make it an allow list URL. This option must not
+                                                                    be used with allow lists that use
+                                                                    <code>Adblock Plus</code> format.
+                                                                </p>
+                                                                <p>Begin a line with <code>#</code> character at the
+                                                                    start to use it for comments.</p>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtBlockListUpdateIntervalHours" class="col-sm-3 control-label">Block List Update Interval</label>
+                                                            <label for="txtBlockListUpdateIntervalHours"
+                                                                class="col-sm-3 control-label">Block List Update
+                                                                Interval</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtBlockListUpdateIntervalHours" placeholder="hours" style="width: 100px; display: inline;">
-                                                                <span>hours (valid range 0-168; default 24; set 0 to disable)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtBlockListUpdateIntervalHours"
+                                                                    placeholder="hours"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>hours (valid range 0-168; default 24; set 0 to
+                                                                    disable)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The interval in hours to automatically download and update the block lists.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The interval in hours to
+                                                                automatically download and update the block lists.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="lblBlockListNextUpdatedOn" class="col-sm-3 control-label">Block List Next Update On</label>
+                                                            <label for="lblBlockListNextUpdatedOn"
+                                                                class="col-sm-3 control-label">Block List Next Update
+                                                                On</label>
                                                             <div class="col-sm-6" style="padding-top: 5px;">
-                                                                <span id="lblBlockListNextUpdatedOn" style="margin-right: 15px;"></span>
-                                                                <button id="btnUpdateBlockListsNow" type="button" class="btn btn-default" style="padding: 2px 0; width: 100px;" data-loading-text="Updating..." onclick="forceUpdateBlockLists();">Update Now</button>
+                                                                <span id="lblBlockListNextUpdatedOn"
+                                                                    style="margin-right: 15px;"></span>
+                                                                <button id="btnUpdateBlockListsNow" type="button"
+                                                                    class="btn btn-default"
+                                                                    style="padding: 2px 0; width: 100px;"
+                                                                    data-loading-text="Updating..."
+                                                                    onclick="forceUpdateBlockLists();">Update
+                                                                    Now</button>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Click the 'Update Now' button to reset the next update schedule and force download and update of the block lists.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Click the 'Update Now' button
+                                                                to reset the next update schedule and force download and
+                                                                update of the block lists.</div>
                                                         </div>
 
-                                                        <div style="margin-top: 10px;">Note! DNS Server will use the data returned by the block list URLs to update the block list zone automatically. The expected file format is standard <code>hosts</code> file format, plain text file containing list of domains to block, wildcard block list file format, or <code>Adblock Plus</code> file format.</div>
-                                                        <div style="margin-top: 10px;">Note! To customize the Quick Add drop down list, read the instructions given in the <code>www/json/readme.txt</code> file found in the installation folder.</div>
-                                                        <div style="margin-top: 10px;"><a href="https://blog.technitium.com/2018/10/blocking-internet-ads-using-dns-sinkhole.html" target="_blank">Help: Blocking Internet Ads Using DNS Sinkhole</a></div>
+                                                        <div style="margin-top: 10px;">Note! DNS Server will use the
+                                                            data returned by the block list URLs to update the block
+                                                            list zone automatically. The expected file format is
+                                                            standard <code>hosts</code> file format, plain text file
+                                                            containing list of domains to block, wildcard block list
+                                                            file format, or <code>Adblock Plus</code> file format.</div>
+                                                        <div style="margin-top: 10px;">Note! To customize the Quick Add
+                                                            drop down list, read the instructions given in the
+                                                            <code>www/json/readme.txt</code> file found in the
+                                                            installation folder.
+                                                        </div>
+                                                        <div style="margin-top: 10px;"><a
+                                                                href="https://blog.technitium.com/2018/10/blocking-internet-ads-using-dns-sinkhole.html"
+                                                                target="_blank">Help: Blocking Internet Ads Using DNS
+                                                                Sinkhole</a></div>
                                                     </div>
                                                 </div>
 
-                                                <div id="settingsTabPaneProxyForwarders" role="tabpanel" class="tab-pane">
+                                                <div id="settingsTabPaneProxyForwarders" role="tabpanel"
+                                                    class="tab-pane">
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
                                                             <label class="col-sm-3 control-label">Network Proxy</label>
                                                             <div class="col-sm-6">
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdProxyType" id="rdProxyTypeNone" value="None" checked>
+                                                                        <input type="radio" name="rdProxyType"
+                                                                            id="rdProxyTypeNone" value="None" checked>
                                                                         No Proxy (default)
                                                                     </label>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdProxyType" id="rdProxyTypeHttp" value="Http">
+                                                                        <input type="radio" name="rdProxyType"
+                                                                            id="rdProxyTypeHttp" value="Http">
                                                                         HTTP Proxy
                                                                     </label>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdProxyType" id="rdProxyTypeSocks5" value="Socks5">
+                                                                        <input type="radio" name="rdProxyType"
+                                                                            id="rdProxyTypeSocks5" value="Socks5">
                                                                         SOCKS5 Proxy
                                                                     </label>
                                                                 </div>
@@ -2017,142 +3267,234 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtProxyAddress" class="col-sm-3 control-label">Proxy Server Address</label>
+                                                            <label for="txtProxyAddress"
+                                                                class="col-sm-3 control-label">Proxy Server
+                                                                Address</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtProxyAddress" placeholder="domain name or IP address" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtProxyAddress"
+                                                                    placeholder="domain name or IP address"
+                                                                    maxlength="255">
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtProxyPort" class="col-sm-3 control-label">Proxy Server Port</label>
+                                                            <label for="txtProxyPort"
+                                                                class="col-sm-3 control-label">Proxy Server Port</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtProxyPort" placeholder="port" style="width: 100px;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtProxyPort" placeholder="port"
+                                                                    style="width: 100px;">
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtProxyUsername" class="col-sm-3 control-label">Username</label>
+                                                            <label for="txtProxyUsername"
+                                                                class="col-sm-3 control-label">Username</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtProxyUsername" placeholder="username" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtProxyUsername" placeholder="username"
+                                                                    maxlength="255">
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtProxyPassword" class="col-sm-3 control-label">Password</label>
+                                                            <label for="txtProxyPassword"
+                                                                class="col-sm-3 control-label">Password</label>
                                                             <div class="col-sm-6">
-                                                                <input type="password" class="form-control" id="txtProxyPassword" placeholder="password" maxlength="255">
+                                                                <input type="password" class="form-control"
+                                                                    id="txtProxyPassword" placeholder="password"
+                                                                    maxlength="255">
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtProxyBypassList" class="col-sm-3 control-label">Proxy Bypass List</label>
+                                                            <label for="txtProxyBypassList"
+                                                                class="col-sm-3 control-label">Proxy Bypass List</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtProxyBypassList" class="form-control" rows="5" spellcheck="false"></textarea>
+                                                                <textarea id="txtProxyBypassList" class="form-control"
+                                                                    rows="5" spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Enter IP addresses, network addresses or domain names to never proxy.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Enter IP addresses, network
+                                                                addresses or domain names to never proxy.</div>
                                                         </div>
 
-                                                        <div style="margin-top: 10px;">Note! When proxy server is configured, DNS Server will use it for all outbound network requests.</div>
+                                                        <div style="margin-top: 10px;">Note! When proxy server is
+                                                            configured, DNS Server will use it for all outbound network
+                                                            requests.</div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtForwarders" class="col-sm-3 control-label">Forwarders</label>
+                                                            <label for="txtForwarders"
+                                                                class="col-sm-3 control-label">Forwarders</label>
                                                             <div class="col-sm-6">
-                                                                <textarea id="txtForwarders" class="form-control" rows="3" spellcheck="false"></textarea>
+                                                                <textarea id="txtForwarders" class="form-control"
+                                                                    rows="3" spellcheck="false"></textarea>
 
-                                                                <label for="optQuickForwarders" class="control-label">Quick Select</label>
-                                                                <select id="optQuickForwarders" class="form-control" style="width: 100%;">
+                                                                <label for="optQuickForwarders"
+                                                                    class="control-label">Quick Select</label>
+                                                                <select id="optQuickForwarders" class="form-control"
+                                                                    style="width: 100%;">
                                                                 </select>
 
-                                                                <div style="padding-top: 5px;">Enter forwarder DNS Server IP addresses or URLs one below another in above text field or use the Quick Select list to select desired forwarder.</div>
+                                                                <div style="padding-top: 5px;">Enter forwarder DNS
+                                                                    Server IP addresses or URLs one below another in
+                                                                    above text field or use the Quick Select list to
+                                                                    select desired forwarder.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Forwarder Protocol</label>
+                                                            <label class="col-sm-3 control-label">Forwarder
+                                                                Protocol</label>
                                                             <div class="col-sm-8">
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdForwarderProtocol" id="rdForwarderProtocolUdp" value="Udp" checked>
+                                                                        <input type="radio" name="rdForwarderProtocol"
+                                                                            id="rdForwarderProtocolUdp" value="Udp"
+                                                                            checked>
                                                                         DNS-over-UDP (default)
                                                                     </label>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdForwarderProtocol" id="rdForwarderProtocolTcp" value="Tcp">
+                                                                        <input type="radio" name="rdForwarderProtocol"
+                                                                            id="rdForwarderProtocolTcp" value="Tcp">
                                                                         DNS-over-TCP
                                                                     </label>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdForwarderProtocol" id="rdForwarderProtocolTls" value="Tls">
+                                                                        <input type="radio" name="rdForwarderProtocol"
+                                                                            id="rdForwarderProtocolTls" value="Tls">
                                                                         DNS-over-TLS
                                                                     </label>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdForwarderProtocol" id="rdForwarderProtocolHttps" value="Https">
+                                                                        <input type="radio" name="rdForwarderProtocol"
+                                                                            id="rdForwarderProtocolHttps" value="Https">
                                                                         DNS-over-HTTPS
                                                                     </label>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdForwarderProtocol" id="rdForwarderProtocolQuic" value="Quic">
+                                                                        <input type="radio" name="rdForwarderProtocol"
+                                                                            id="rdForwarderProtocolQuic" value="Quic">
                                                                         DNS-over-QUIC
                                                                     </label>
                                                                 </div>
 
-                                                                <div style="padding-top: 5px;">Select a protocol that this DNS server must use to query the forwarders specified above.</div>
+                                                                <div style="padding-top: 5px;">Select a protocol that
+                                                                    this DNS server must use to query the forwarders
+                                                                    specified above.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Concurrent Forwarding</label>
+                                                            <label class="col-sm-3 control-label">Concurrent
+                                                                Forwarding</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableConcurrentForwarding" type="checkbox"> Enable Concurrent Forwarding
+                                                                        <input id="chkEnableConcurrentForwarding"
+                                                                            type="checkbox"> Enable Concurrent
+                                                                        Forwarding
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to allow querying two or more forwarders concurrently instead of sequentially querying them in their given order. The DNS server will automatically select forwarders (based on their average latency) to query and use the fastest response it receives from any of them. If none of the selected forwarders respond in time, the DNS server will similarly select forwarders from the remaining ones and queries them till all are tried before giving up.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to allow querying two or more
+                                                                    forwarders concurrently instead of sequentially
+                                                                    querying them in their given order. The DNS server
+                                                                    will automatically select forwarders (based on their
+                                                                    average latency) to query and use the fastest
+                                                                    response it receives from any of them. If none of
+                                                                    the selected forwarders respond in time, the DNS
+                                                                    server will similarly select forwarders from the
+                                                                    remaining ones and queries them till all are tried
+                                                                    before giving up.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtForwarderConcurrency" class="col-sm-3 control-label">Forwarder Concurrency</label>
+                                                            <label for="txtForwarderConcurrency"
+                                                                class="col-sm-3 control-label">Forwarder
+                                                                Concurrency</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtForwarderConcurrency" placeholder="count" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtForwarderConcurrency" placeholder="count"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(valid range 1-10; default 2)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The number of concurrent requests that must be sent when Concurrent Forwarding is enabled for resolving a domain name.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The number of concurrent
+                                                                requests that must be sent when Concurrent Forwarding is
+                                                                enabled for resolving a domain name.</div>
                                                         </div>
 
-                                                        <div style="margin-top: 10px;">Note! Forwarders are upstream DNS servers which this DNS Server must use to resolve domain names. If no forwarders are configured then the DNS server will use preconfigured ROOT HINTS to perform recursive resolution to resolve domain names.</div>
-                                                        <div style="margin-top: 10px;">Note! The <code>https</code> URL scheme supports only DNS-over-HTTPS/2 and DNS-over-HTTPS/1.1 protocols. For DNS-over-HTTPS/3, use <code>h3</code> URL scheme instead of <code>https</code> but note that there wont be any protocol fallback if the connection attempt fails.</div>
-                                                        <div style="margin-top: 10px;">Note! The DNS server uses Epsilon-Greedy machine learning algorithm and will automatically learn which of the forwarders are answering faster without errors and will use those forwarders most of the time.</div>
-                                                        <div style="margin-top: 10px;">Note! To customize the Quick Select drop down list, read the instructions given in the <code>www/json/readme.txt</code> file found in the installation folder.</div>
-                                                        <div style="margin-top: 10px;"><a href="https://blog.technitium.com/2018/06/configuring-dns-server-for-privacy.html" target="_blank">Help: Configuring DNS Server For Privacy & Security</a></div>
-                                                        <div style="margin-top: 10px;"><a href="https://blog.technitium.com/2023/02/configuring-dns-over-quic-and-https3.html" target="_blank">Help: Configuring DNS-over-QUIC and HTTPS/3 For Technitium DNS Server</a></div>
+                                                        <div style="margin-top: 10px;">Note! Forwarders are upstream DNS
+                                                            servers which this DNS Server must use to resolve domain
+                                                            names. If no forwarders are configured then the DNS server
+                                                            will use preconfigured ROOT HINTS to perform recursive
+                                                            resolution to resolve domain names.</div>
+                                                        <div style="margin-top: 10px;">Note! The <code>https</code> URL
+                                                            scheme supports only DNS-over-HTTPS/2 and DNS-over-HTTPS/1.1
+                                                            protocols. For DNS-over-HTTPS/3, use <code>h3</code> URL
+                                                            scheme instead of <code>https</code> but note that there
+                                                            wont be any protocol fallback if the connection attempt
+                                                            fails.</div>
+                                                        <div style="margin-top: 10px;">Note! The DNS server uses
+                                                            Epsilon-Greedy machine learning algorithm and will
+                                                            automatically learn which of the forwarders are answering
+                                                            faster without errors and will use those forwarders most of
+                                                            the time.</div>
+                                                        <div style="margin-top: 10px;">Note! To customize the Quick
+                                                            Select drop down list, read the instructions given in the
+                                                            <code>www/json/readme.txt</code> file found in the
+                                                            installation folder.
+                                                        </div>
+                                                        <div style="margin-top: 10px;"><a
+                                                                href="https://blog.technitium.com/2018/06/configuring-dns-server-for-privacy.html"
+                                                                target="_blank">Help: Configuring DNS Server For Privacy
+                                                                & Security</a></div>
+                                                        <div style="margin-top: 10px;"><a
+                                                                href="https://blog.technitium.com/2023/02/configuring-dns-over-quic-and-https3.html"
+                                                                target="_blank">Help: Configuring DNS-over-QUIC and
+                                                                HTTPS/3 For Technitium DNS Server</a></div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtForwarderRetries" class="col-sm-3 control-label">Forwarder Retries</label>
+                                                            <label for="txtForwarderRetries"
+                                                                class="col-sm-3 control-label">Forwarder Retries</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtForwarderRetries" placeholder="retries" style="width: 100px; display: inline;">
+                                                                <input type="number" class="form-control"
+                                                                    id="txtForwarderRetries" placeholder="retries"
+                                                                    style="width: 100px; display: inline;">
                                                                 <span>(valid range 1-10; default 3)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The total number of retries the forwarder or conditional forwarder resolver must do per upstream DNS server.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The total number of retries
+                                                                the forwarder or conditional forwarder resolver must do
+                                                                per upstream DNS server.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtForwarderTimeout" class="col-sm-3 control-label">Forwarder Timeout</label>
+                                                            <label for="txtForwarderTimeout"
+                                                                class="col-sm-3 control-label">Forwarder Timeout</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtForwarderTimeout" placeholder="timeout" style="width: 100px; display: inline;">
-                                                                <span>milliseconds (valid range 1000-10000; default 2000)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtForwarderTimeout" placeholder="timeout"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>milliseconds (valid range 1000-10000; default
+                                                                    2000)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The amount of time the forwarder or conditional forwarder resolver must wait between retries.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The amount of time the
+                                                                forwarder or conditional forwarder resolver must wait
+                                                                between retries.</div>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -2160,85 +3502,125 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                 <div id="settingsTabPaneLogging" role="tabpanel" class="tab-pane">
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Enable Logging To</label>
+                                                            <label class="col-sm-3 control-label">Enable Logging
+                                                                To</label>
                                                             <div class="col-sm-8">
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdLoggingType" id="rdLoggingTypeNone" value="None">
+                                                                        <input type="radio" name="rdLoggingType"
+                                                                            id="rdLoggingTypeNone" value="None">
                                                                         None
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Disables all logging including error logs and audit logs.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Disables all logging including error logs and
+                                                                        audit logs.</div>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdLoggingType" id="rdLoggingTypeFile" value="File">
+                                                                        <input type="radio" name="rdLoggingType"
+                                                                            id="rdLoggingTypeFile" value="File">
                                                                         File
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Enables logging errors and audit logs to the log file.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Enables logging errors and audit logs to the log
+                                                                        file.</div>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdLoggingType" id="rdLoggingTypeConsole" value="Console">
+                                                                        <input type="radio" name="rdLoggingType"
+                                                                            id="rdLoggingTypeConsole" value="Console">
                                                                         Console
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Enables logging errors and audit logs to the console.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Enables logging errors and audit logs to the
+                                                                        console.</div>
                                                                 </div>
                                                                 <div class="radio">
                                                                     <label>
-                                                                        <input type="radio" name="rdLoggingType" id="rdLoggingTypeFileAndConsole" value="FileAndConsole">
+                                                                        <input type="radio" name="rdLoggingType"
+                                                                            id="rdLoggingTypeFileAndConsole"
+                                                                            value="FileAndConsole">
                                                                         Both File And Console
                                                                     </label>
-                                                                    <div style="padding-top: 5px; padding-left: 20px;">Enables logging errors and audit logs to both the log file and console.</div>
+                                                                    <div style="padding-top: 5px; padding-left: 20px;">
+                                                                        Enables logging errors and audit logs to both
+                                                                        the log file and console.</div>
                                                                 </div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label class="col-sm-3 control-label">Logging Options</label>
+                                                            <label class="col-sm-3 control-label">Logging
+                                                                Options</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkIgnoreResolverLogs" type="checkbox"> Ignore Resolver Error Logs
+                                                                        <input id="chkIgnoreResolverLogs"
+                                                                            type="checkbox"> Ignore Resolver Error Logs
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to stop logging domain name resolution errors into the log file.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to stop logging domain name
+                                                                    resolution errors into the log file.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkLogQueries" type="checkbox"> Log All Queries
+                                                                        <input id="chkLogQueries" type="checkbox"> Log
+                                                                        All Queries
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to log every query received by this DNS Server and the corresponding response answers into the log file.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to log every query received by
+                                                                    this DNS Server and the corresponding response
+                                                                    answers into the log file.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkUseLocalTime" type="checkbox"> Use Local Time
+                                                                        <input id="chkUseLocalTime" type="checkbox"> Use
+                                                                        Local Time
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to use local time instead of UTC for logging.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to use local time instead of UTC
+                                                                    for logging.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtLogFolderPath" class="col-sm-3 control-label">Log Folder Path</label>
+                                                            <label for="txtLogFolderPath"
+                                                                class="col-sm-3 control-label">Log Folder Path</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtLogFolderPath" placeholder="Log Folder Path On Server" maxlength="255">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtLogFolderPath"
+                                                                    placeholder="Log Folder Path On Server"
+                                                                    maxlength="255">
                                                             </div>
 
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The folder path on the server where the log files should be saved. The path can be relative to the DNS server's config folder.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The folder path on the server
+                                                                where the log files should be saved. The path can be
+                                                                relative to the DNS server's config folder.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtMaxLogFileDays" class="col-sm-3 control-label">Max Log File Days</label>
+                                                            <label for="txtMaxLogFileDays"
+                                                                class="col-sm-3 control-label">Max Log File Days</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtMaxLogFileDays" placeholder="Max Days" style="width: 100px; display: inline;">
-                                                                <span>days (default 365, set 0 to disable auto delete)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtMaxLogFileDays" placeholder="Max Days"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>days (default 365, set 0 to disable auto
+                                                                    delete)</span>
                                                             </div>
 
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Max number of days to keep the log files. Log files older than the specified number of days will be deleted automatically.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Max number of days to keep the
+                                                                log files. Log files older than the specified number of
+                                                                days will be deleted automatically.</div>
                                                         </div>
 
-                                                        <div>Warning! Enabling query logging will significantly increase the log file size and use up disk space.</div>
+                                                        <div>Warning! Enabling query logging will significantly increase
+                                                            the log file size and use up disk space.</div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
@@ -2247,21 +3629,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkEnableInMemoryStats" type="checkbox"> Enable In-Memory Stats
+                                                                        <input id="chkEnableInMemoryStats"
+                                                                            type="checkbox"> Enable In-Memory Stats
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">This option will enable in-memory stats and only Last Hour data will be available on Dashboard. No stats data will be stored on disk.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">This
+                                                                    option will enable in-memory stats and only Last
+                                                                    Hour data will be available on Dashboard. No stats
+                                                                    data will be stored on disk.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtMaxStatFileDays" class="col-sm-3 control-label">Max Stat File Days</label>
+                                                            <label for="txtMaxStatFileDays"
+                                                                class="col-sm-3 control-label">Max Stat File
+                                                                Days</label>
                                                             <div class="col-sm-6">
-                                                                <input type="number" class="form-control" id="txtMaxStatFileDays" placeholder="Max Days" style="width: 100px; display: inline;">
-                                                                <span>days (default 365, set 0 to disable auto delete)</span>
+                                                                <input type="number" class="form-control"
+                                                                    id="txtMaxStatFileDays" placeholder="Max Days"
+                                                                    style="width: 100px; display: inline;">
+                                                                <span>days (default 365, set 0 to disable auto
+                                                                    delete)</span>
                                                             </div>
 
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Max number of days to keep the dashboard stats. Stat files older than the specified number of days will be deleted automatically.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Max number of days to keep the
+                                                                dashboard stats. Stat files older than the specified
+                                                                number of days will be deleted automatically.</div>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -2269,12 +3663,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                             <div class="form-group" style="margin-bottom: 0px;">
                                                 <div class="pull-left">
-                                                    <button type="button" class="btn btn-primary" data-loading-text="Saving..." onclick="saveDnsSettings(this);">Save Settings</button>
-                                                    <button id="btnSettingsFlushCache" type="button" class="btn btn-danger" data-loading-text="Flushing..." onclick="flushDnsCache(this, $('#optSettingsClusterNode').val());" style="margin-left: 6px;">Flush Cache</button>
+                                                    <button type="button" class="btn btn-primary"
+                                                        data-loading-text="Saving..."
+                                                        onclick="saveDnsSettings(this);">Save Settings</button>
+                                                    <button id="btnSettingsFlushCache" type="button"
+                                                        class="btn btn-danger" data-loading-text="Flushing..."
+                                                        onclick="flushDnsCache(this, $('#optSettingsClusterNode').val());"
+                                                        style="margin-left: 6px;">Flush Cache</button>
                                                 </div>
                                                 <div class="pull-right">
-                                                    <button id="btnShowBackupSettingsModal" type="button" class="btn btn-success" onclick="resetBackupSettingsModal();" data-toggle="modal" data-target="#modalBackupSettings">Backup Settings</button>
-                                                    <button id="btnShowRestoreSettingsModal" type="button" class="btn btn-warning" onclick="resetRestoreSettingsModal();" data-toggle="modal" data-target="#modalRestoreSettings" style="margin-left: 6px;">Restore Settings</button>
+                                                    <button id="btnShowBackupSettingsModal" type="button"
+                                                        class="btn btn-success" onclick="resetBackupSettingsModal();"
+                                                        data-toggle="modal" data-target="#modalBackupSettings">Backup
+                                                        Settings</button>
+                                                    <button id="btnShowRestoreSettingsModal" type="button"
+                                                        class="btn btn-warning" onclick="resetRestoreSettingsModal();"
+                                                        data-toggle="modal" data-target="#modalRestoreSettings"
+                                                        style="margin-left: 6px;">Restore Settings</button>
                                                 </div>
                                                 <div class="clearfix"></div>
                                             </div>
@@ -2284,442 +3689,752 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                 </div>
 
-                                <div id="mainPanelTabPaneDhcp" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
+                                <div id="mainPanelTabPaneDhcp" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
 
                                     <ul class="nav nav-tabs" role="tablist">
-                                        <li id="dhcpTabListLeases" role="presentation" class="active"><a href="#dhcpTabPaneLeases" aria-controls="dhcpTabPaneLeases" role="tab" data-toggle="tab" onclick="refreshDhcpLeases();">Leases</a></li>
-                                        <li id="dhcpTabListScopes" role="presentation"><a href="#dhcpTabPaneScopes" aria-controls="dhcpTabPaneScopes" role="tab" data-toggle="tab" onclick="refreshDhcpScopes(true);">Scopes</a></li>
+                                        <li id="dhcpTabListLeases" role="presentation" class="active"><a
+                                                href="#dhcpTabPaneLeases" aria-controls="dhcpTabPaneLeases" role="tab"
+                                                data-toggle="tab" onclick="refreshDhcpLeases();">Leases</a></li>
+                                        <li id="dhcpTabListScopes" role="presentation"><a href="#dhcpTabPaneScopes"
+                                                aria-controls="dhcpTabPaneScopes" role="tab" data-toggle="tab"
+                                                onclick="refreshDhcpScopes(true);">Scopes</a></li>
 
                                         <li class="pull-right">
-                                            <select id="optDhcpClusterNode" class="form-control pull-right cluster-node-dropdown" style="margin-left: 0px;" onchange="refreshDhcpTab();"></select>
+                                            <select id="optDhcpClusterNode"
+                                                class="form-control pull-right cluster-node-dropdown"
+                                                style="margin-left: 0px;" onchange="refreshDhcpTab();"></select>
                                         </li>
                                     </ul>
 
                                     <div class="tab-content">
                                         <div id="dhcpTabPaneLeases" class="tab-pane active">
-                                            <div id="divDhcpLeasesLoader" style="margin-top: 10px; height: 350px;"></div>
+                                            <div id="divDhcpLeasesLoader" style="margin-top: 10px; height: 350px;">
+                                            </div>
 
                                             <div id="divDhcpLeases" style="margin-top: 10px;">
                                                 <table class="table table-hover">
                                                     <thead>
                                                         <tr>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpLeasesBody', 0); return false;">Scope</a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpLeasesBody', 1); return false;">MAC Address</a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpLeasesBody', 2); return false;">IP Address</a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpLeasesBody', 3); return false;"></a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpLeasesBody', 4); return false;">Host Name</a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpLeasesBody', 5); return false;">Lease Obtained</a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpLeasesBody', 6); return false;">Lease Expires</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpLeasesBody', 0); return false;">Scope</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpLeasesBody', 1); return false;">MAC
+                                                                    Address</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpLeasesBody', 2); return false;">IP
+                                                                    Address</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpLeasesBody', 3); return false;"></a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpLeasesBody', 4); return false;">Host
+                                                                    Name</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpLeasesBody', 5); return false;">Lease
+                                                                    Obtained</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpLeasesBody', 6); return false;">Lease
+                                                                    Expires</a></th>
                                                             <th style="width: 36px;"></th>
                                                         </tr>
                                                     </thead>
                                                     <tbody id="tableDhcpLeasesBody">
                                                     </tbody>
                                                     <tfoot id="tableDhcpLeasesFooter">
-                                                        <tr><td><b>Total Leases: 0</b></td></tr>
+                                                        <tr>
+                                                            <td><b>Total Leases: 0</b></td>
+                                                        </tr>
                                                     </tfoot>
                                                 </table>
                                             </div>
                                         </div>
 
                                         <div id="dhcpTabPaneScopes" class="tab-pane">
-                                            <div id="divDhcpViewScopesLoader" style="margin-top: 10px; height: 350px;"></div>
+                                            <div id="divDhcpViewScopesLoader" style="margin-top: 10px; height: 350px;">
+                                            </div>
 
                                             <div id="divDhcpViewScopes" style="margin-top: 10px;">
 
                                                 <div style="float: right; padding: 2px 0px;">
-                                                    <button type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showAddDhcpScope();">Add Scope</button>
+                                                    <button type="button" class="btn btn-primary"
+                                                        style="padding: 2px 0px; width: 100px;"
+                                                        onclick="showAddDhcpScope();">Add Scope</button>
                                                 </div>
                                                 <div style="clear: both;"></div>
 
                                                 <table class="table table-hover">
                                                     <thead>
                                                         <tr>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpScopesBody', 0); return false;">Name</a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpScopesBody', 1); return false;">Scope Range/Subnet Mask</a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpScopesBody', 2); return false;">Network/Broadcast</a></th>
-                                                            <th><a href="#" onclick="sortTable('tableDhcpScopesBody', 3); return false;">Interface</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpScopesBody', 0); return false;">Name</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpScopesBody', 1); return false;">Scope
+                                                                    Range/Subnet Mask</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpScopesBody', 2); return false;">Network/Broadcast</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tableDhcpScopesBody', 3); return false;">Interface</a>
+                                                            </th>
                                                             <th></th>
                                                         </tr>
                                                     </thead>
                                                     <tbody id="tableDhcpScopesBody">
                                                     </tbody>
                                                     <tfoot id="tableDhcpScopesFooter">
-                                                        <tr><td><b>Total Leases: 0</b></td></tr>
+                                                        <tr>
+                                                            <td><b>Total Leases: 0</b></td>
+                                                        </tr>
                                                     </tfoot>
                                                 </table>
 
                                             </div>
 
                                             <div id="divDhcpEditScope" style="display: none;">
-                                                <form style="margin-top: 10px; margin-bottom: 0px;" onsubmit="return false;">
+                                                <form style="margin-top: 10px; margin-bottom: 0px;"
+                                                    onsubmit="return false;">
 
-                                                    <h4 style="padding: 10px 0px;" id="titleDhcpEditScope">Edit Scope</h4>
+                                                    <h4 style="padding: 10px 0px;" id="titleDhcpEditScope">Edit Scope
+                                                    </h4>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeName" class="col-sm-3 control-label">Name</label>
+                                                            <label for="txtDhcpScopeName"
+                                                                class="col-sm-3 control-label">Name</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeName" data-name="" placeholder="Scope Name">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeName" data-name=""
+                                                                    placeholder="Scope Name">
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeStartingAddress" class="col-sm-3 control-label">Starting Address</label>
+                                                            <label for="txtDhcpScopeStartingAddress"
+                                                                class="col-sm-3 control-label">Starting Address</label>
                                                             <div class="col-sm-3">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeStartingAddress" placeholder="Starting Address">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeStartingAddress"
+                                                                    placeholder="Starting Address">
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeEndingAddress" class="col-sm-3 control-label">Ending Address</label>
+                                                            <label for="txtDhcpScopeEndingAddress"
+                                                                class="col-sm-3 control-label">Ending Address</label>
                                                             <div class="col-sm-3">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeEndingAddress" placeholder="Ending Address">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeEndingAddress"
+                                                                    placeholder="Ending Address">
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeSubnetMask" class="col-sm-3 control-label">Subnet Mask</label>
+                                                            <label for="txtDhcpScopeSubnetMask"
+                                                                class="col-sm-3 control-label">Subnet Mask</label>
                                                             <div class="col-sm-3">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeSubnetMask" placeholder="Subnet Mask">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeSubnetMask"
+                                                                    placeholder="Subnet Mask">
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeLeaseTimeDays" class="col-sm-3 control-label">Lease Time</label>
+                                                            <label for="txtDhcpScopeLeaseTimeDays"
+                                                                class="col-sm-3 control-label">Lease Time</label>
                                                             <div class="col-sm-7">
-                                                                <label for="txtDhcpScopeLeaseTimeDays" class="control-label">Days</label>
-                                                                <input type="number" class="form-control" style="display: inline; width: 80px; margin-right: 15px;" id="txtDhcpScopeLeaseTimeDays" placeholder="Days">
+                                                                <label for="txtDhcpScopeLeaseTimeDays"
+                                                                    class="control-label">Days</label>
+                                                                <input type="number" class="form-control"
+                                                                    style="display: inline; width: 80px; margin-right: 15px;"
+                                                                    id="txtDhcpScopeLeaseTimeDays" placeholder="Days">
 
-                                                                <label for="txtDhcpScopeLeaseTimeHours" class="control-label">Hours</label>
-                                                                <input type="number" class="form-control" style="display: inline; width: 80px; margin-right: 15px;" id="txtDhcpScopeLeaseTimeHours" placeholder="Hrs">
+                                                                <label for="txtDhcpScopeLeaseTimeHours"
+                                                                    class="control-label">Hours</label>
+                                                                <input type="number" class="form-control"
+                                                                    style="display: inline; width: 80px; margin-right: 15px;"
+                                                                    id="txtDhcpScopeLeaseTimeHours" placeholder="Hrs">
 
-                                                                <label for="txtDhcpScopeLeaseTimeMinutes" class="control-label">Minutes</label>
-                                                                <input type="number" class="form-control" style="display: inline; width: 80px; margin-right: 15px;" id="txtDhcpScopeLeaseTimeMinutes" placeholder="Mins">
+                                                                <label for="txtDhcpScopeLeaseTimeMinutes"
+                                                                    class="control-label">Minutes</label>
+                                                                <input type="number" class="form-control"
+                                                                    style="display: inline; width: 80px; margin-right: 15px;"
+                                                                    id="txtDhcpScopeLeaseTimeMinutes"
+                                                                    placeholder="Mins">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The duration for which the clients should be leased the IP address.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The duration for which the
+                                                                clients should be leased the IP address.</div>
                                                         </div>
 
                                                         <div class="form-group" style="margin-bottom: 0px;">
-                                                            <label for="txtDhcpScopeOfferDelayTime" class="col-sm-3 control-label">Offer Delay Time</label>
+                                                            <label for="txtDhcpScopeOfferDelayTime"
+                                                                class="col-sm-3 control-label">Offer Delay Time</label>
                                                             <div class="col-sm-3">
-                                                                <input type="number" class="form-control" style="width: 80px; display: inline;" id="txtDhcpScopeOfferDelayTime" placeholder="Delay">
+                                                                <input type="number" class="form-control"
+                                                                    style="width: 80px; display: inline;"
+                                                                    id="txtDhcpScopeOfferDelayTime" placeholder="Delay">
                                                                 <span>milliseconds</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The time duration that the DHCP server delays sending an DHCPOFFER message.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The time duration that the
+                                                                DHCP server delays sending an DHCPOFFER message.</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="chkDhcpScopePingCheckEnabled" class="col-sm-3 control-label">Ping Check</label>
+                                                            <label for="chkDhcpScopePingCheckEnabled"
+                                                                class="col-sm-3 control-label">Ping Check</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkDhcpScopePingCheckEnabled" type="checkbox"> Enable Ping Check
+                                                                        <input id="chkDhcpScopePingCheckEnabled"
+                                                                            type="checkbox"> Enable Ping Check
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to allow DHCP server to find out if an IP address is already in use to prevent IP address conflict when some of the devices on the network have manually configured IP addresses.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to allow DHCP server to find out
+                                                                    if an IP address is already in use to prevent IP
+                                                                    address conflict when some of the devices on the
+                                                                    network have manually configured IP addresses.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopePingCheckTimeout" class="col-sm-3 control-label">Ping Check Timeout</label>
+                                                            <label for="txtDhcpScopePingCheckTimeout"
+                                                                class="col-sm-3 control-label">Ping Check
+                                                                Timeout</label>
                                                             <div class="col-sm-4">
-                                                                <input type="number" class="form-control" style="width: 100px; display: inline;" id="txtDhcpScopePingCheckTimeout" placeholder="timeout">
+                                                                <input type="number" class="form-control"
+                                                                    style="width: 100px; display: inline;"
+                                                                    id="txtDhcpScopePingCheckTimeout"
+                                                                    placeholder="timeout">
                                                                 <span>milliseconds (default 1000)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The timeout interval to wait for an ping reply.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The timeout interval to wait
+                                                                for an ping reply.</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopePingCheckRetries" class="col-sm-3 control-label">Ping Check Retries</label>
+                                                            <label for="txtDhcpScopePingCheckRetries"
+                                                                class="col-sm-3 control-label">Ping Check
+                                                                Retries</label>
                                                             <div class="col-sm-3">
-                                                                <input type="number" class="form-control" style="width: 100px; display: inline;" id="txtDhcpScopePingCheckRetries" placeholder="retry">
+                                                                <input type="number" class="form-control"
+                                                                    style="width: 100px; display: inline;"
+                                                                    id="txtDhcpScopePingCheckRetries"
+                                                                    placeholder="retry">
                                                                 <span>(default 2)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The maximum number of ping requests to try.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The maximum number of ping
+                                                                requests to try.</div>
                                                         </div>
 
-                                                        <div style="padding-top: 5px;">Warning! Ping check would work as expected only when you make sure that all the client devices with manually configured IP addresses on the network respond to a ping request. Devices running Microsoft Windows by default drop ping requests at host firewall and will cause this ping check to fail to detect in use IP addresses. It is recommended to not rely on this option and instead make sure that you exclude a range of addresses using Exclusions and manually assign IP addresses to your devices only in the excluded range.</div>
+                                                        <div style="padding-top: 5px;">Warning! Ping check would work as
+                                                            expected only when you make sure that all the client devices
+                                                            with manually configured IP addresses on the network respond
+                                                            to a ping request. Devices running Microsoft Windows by
+                                                            default drop ping requests at host firewall and will cause
+                                                            this ping check to fail to detect in use IP addresses. It is
+                                                            recommended to not rely on this option and instead make sure
+                                                            that you exclude a range of addresses using Exclusions and
+                                                            manually assign IP addresses to your devices only in the
+                                                            excluded range.</div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeDomainName" class="col-sm-3 control-label">Domain Name</label>
+                                                            <label for="txtDhcpScopeDomainName"
+                                                                class="col-sm-3 control-label">Domain Name</label>
                                                             <div class="col-sm-6">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeDomainName" placeholder="Domain Name">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeDomainName"
+                                                                    placeholder="Domain Name">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The domain name for this network to allow assigning a fully qualified domain name to clients. Use a domain name that you own or that is not in common use like 'home' or 'lan' so that you don't block out an existing domain name. (Option 15)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The domain name for this
+                                                                network to allow assigning a fully qualified domain name
+                                                                to clients. Use a domain name that you own or that is
+                                                                not in common use like 'home' or 'lan' so that you don't
+                                                                block out an existing domain name. (Option 15)</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeDomainSearchStrings" class="col-sm-3 control-label">Domain Search List</label>
+                                                            <label for="txtDhcpScopeDomainSearchStrings"
+                                                                class="col-sm-3 control-label">Domain Search
+                                                                List</label>
                                                             <div class="col-sm-3">
-                                                                <textarea id="txtDhcpScopeDomainSearchStrings" class="form-control" rows="2" spellcheck="false"></textarea>
+                                                                <textarea id="txtDhcpScopeDomainSearchStrings"
+                                                                    class="form-control" rows="2"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The list of domain names that the clients can use as a suffix when searching a domain name. (Option 119)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The list of domain names that
+                                                                the clients can use as a suffix when searching a domain
+                                                                name. (Option 119)</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="chkDhcpScopeDnsUpdates" class="col-sm-3 control-label">DNS Updates</label>
+                                                            <label for="chkDhcpScopeDnsUpdates"
+                                                                class="col-sm-3 control-label">DNS Updates</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkDhcpScopeDnsUpdates" type="checkbox"> Enable DNS Updates
+                                                                        <input id="chkDhcpScopeDnsUpdates"
+                                                                            type="checkbox"> Enable DNS Updates
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to allow the DHCP server to automatically update forward and reverse DNS entries for clients.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to allow the DHCP server to
+                                                                    automatically update forward and reverse DNS entries
+                                                                    for clients.</div>
 
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkDnsOverwriteForDynamicLease" type="checkbox"> Enable DNS Overwrite For Dynamic Lease
+                                                                        <input id="chkDnsOverwriteForDynamicLease"
+                                                                            type="checkbox"> Enable DNS Overwrite For
+                                                                        Dynamic Lease
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to allow the DHCP server to overwrite existing DNS A record matching the client domain name for dynamic leases.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to allow the DHCP server to
+                                                                    overwrite existing DNS A record matching the client
+                                                                    domain name for dynamic leases.</div>
                                                             </div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeDnsTtl" class="col-sm-3 control-label">DNS TTL</label>
+                                                            <label for="txtDhcpScopeDnsTtl"
+                                                                class="col-sm-3 control-label">DNS TTL</label>
                                                             <div class="col-sm-8">
-                                                                <input type="text" class="form-control" style="width: 100px; display: inline;" id="txtDhcpScopeDnsTtl" placeholder="DNS TTL">
+                                                                <input type="text" class="form-control"
+                                                                    style="width: 100px; display: inline;"
+                                                                    id="txtDhcpScopeDnsTtl" placeholder="DNS TTL">
                                                                 <span>seconds (default 900/15m)</span>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The TTL value of the DNS records updated for the above provided domain name.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The TTL value of the DNS
+                                                                records updated for the above provided domain name.
+                                                            </div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeRouterAddress" class="col-sm-3 control-label">Router Address</label>
+                                                            <label for="txtDhcpScopeRouterAddress"
+                                                                class="col-sm-3 control-label">Router Address</label>
                                                             <div class="col-sm-3">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeRouterAddress" placeholder="Router Address">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeRouterAddress"
+                                                                    placeholder="Router Address">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The default gateway IP address to be used by the clients. (Option 3)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The default gateway IP address
+                                                                to be used by the clients. (Option 3)</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeDnsServers" class="col-sm-3 control-label">DNS Servers</label>
+                                                            <label for="txtDhcpScopeDnsServers"
+                                                                class="col-sm-3 control-label">DNS Servers</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkUseThisDnsServer" type="checkbox" onclick="$('#txtDhcpScopeDnsServers').prop('disabled', $(this).prop('checked'));"> Use This DNS Server
+                                                                        <input id="chkUseThisDnsServer" type="checkbox"
+                                                                            onclick="$('#txtDhcpScopeDnsServers').prop('disabled', $(this).prop('checked'));">
+                                                                        Use This DNS Server
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px; margin-bottom: 10px;">Enable this option to automatically use this DNS Server.</div>
+                                                                <div
+                                                                    style="padding-top: 5px; padding-left: 20px; margin-bottom: 10px;">
+                                                                    Enable this option to automatically use this DNS
+                                                                    Server.</div>
                                                             </div>
                                                             <div class="col-sm-offset-3 col-sm-3">
-                                                                <textarea id="txtDhcpScopeDnsServers" class="form-control" rows="2" spellcheck="false"></textarea>
+                                                                <textarea id="txtDhcpScopeDnsServers"
+                                                                    class="form-control" rows="2"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The DNS server IP addresses to be used by the clients. (Option 6)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The DNS server IP addresses to
+                                                                be used by the clients. (Option 6)</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeWinsServers" class="col-sm-3 control-label">WINS Servers</label>
+                                                            <label for="txtDhcpScopeWinsServers"
+                                                                class="col-sm-3 control-label">WINS Servers</label>
                                                             <div class="col-sm-3">
-                                                                <textarea id="txtDhcpScopeWinsServers" class="form-control" rows="2" spellcheck="false"></textarea>
+                                                                <textarea id="txtDhcpScopeWinsServers"
+                                                                    class="form-control" rows="2"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The NBNS/WINS server IP addresses to be used by the clients. (Option 44)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The NBNS/WINS server IP
+                                                                addresses to be used by the clients. (Option 44)</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeNtpServers" class="col-sm-3 control-label">NTP Servers</label>
+                                                            <label for="txtDhcpScopeNtpServers"
+                                                                class="col-sm-3 control-label">NTP Servers</label>
                                                             <div class="col-sm-3">
-                                                                <textarea id="txtDhcpScopeNtpServers" class="form-control" rows="2" spellcheck="false"></textarea>
+                                                                <textarea id="txtDhcpScopeNtpServers"
+                                                                    class="form-control" rows="2"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The Network Time Protocol (NTP) server IP addresses to be used by the clients. (Option 42)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The Network Time Protocol
+                                                                (NTP) server IP addresses to be used by the clients.
+                                                                (Option 42)</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeNtpServerDomainNames" class="col-sm-3 control-label">NTP Server Domain Names</label>
+                                                            <label for="txtDhcpScopeNtpServerDomainNames"
+                                                                class="col-sm-3 control-label">NTP Server Domain
+                                                                Names</label>
                                                             <div class="col-sm-3">
-                                                                <textarea id="txtDhcpScopeNtpServerDomainNames" class="form-control" rows="2" spellcheck="false"></textarea>
+                                                                <textarea id="txtDhcpScopeNtpServerDomainNames"
+                                                                    class="form-control" rows="2"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">Enter NTP server domain names (e.g. pool.ntp.org) above that the DHCP server should automatically resolve and pass the resolved IP addresses to clients as NTP server option. (Option 42)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">Enter NTP server domain names
+                                                                (e.g. pool.ntp.org) above that the DHCP server should
+                                                                automatically resolve and pass the resolved IP addresses
+                                                                to clients as NTP server option. (Option 42)</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group" style="margin-bottom: 0px;">
-                                                            <label for="tableDhcpScopeStaticRoutes" class="col-sm-3 control-label">Static Routes</label>
+                                                            <label for="tableDhcpScopeStaticRoutes"
+                                                                class="col-sm-3 control-label">Static Routes</label>
                                                             <div class="col-sm-7">
-                                                                <table class="table table-hover" style="margin-bottom: 0px;">
+                                                                <table class="table table-hover"
+                                                                    style="margin-bottom: 0px;">
                                                                     <thead>
                                                                         <tr>
                                                                             <th>Destination</th>
                                                                             <th>Subnet Mask</th>
                                                                             <th>Router</th>
-                                                                            <th style="width: 84px;"><button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addDhcpScopeStaticRouteRow('', '', '');">Add</button></th>
+                                                                            <th style="width: 84px;"><button
+                                                                                    type="button"
+                                                                                    class="btn btn-default"
+                                                                                    style="padding: 0px 20px;"
+                                                                                    onclick="addDhcpScopeStaticRouteRow('', '', '');">Add</button>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody id="tableDhcpScopeStaticRoutes"></tbody>
                                                                 </table>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The static routes to be used by the clients for accessing specified destination networks. (Option 121)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The static routes to be used
+                                                                by the clients for accessing specified destination
+                                                                networks. (Option 121)</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeServerAddress" class="col-sm-3 control-label">Bootstrap Server Address</label>
+                                                            <label for="txtDhcpScopeServerAddress"
+                                                                class="col-sm-3 control-label">Bootstrap Server
+                                                                Address</label>
                                                             <div class="col-sm-3">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeServerAddress" placeholder="Bootstrap Server Address">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeServerAddress"
+                                                                    placeholder="Bootstrap Server Address">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The IP address of next server (TFTP) to use in bootstrap by the clients. If not specified, the DHCP server's IP address is used. (siaddr)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The IP address of next server
+                                                                (TFTP) to use in bootstrap by the clients. If not
+                                                                specified, the DHCP server's IP address is used.
+                                                                (siaddr)</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeServerHostName" class="col-sm-3 control-label">Bootstrap Server Host Name</label>
+                                                            <label for="txtDhcpScopeServerHostName"
+                                                                class="col-sm-3 control-label">Bootstrap Server Host
+                                                                Name</label>
                                                             <div class="col-sm-3">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeServerHostName" placeholder="Bootstrap Server Host Name">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeServerHostName"
+                                                                    placeholder="Bootstrap Server Host Name">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The optional bootstrap server host name to be used by the clients to identify the TFTP server. (sname/Option 66)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The optional bootstrap server
+                                                                host name to be used by the clients to identify the TFTP
+                                                                server. (sname/Option 66)</div>
                                                         </div>
 
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeBootFileName" class="col-sm-3 control-label">Boot File Name</label>
+                                                            <label for="txtDhcpScopeBootFileName"
+                                                                class="col-sm-3 control-label">Boot File Name</label>
                                                             <div class="col-sm-3">
-                                                                <input type="text" class="form-control" id="txtDhcpScopeBootFileName" placeholder="Boot File Name">
+                                                                <input type="text" class="form-control"
+                                                                    id="txtDhcpScopeBootFileName"
+                                                                    placeholder="Boot File Name">
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The boot file name stored on the bootstrap TFTP server to be used by the clients. (file/Option 67)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The boot file name stored on
+                                                                the bootstrap TFTP server to be used by the clients.
+                                                                (file/Option 67)</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group" style="margin-bottom: 0px;">
-                                                            <label for="tableDhcpScopeVendorInfo" class="col-sm-3 control-label">Vendor Specific Information</label>
+                                                            <label for="tableDhcpScopeVendorInfo"
+                                                                class="col-sm-3 control-label">Vendor Specific
+                                                                Information</label>
                                                             <div class="col-sm-9">
-                                                                <table class="table table-hover" style="margin-bottom: 0px;">
+                                                                <table class="table table-hover"
+                                                                    style="margin-bottom: 0px;">
                                                                     <thead>
                                                                         <tr>
                                                                             <th>Vendor Class Identifier</th>
                                                                             <th>Vendor Specific Information</th>
-                                                                            <th style="width: 84px;"><button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addDhcpScopeVendorInfoRow('', '');">Add</button></th>
+                                                                            <th style="width: 84px;"><button
+                                                                                    type="button"
+                                                                                    class="btn btn-default"
+                                                                                    style="padding: 0px 20px;"
+                                                                                    onclick="addDhcpScopeVendorInfoRow('', '');">Add</button>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody id="tableDhcpScopeVendorInfo"></tbody>
                                                                 </table>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The Vendor Specific Information (option 43) to be sent to the clients that match the Vendor Class Identifier (option 60) in the request. The Vendor Class Identifier can be empty string to match any identifier, or matched exactly, or match a substring, for example <code>substring(vendor-class-identifier,0,9)=="PXEClient"</code>. The Vendor Specific Information must be either a colon (:) separated hex string or a normal hex string, for example <code>06:01:03:0A:04:00:50:58:45:09:14:00:00:11:52:61:73:70:62:65:72:72:79:20:50:69:20:42:6F:6F:74:FF</code> OR <code>0601030A0400505845091400001152617370626572727920506920426F6F74FF</code>.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The Vendor Specific
+                                                                Information (option 43) to be sent to the clients that
+                                                                match the Vendor Class Identifier (option 60) in the
+                                                                request. The Vendor Class Identifier can be empty string
+                                                                to match any identifier, or matched exactly, or match a
+                                                                substring, for example
+                                                                <code>substring(vendor-class-identifier,0,9)=="PXEClient"</code>.
+                                                                The Vendor Specific Information must be either a colon
+                                                                (:) separated hex string or a normal hex string, for
+                                                                example
+                                                                <code>06:01:03:0A:04:00:50:58:45:09:14:00:00:11:52:61:73:70:62:65:72:72:79:20:50:69:20:42:6F:6F:74:FF</code>
+                                                                OR
+                                                                <code>0601030A0400505845091400001152617370626572727920506920426F6F74FF</code>.
+                                                            </div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeCAPWAPApIpAddresses" class="col-sm-3 control-label">CAPWAP Access Controller Addresses</label>
+                                                            <label for="txtDhcpScopeCAPWAPApIpAddresses"
+                                                                class="col-sm-3 control-label">CAPWAP Access Controller
+                                                                Addresses</label>
                                                             <div class="col-sm-3">
-                                                                <textarea id="txtDhcpScopeCAPWAPApIpAddresses" class="form-control" rows="2" spellcheck="false"></textarea>
+                                                                <textarea id="txtDhcpScopeCAPWAPApIpAddresses"
+                                                                    class="form-control" rows="2"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The Control And Provisioning of Wireless Access Points (CAPWAP) Access Controller IP addresses to be used by Wireless Termination Points to discover the Access Controllers to which it is to connect. (Option 138)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The Control And Provisioning
+                                                                of Wireless Access Points (CAPWAP) Access Controller IP
+                                                                addresses to be used by Wireless Termination Points to
+                                                                discover the Access Controllers to which it is to
+                                                                connect. (Option 138)</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="txtDhcpScopeTftpServerAddresses" class="col-sm-3 control-label">TFTP Server Addresses</label>
+                                                            <label for="txtDhcpScopeTftpServerAddresses"
+                                                                class="col-sm-3 control-label">TFTP Server
+                                                                Addresses</label>
                                                             <div class="col-sm-3">
-                                                                <textarea id="txtDhcpScopeTftpServerAddresses" class="form-control" rows="2" spellcheck="false"></textarea>
+                                                                <textarea id="txtDhcpScopeTftpServerAddresses"
+                                                                    class="form-control" rows="2"
+                                                                    spellcheck="false"></textarea>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The TFTP Server Address or the VoIP Configuration Server Address. (Option 150)</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The TFTP Server Address or the
+                                                                VoIP Configuration Server Address. (Option 150)</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group" style="margin-bottom: 0px;">
-                                                            <label for="tableDhcpScopeGenericOptions" class="col-sm-3 control-label">Generic DHCP Options</label>
+                                                            <label for="tableDhcpScopeGenericOptions"
+                                                                class="col-sm-3 control-label">Generic DHCP
+                                                                Options</label>
                                                             <div class="col-sm-9">
-                                                                <table class="table table-hover" style="margin-bottom: 0px;">
+                                                                <table class="table table-hover"
+                                                                    style="margin-bottom: 0px;">
                                                                     <thead>
                                                                         <tr>
                                                                             <th style="width: 90px;">Code</th>
                                                                             <th>Hex Value</th>
-                                                                            <th style="width: 84px;"><button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addDhcpScopeGenericOptionsRow('', '');">Add</button></th>
+                                                                            <th style="width: 84px;"><button
+                                                                                    type="button"
+                                                                                    class="btn btn-default"
+                                                                                    style="padding: 0px 20px;"
+                                                                                    onclick="addDhcpScopeGenericOptionsRow('', '');">Add</button>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody id="tableDhcpScopeGenericOptions"></tbody>
                                                                 </table>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">This feature allows you to define DHCP options that are not yet directly supported. To add an option, use the DHCP option code defined for it and enter the value in either a colon (:) separated hex string or a normal hex string format, for example <code>C0:A8:01:01</code> OR <code>C0A80101</code>.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">This feature allows you to
+                                                                define DHCP options that are not yet directly supported.
+                                                                To add an option, use the DHCP option code defined for
+                                                                it and enter the value in either a colon (:) separated
+                                                                hex string or a normal hex string format, for example
+                                                                <code>C0:A8:01:01</code> OR <code>C0A80101</code>.
+                                                            </div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="tableDhcpScopeExclusions" class="col-sm-3 control-label">Exclusions</label>
+                                                            <label for="tableDhcpScopeExclusions"
+                                                                class="col-sm-3 control-label">Exclusions</label>
                                                             <div class="col-sm-6">
-                                                                <table class="table table-hover" style="margin-bottom: 0px;">
+                                                                <table class="table table-hover"
+                                                                    style="margin-bottom: 0px;">
                                                                     <thead>
                                                                         <tr>
                                                                             <th>Starting Address</th>
                                                                             <th>Ending Address</th>
-                                                                            <th style="width: 84px;"><button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addDhcpScopeExclusionRow('', '');">Add</button></th>
+                                                                            <th style="width: 84px;"><button
+                                                                                    type="button"
+                                                                                    class="btn btn-default"
+                                                                                    style="padding: 0px 20px;"
+                                                                                    onclick="addDhcpScopeExclusionRow('', '');">Add</button>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody id="tableDhcpScopeExclusions"></tbody>
                                                                 </table>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The IP address range that must be excluded or not assigned dynamically to any client by the DHCP server.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The IP address range that must
+                                                                be excluded or not assigned dynamically to any client by
+                                                                the DHCP server.</div>
                                                         </div>
-                                                        <div style="padding-top: 5px;">Note! Make sure to exclude address ranges if you plan to manually assign IP addresses to some of the devices or to assign reserved leases so that these IP addresses are not dynamically allocated in the first place.</div>
+                                                        <div style="padding-top: 5px;">Note! Make sure to exclude
+                                                            address ranges if you plan to manually assign IP addresses
+                                                            to some of the devices or to assign reserved leases so that
+                                                            these IP addresses are not dynamically allocated in the
+                                                            first place.</div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group">
-                                                            <label for="tableDhcpScopeReservedLeases" class="col-sm-3 control-label">Advanced Options</label>
+                                                            <label for="tableDhcpScopeReservedLeases"
+                                                                class="col-sm-3 control-label">Advanced Options</label>
                                                             <div class="col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkAllowOnlyReservedLeases" type="checkbox"> Allow Only Reserved Lease Allocations
+                                                                        <input id="chkAllowOnlyReservedLeases"
+                                                                            type="checkbox"> Allow Only Reserved Lease
+                                                                        Allocations
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to stop dynamic IP address allocation and allocate only reserved IP addresses.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to stop dynamic IP address
+                                                                    allocation and allocate only reserved IP addresses.
+                                                                </div>
                                                             </div>
 
                                                             <div class="col-sm-offset-3 col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkBlockLocallyAdministeredMacAddresses" type="checkbox"> Block Locally Administered MAC Addresses
+                                                                        <input
+                                                                            id="chkBlockLocallyAdministeredMacAddresses"
+                                                                            type="checkbox"> Block Locally Administered
+                                                                        MAC Addresses
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">Enable this option to stop dynamic IP address allocation for clients with locally administered MAC addresses. MAC address with 0x02 bit set in the first octet indicate a <a href="https://en.wikipedia.org/wiki/MAC_address" target="_blank">locally administered</a> MAC address which usually means that the device is not using its original MAC address.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">
+                                                                    Enable this option to stop dynamic IP address
+                                                                    allocation for clients with locally administered MAC
+                                                                    addresses. MAC address with 0x02 bit set in the
+                                                                    first octet indicate a <a
+                                                                        href="https://en.wikipedia.org/wiki/MAC_address"
+                                                                        target="_blank">locally administered</a> MAC
+                                                                    address which usually means that the device is not
+                                                                    using its original MAC address.</div>
                                                             </div>
 
                                                             <div class="col-sm-offset-3 col-sm-8">
                                                                 <div class="checkbox">
                                                                     <label>
-                                                                        <input id="chkIgnoreClientIdentifierOption" type="checkbox"> Ignore Client Identifier (Option 61)
+                                                                        <input id="chkIgnoreClientIdentifierOption"
+                                                                            type="checkbox"> Ignore Client Identifier
+                                                                        (Option 61)
                                                                     </label>
                                                                 </div>
-                                                                <div style="padding-top: 5px; padding-left: 20px;">This option when enabled will always use the client's MAC address as the identifier to allocate lease instead of the Client Identifier (Option 61) provided by the client in the request. Some Linux distros use a custom Client Identifier instead of the device's MAC Address which can cause issues when the Virtual Machine (VM) in which the OS is installed is cloned causing both the original and cloned clients to get same IP allocated. There can be issues too when the same client changes its Client Identifier and starts getting a different IP address lease. Enabling the Ignore Client Identifier option will fix such issues. Changing this option may cause the existing clients to get a different IP lease on renewal.</div>
+                                                                <div style="padding-top: 5px; padding-left: 20px;">This
+                                                                    option when enabled will always use the client's MAC
+                                                                    address as the identifier to allocate lease instead
+                                                                    of the Client Identifier (Option 61) provided by the
+                                                                    client in the request. Some Linux distros use a
+                                                                    custom Client Identifier instead of the device's MAC
+                                                                    Address which can cause issues when the Virtual
+                                                                    Machine (VM) in which the OS is installed is cloned
+                                                                    causing both the original and cloned clients to get
+                                                                    same IP allocated. There can be issues too when the
+                                                                    same client changes its Client Identifier and starts
+                                                                    getting a different IP address lease. Enabling the
+                                                                    Ignore Client Identifier option will fix such
+                                                                    issues. Changing this option may cause the existing
+                                                                    clients to get a different IP lease on renewal.
+                                                                </div>
                                                             </div>
                                                         </div>
                                                     </div>
 
                                                     <div class="well well-sm form-horizontal">
                                                         <div class="form-group" style="margin-bottom: 0px;">
-                                                            <label for="tableDhcpScopeReservedLeases" class="col-sm-3 control-label">Reserved Leases</label>
+                                                            <label for="tableDhcpScopeReservedLeases"
+                                                                class="col-sm-3 control-label">Reserved Leases</label>
                                                             <div class="col-sm-9">
-                                                                <table class="table table-hover" style="margin-bottom: 0px;">
+                                                                <table class="table table-hover"
+                                                                    style="margin-bottom: 0px;">
                                                                     <thead>
                                                                         <tr>
                                                                             <th>Host Name</th>
                                                                             <th>MAC Address</th>
                                                                             <th>IP Address</th>
                                                                             <th>Comments</th>
-                                                                            <th style="width: 84px;"><button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addDhcpScopeReservedLeaseRow('', '', '', '');">Add</button></th>
+                                                                            <th style="width: 84px;"><button
+                                                                                    type="button"
+                                                                                    class="btn btn-default"
+                                                                                    style="padding: 0px 20px;"
+                                                                                    onclick="addDhcpScopeReservedLeaseRow('', '', '', '');">Add</button>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody id="tableDhcpScopeReservedLeases"></tbody>
                                                                 </table>
                                                             </div>
-                                                            <div class="col-sm-offset-3 col-sm-8" style="padding-top: 5px;">The reserved IP addresses to be assigned to specific clients based on their MAC address. Set a hostname to override the client's hostname.</div>
+                                                            <div class="col-sm-offset-3 col-sm-8"
+                                                                style="padding-top: 5px;">The reserved IP addresses to
+                                                                be assigned to specific clients based on their MAC
+                                                                address. Set a hostname to override the client's
+                                                                hostname.</div>
                                                         </div>
                                                     </div>
 
                                                     <div class="form-group" style="margin-bottom: 0px;">
-                                                        <button type="submit" class="btn btn-primary" style="width: 100px;" id="btnSaveDhcpScope" data-loading-text="Saving..." onclick="saveDhcpScope(); return false;">Save</button>
-                                                        <button type="button" class="btn btn-default" style="width: 100px;" onclick="refreshDhcpScopes();">Cancel</button>
+                                                        <button type="submit" class="btn btn-primary"
+                                                            style="width: 100px;" id="btnSaveDhcpScope"
+                                                            data-loading-text="Saving..."
+                                                            onclick="saveDhcpScope(); return false;">Save</button>
+                                                        <button type="button" class="btn btn-default"
+                                                            style="width: 100px;"
+                                                            onclick="refreshDhcpScopes();">Cancel</button>
                                                     </div>
                                                 </form>
                                             </div>
@@ -2727,15 +4442,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     </div>
                                 </div>
 
-                                <div id="mainPanelTabPaneAdmin" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
+                                <div id="mainPanelTabPaneAdmin" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
 
                                     <div>
                                         <ul class="nav nav-tabs" role="tablist">
-                                            <li id="adminTabListSessions" role="presentation" class="active"><a href="#adminTabPaneSessions" aria-controls="adminTabPaneSessions" role="tab" data-toggle="tab" onclick="refreshAdminSessions();">Sessions</a></li>
-                                            <li id="adminTabListUsers" role="presentation"><a href="#adminTabPaneUsers" aria-controls="adminTabPaneUsers" role="tab" data-toggle="tab" onclick="refreshAdminUsers();">Users</a></li>
-                                            <li id="adminTabListGroups" role="presentation"><a href="#adminTabPaneGroups" aria-controls="adminTabPaneGroups" role="tab" data-toggle="tab" onclick="refreshAdminGroups();">Groups</a></li>
-                                            <li id="adminTabListPermissions" role="presentation"><a href="#adminTabPanePermissions" aria-controls="adminTabPanePermissions" role="tab" data-toggle="tab" onclick="refreshAdminPermissions();">Permissions</a></li>
-                                            <li id="adminTabListCluster" role="presentation"><a href="#adminTabPaneCluster" aria-controls="adminTabPaneCluster" role="tab" data-toggle="tab" onclick="refreshAdminCluster();">Cluster</a></li>
+                                            <li id="adminTabListSessions" role="presentation" class="active"><a
+                                                    href="#adminTabPaneSessions" aria-controls="adminTabPaneSessions"
+                                                    role="tab" data-toggle="tab"
+                                                    onclick="refreshAdminSessions();">Sessions</a></li>
+                                            <li id="adminTabListUsers" role="presentation"><a href="#adminTabPaneUsers"
+                                                    aria-controls="adminTabPaneUsers" role="tab" data-toggle="tab"
+                                                    onclick="refreshAdminUsers();">Users</a></li>
+                                            <li id="adminTabListGroups" role="presentation"><a
+                                                    href="#adminTabPaneGroups" aria-controls="adminTabPaneGroups"
+                                                    role="tab" data-toggle="tab"
+                                                    onclick="refreshAdminGroups();">Groups</a></li>
+                                            <li id="adminTabListPermissions" role="presentation"><a
+                                                    href="#adminTabPanePermissions"
+                                                    aria-controls="adminTabPanePermissions" role="tab" data-toggle="tab"
+                                                    onclick="refreshAdminPermissions();">Permissions</a></li>
+                                            <li id="adminTabListCluster" role="presentation"><a
+                                                    href="#adminTabPaneCluster" aria-controls="adminTabPaneCluster"
+                                                    role="tab" data-toggle="tab"
+                                                    onclick="refreshAdminCluster();">Cluster</a></li>
                                         </ul>
 
                                         <div class="clearfix"></div>
@@ -2744,12 +4474,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     <div class="tab-content">
 
                                         <div id="adminTabPaneSessions" class="tab-pane active">
-                                            <div id="divAdminSessionsLoader" style="margin-top: 10px; height: 350px;"></div>
+                                            <div id="divAdminSessionsLoader" style="margin-top: 10px; height: 350px;">
+                                            </div>
 
                                             <div id="divAdminSessionsView" style="margin-top: 10px;">
                                                 <div class="form-inline pull-right" style="padding: 2px 0px;">
-                                                    <button id="btnAdminSessionsCreateToken" type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showCreateApiTokenModal();">Create Token</button>
-                                                    <select id="optAdminSessionsClusterNode" class="form-control cluster-node-dropdown" onchange="refreshAdminSessions();"></select>
+                                                    <button id="btnAdminSessionsCreateToken" type="button"
+                                                        class="btn btn-primary" style="padding: 2px 0px; width: 100px;"
+                                                        onclick="showCreateApiTokenModal();">Create Token</button>
+                                                    <select id="optAdminSessionsClusterNode"
+                                                        class="form-control cluster-node-dropdown"
+                                                        onchange="refreshAdminSessions();"></select>
                                                 </div>
 
                                                 <div style="clear: both;"></div>
@@ -2757,29 +4492,44 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                 <table id="tableAdminSessions" class="table table-hover">
                                                     <thead>
                                                         <tr>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminSessions', 0); return false;">Username</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminSessions', 1); return false;">Session</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminSessions', 2); return false;">Last Seen</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminSessions', 3); return false;">Remote Address</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminSessions', 4); return false;">User Agent</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminSessions', 0); return false;">Username</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminSessions', 1); return false;">Session</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminSessions', 2); return false;">Last
+                                                                    Seen</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminSessions', 3); return false;">Remote
+                                                                    Address</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminSessions', 4); return false;">User
+                                                                    Agent</a></th>
                                                             <th style="width: 36px;"></th>
                                                         </tr>
                                                     </thead>
                                                     <tbody id="tbodyAdminSessions">
                                                     </tbody>
                                                     <tfoot>
-                                                        <tr><th colspan="6" id="tfootAdminSessions"></th></tr>
+                                                        <tr>
+                                                            <th colspan="6" id="tfootAdminSessions"></th>
+                                                        </tr>
                                                     </tfoot>
                                                 </table>
                                             </div>
                                         </div>
 
                                         <div id="adminTabPaneUsers" class="tab-pane">
-                                            <div id="divAdminUsersLoader" style="margin-top: 10px; height: 350px;"></div>
+                                            <div id="divAdminUsersLoader" style="margin-top: 10px; height: 350px;">
+                                            </div>
 
                                             <div id="divAdminUsersView" style="margin-top: 10px;">
                                                 <div style="float: right; padding: 2px 0px;">
-                                                    <button type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showAddUserModal();">Add User</button>
+                                                    <button type="button" class="btn btn-primary"
+                                                        style="padding: 2px 0px; width: 100px;"
+                                                        onclick="showAddUserModal();">Add User</button>
                                                 </div>
 
                                                 <div style="clear: both;"></div>
@@ -2787,30 +4537,47 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                 <table id="tableAdminUsers" class="table table-hover">
                                                     <thead>
                                                         <tr>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminUsers', 0); return false;">Username</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminUsers', 1); return false;">Display Name</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminUsers', 2); return false;">2FA Status</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminUsers', 3); return false;">Status</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminUsers', 4); return false;">Recent Login</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminUsers', 5); return false;">Previous Login</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminUsers', 0); return false;">Username</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminUsers', 1); return false;">Display
+                                                                    Name</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminUsers', 2); return false;">2FA
+                                                                    Status</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminUsers', 3); return false;">Status</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminUsers', 4); return false;">Recent
+                                                                    Login</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminUsers', 5); return false;">Previous
+                                                                    Login</a></th>
                                                             <th style="width: 36px;"></th>
                                                         </tr>
                                                     </thead>
                                                     <tbody id="tbodyAdminUsers">
                                                     </tbody>
                                                     <tfoot>
-                                                        <tr><th colspan="7" id="tfootAdminUsers"></th></tr>
+                                                        <tr>
+                                                            <th colspan="7" id="tfootAdminUsers"></th>
+                                                        </tr>
                                                     </tfoot>
                                                 </table>
                                             </div>
                                         </div>
 
                                         <div id="adminTabPaneGroups" class="tab-pane">
-                                            <div id="divAdminGroupsLoader" style="margin-top: 10px; height: 350px;"></div>
+                                            <div id="divAdminGroupsLoader" style="margin-top: 10px; height: 350px;">
+                                            </div>
 
                                             <div id="divAdminGroupsView" style="margin-top: 10px;">
                                                 <div style="float: right; padding: 2px 0px;">
-                                                    <button type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showAddGroupModal();">Add Group</button>
+                                                    <button type="button" class="btn btn-primary"
+                                                        style="padding: 2px 0px; width: 100px;"
+                                                        onclick="showAddGroupModal();">Add Group</button>
                                                 </div>
 
                                                 <div style="clear: both;"></div>
@@ -2818,28 +4585,37 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                 <table id="tableAdminGroups" class="table table-hover">
                                                     <thead>
                                                         <tr>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminGroups', 0); return false;">Name</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminGroups', 1); return false;">Description</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminGroups', 0); return false;">Name</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminGroups', 1); return false;">Description</a>
+                                                            </th>
                                                             <th style="width: 36px;"></th>
                                                         </tr>
                                                     </thead>
                                                     <tbody id="tbodyAdminGroups">
                                                     </tbody>
                                                     <tfoot>
-                                                        <tr><th colspan="3" id="tfootAdminGroups"></th></tr>
+                                                        <tr>
+                                                            <th colspan="3" id="tfootAdminGroups"></th>
+                                                        </tr>
                                                     </tfoot>
                                                 </table>
                                             </div>
                                         </div>
 
                                         <div id="adminTabPanePermissions" class="tab-pane">
-                                            <div id="divAdminPermissionsLoader" style="margin-top: 10px; height: 350px;"></div>
+                                            <div id="divAdminPermissionsLoader"
+                                                style="margin-top: 10px; height: 350px;"></div>
 
                                             <div id="divAdminPermissionsView" style="margin-top: 10px;">
                                                 <table id="tableAdminPermissions" class="table table-hover">
                                                     <thead>
                                                         <tr>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminPermissions', 0); return false;">Section</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminPermissions', 0); return false;">Section</a>
+                                                            </th>
                                                             <th>User Permissions</th>
                                                             <th>Group Permissions</th>
                                                             <th style="width: 36px;"></th>
@@ -2848,32 +4624,53 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                     <tbody id="tbodyAdminPermissions">
                                                     </tbody>
                                                     <tfoot>
-                                                        <tr><th colspan="4" id="tfootAdminPermissions"></th></tr>
+                                                        <tr>
+                                                            <th colspan="4" id="tfootAdminPermissions"></th>
+                                                        </tr>
                                                     </tfoot>
                                                 </table>
                                             </div>
                                         </div>
 
                                         <div id="adminTabPaneCluster" class="tab-pane">
-                                            <div id="divAdminClusterLoader" style="margin-top: 10px; height: 350px;"></div>
+                                            <div id="divAdminClusterLoader" style="margin-top: 10px; height: 350px;">
+                                            </div>
 
                                             <div id="divAdminClusterView" style="margin-top: 10px;">
                                                 <div class="form-inline pull-right" style="padding: 2px 0px;">
                                                     <div id="divAdminClusterInitialize" class="btn-group">
-                                                        <button type="button" class="btn btn-primary dropdown-toggle" style="padding: 2px 0px; width: 100px;" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                        <button type="button" class="btn btn-primary dropdown-toggle"
+                                                            style="padding: 2px 0px; width: 100px;"
+                                                            data-toggle="dropdown" aria-haspopup="true"
+                                                            aria-expanded="false">
                                                             Initialize <span class="caret"></span>
                                                         </button>
                                                         <ul class="dropdown-menu">
-                                                            <li id="lnkAdminClusterInitializeNewCluster"><a href="#" onclick="showInitializeClusterModal(); return false;">New Cluster</a></li>
-                                                            <li id="lnkAdminClusterInitializeJoinCluster"><a href="#" onclick="showInitializeJoinClusterModal();  return false;">Join Cluster</a></li>
+                                                            <li id="lnkAdminClusterInitializeNewCluster"><a href="#"
+                                                                    onclick="showInitializeClusterModal(); return false;">New
+                                                                    Cluster</a></li>
+                                                            <li id="lnkAdminClusterInitializeJoinCluster"><a href="#"
+                                                                    onclick="showInitializeJoinClusterModal();  return false;">Join
+                                                                    Cluster</a></li>
                                                         </ul>
                                                     </div>
 
-                                                    <button id="btnClusterResync" type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="resyncCluster(this);" data-loading-text="Resyncing...">Resync</button>
-                                                    <button id="btnClusterOptions" type="button" class="btn btn-primary" style="padding: 2px 0px; width: 100px;" onclick="showClusterOptionsModal();">Options</button>
-                                                    <button id="btnClusterLeave" type="button" class="btn btn-warning" style="padding: 2px 0px; width: 100px;" onclick="showLeaveClusterModal();">Leave Cluster</button>
-                                                    <button id="btnClusterDelete" type="button" class="btn btn-danger" style="padding: 2px 0px; width: 100px;" onclick="showDeleteClusterModal();">Delete Cluster</button>
-                                                    <select id="optAdminClusterNode" class="form-control cluster-node-dropdown" onchange="refreshAdminCluster();"></select>
+                                                    <button id="btnClusterResync" type="button" class="btn btn-primary"
+                                                        style="padding: 2px 0px; width: 100px;"
+                                                        onclick="resyncCluster(this);"
+                                                        data-loading-text="Resyncing...">Resync</button>
+                                                    <button id="btnClusterOptions" type="button" class="btn btn-primary"
+                                                        style="padding: 2px 0px; width: 100px;"
+                                                        onclick="showClusterOptionsModal();">Options</button>
+                                                    <button id="btnClusterLeave" type="button" class="btn btn-warning"
+                                                        style="padding: 2px 0px; width: 100px;"
+                                                        onclick="showLeaveClusterModal();">Leave Cluster</button>
+                                                    <button id="btnClusterDelete" type="button" class="btn btn-danger"
+                                                        style="padding: 2px 0px; width: 100px;"
+                                                        onclick="showDeleteClusterModal();">Delete Cluster</button>
+                                                    <select id="optAdminClusterNode"
+                                                        class="form-control cluster-node-dropdown"
+                                                        onchange="refreshAdminCluster();"></select>
                                                 </div>
 
                                                 <div style="clear: both;"></div>
@@ -2881,21 +4678,39 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                 <table id="tableAdminCluster" class="table table-hover">
                                                     <thead>
                                                         <tr>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminCluster', 0); return false;">Node Name</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminCluster', 1); return false;">IP Address</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminCluster', 2); return false;">URL</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminCluster', 3); return false;">Type</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminCluster', 4); return false;">State</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminCluster', 5); return false;">Up Since</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminCluster', 6); return false;">Last Seen</a></th>
-                                                            <th><a href="#" onclick="sortTable('tbodyAdminCluster', 7); return false;">Last Synced</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminCluster', 0); return false;">Node
+                                                                    Name</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminCluster', 1); return false;">IP
+                                                                    Address</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminCluster', 2); return false;">URL</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminCluster', 3); return false;">Type</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminCluster', 4); return false;">State</a>
+                                                            </th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminCluster', 5); return false;">Up
+                                                                    Since</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminCluster', 6); return false;">Last
+                                                                    Seen</a></th>
+                                                            <th><a href="#"
+                                                                    onclick="sortTable('tbodyAdminCluster', 7); return false;">Last
+                                                                    Synced</a></th>
                                                             <th style="width: 36px;"></th>
                                                         </tr>
                                                     </thead>
                                                     <tbody id="tbodyAdminCluster">
                                                     </tbody>
                                                     <tfoot>
-                                                        <tr><th colspan="9" id="tfootAdminCluster"></th></tr>
+                                                        <tr>
+                                                            <th colspan="9" id="tfootAdminCluster"></th>
+                                                        </tr>
                                                     </tfoot>
                                                 </table>
                                             </div>
@@ -2904,19 +4719,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                 </div>
 
-                                <div id="mainPanelTabPaneLogs" role="tabpanel" class="tab-pane" style="padding: 10px 0 0 0;">
+                                <div id="mainPanelTabPaneLogs" role="tabpanel" class="tab-pane"
+                                    style="padding: 10px 0 0 0;">
 
                                     <ul class="nav nav-tabs" role="tablist">
-                                        <li id="logsTabListLogViewer" role="presentation" class="active"><a href="#logsTabPaneLogViewer" aria-controls="logsTabPaneLogViewer" role="tab" data-toggle="tab" onclick="refreshLogFilesList();">View Logs</a></li>
-                                        <li id="logsTabListQueryLogs" role="presentation"><a href="#logsTabPaneQueryLogs" aria-controls="logsTabPaneQueryLogs" role="tab" data-toggle="tab" onclick="refreshQueryLogsTab();">Query Logs</a></li>
+                                        <li id="logsTabListLogViewer" role="presentation" class="active"><a
+                                                href="#logsTabPaneLogViewer" aria-controls="logsTabPaneLogViewer"
+                                                role="tab" data-toggle="tab" onclick="refreshLogFilesList();">View
+                                                Logs</a></li>
+                                        <li id="logsTabListQueryLogs" role="presentation"><a
+                                                href="#logsTabPaneQueryLogs" aria-controls="logsTabPaneQueryLogs"
+                                                role="tab" data-toggle="tab" onclick="refreshQueryLogsTab();">Query
+                                                Logs</a></li>
 
                                         <li class="pull-right">
-                                            <select id="optLogsClusterNode" class="form-control pull-right cluster-node-dropdown" style="margin-left: 0px;" onchange="logsClusterNodeChanged();"></select>
+                                            <select id="optLogsClusterNode"
+                                                class="form-control pull-right cluster-node-dropdown"
+                                                style="margin-left: 0px;" onchange="logsClusterNodeChanged();"></select>
                                         </li>
                                     </ul>
 
                                     <div class="tab-content">
-                                        <div id="logsTabPaneLogViewer" class="tab-pane active" style="padding-top: 15px;">
+                                        <div id="logsTabPaneLogViewer" class="tab-pane active"
+                                            style="padding-top: 15px;">
 
                                             <div class="well well-sm log-list-pane">
                                                 <div id="lstLogFiles" class="logs">
@@ -2926,25 +4751,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                             <div id="divLogViewer" class="log-viewer-pane">
                                                 <div class="panel panel-default">
                                                     <div class="panel-heading" style="height: 36px; padding: 4px 6px;">
-                                                        <div id="txtLogViewerTitle" style="float: left; padding: 4px;">20171012</div>
+                                                        <div id="txtLogViewerTitle" style="float: left; padding: 4px;">
+                                                            20171012</div>
                                                         <div style="float: right;">
-                                                            <button type="button" class="btn btn-default" data-loading-text="Download" onclick="downloadLog();" style="font-size: 12px; padding: 4px 6px;">Download</button>
-                                                            <button id="btnDeleteLog" type="button" class="btn btn-danger" data-loading-text="Delete" onclick="deleteLog();" style="font-size: 12px; padding: 4px 6px;">Delete</button>
+                                                            <button type="button" class="btn btn-default"
+                                                                data-loading-text="Download" onclick="downloadLog();"
+                                                                style="font-size: 12px; padding: 4px 6px;">Download</button>
+                                                            <button id="btnDeleteLog" type="button"
+                                                                class="btn btn-danger" data-loading-text="Delete"
+                                                                onclick="deleteLog();"
+                                                                style="font-size: 12px; padding: 4px 6px;">Delete</button>
                                                         </div>
                                                     </div>
 
                                                     <div class="panel-body">
-                                                        <div id="divLogViewerLoader" style="margin-top: 20px; height: 400px;"></div>
-                                                        <pre id="preLogViewerBody" style="display: none; word-wrap: normal; word-break: normal;"></pre>
+                                                        <div id="divLogViewerLoader"
+                                                            style="margin-top: 20px; height: 400px;"></div>
+                                                        <pre id="preLogViewerBody"
+                                                            style="display: none; word-wrap: normal; word-break: normal;"></pre>
                                                     </div>
                                                 </div>
                                             </div>
 
                                         </div>
 
-                                        <div id="logsTabPaneQueryLogs" class="tab-pane active" style="padding-top: 15px;">
+                                        <div id="logsTabPaneQueryLogs" class="tab-pane active"
+                                            style="padding-top: 15px;">
 
-                                            <form id="frmQueryLogs" class="form-inline well" style="padding-bottom: 6px;">
+                                            <form id="frmQueryLogs" class="form-inline well"
+                                                style="padding-bottom: 6px;">
                                                 <div class="form-group">
                                                     <label for="optQueryLogsAppName">App Name</label>
                                                     <select class="form-control" id="optQueryLogsAppName">
@@ -2959,7 +4794,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                                 <div class="form-group">
                                                     <label for="txtQueryLogPageNumber">Page Number</label>
-                                                    <input id="txtQueryLogPageNumber" type="number" class="form-control" style="width: 120px;" value="1" />
+                                                    <input id="txtQueryLogPageNumber" type="number" class="form-control"
+                                                        style="width: 120px;" value="1" />
                                                 </div>
 
                                                 <div class="form-group">
@@ -2984,17 +4820,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                                 <div class="form-group">
                                                     <label for="txtQueryLogStart">From</label>
-                                                    <input id="txtQueryLogStart" type="datetime-local" class="form-control" />
+                                                    <input id="txtQueryLogStart" type="datetime-local"
+                                                        class="form-control" />
                                                 </div>
 
                                                 <div class="form-group">
                                                     <label for="txtQueryLogEnd">To</label>
-                                                    <input id="txtQueryLogEnd" type="datetime-local" class="form-control" />
+                                                    <input id="txtQueryLogEnd" type="datetime-local"
+                                                        class="form-control" />
                                                 </div>
 
                                                 <div class="form-group">
                                                     <label for="txtQueryLogClientIpAddress">Client IP Address</label>
-                                                    <input id="txtQueryLogClientIpAddress" type="text" class="form-control" style="min-width: 170px;" />
+                                                    <input id="txtQueryLogClientIpAddress" type="text"
+                                                        class="form-control" style="min-width: 170px;" />
                                                 </div>
 
                                                 <div class="form-group">
@@ -3044,7 +4883,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                                 <div class="form-group">
                                                     <label for="txtQueryLogQName">Domain</label>
-                                                    <input id="txtQueryLogQName" type="text" class="form-control" style="min-width: 300px;" />
+                                                    <input id="txtQueryLogQName" type="text" class="form-control"
+                                                        style="min-width: 300px;" />
                                                 </div>
 
                                                 <div class="form-group">
@@ -3066,8 +4906,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                 </div>
 
                                                 <div class="form-group" style="display: block;">
-                                                    <button type="submit" class="btn btn-primary" id="btnQueryLogs" data-loading-text="Querying..." onclick="queryLogs(); return false;" style="margin-right: 6px;">Query</button>
-                                                    <button type="button" class="btn btn-default" onclick="exportQueryLogsCsv(); return false;" style="margin-right: 6px;">Export</button>
+                                                    <button type="submit" class="btn btn-primary" id="btnQueryLogs"
+                                                        data-loading-text="Querying..."
+                                                        onclick="queryLogs(); return false;"
+                                                        style="margin-right: 6px;">Query</button>
+                                                    <button type="button" class="btn btn-default"
+                                                        onclick="exportQueryLogsCsv(); return false;"
+                                                        style="margin-right: 6px;">Export</button>
                                                     <button type="reset" class="btn btn-default">Reset</button>
                                                 </div>
                                             </form>
@@ -3081,10 +4926,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                     </div>
                                                     <div class="pull-right">
                                                         <nav aria-label="Page navigation">
-                                                            <ul id="tableQueryLogsTopPagination" class="pagination" style="margin: 0;">
-                                                                <li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
+                                                            <ul id="tableQueryLogsTopPagination" class="pagination"
+                                                                style="margin: 0;">
+                                                                <li><a href="#" aria-label="Previous"><span
+                                                                            aria-hidden="true">&laquo;</span></a></li>
                                                                 <li><a href="#">1</a></li>
-                                                                <li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+                                                                <li><a href="#" aria-label="Next"><span
+                                                                            aria-hidden="true">&raquo;</span></a></li>
                                                             </ul>
                                                         </nav>
                                                     </div>
@@ -3114,14 +4962,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                             <td colspan="11">
                                                                 <div>
                                                                     <div class="pull-left" style="padding-top: 8px;">
-                                                                        <b id="tableQueryLogsFooterStatus">Found: 0 logs</b>
+                                                                        <b id="tableQueryLogsFooterStatus">Found: 0
+                                                                            logs</b>
                                                                     </div>
                                                                     <div class="pull-right">
                                                                         <nav aria-label="Page navigation">
-                                                                            <ul id="tableQueryLogsFooterPagination" class="pagination" style="margin: 0;">
-                                                                                <li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
+                                                                            <ul id="tableQueryLogsFooterPagination"
+                                                                                class="pagination" style="margin: 0;">
+                                                                                <li><a href="#"
+                                                                                        aria-label="Previous"><span
+                                                                                            aria-hidden="true">&laquo;</span></a>
+                                                                                </li>
                                                                                 <li><a href="#">1</a></li>
-                                                                                <li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+                                                                                <li><a href="#" aria-label="Next"><span
+                                                                                            aria-hidden="true">&raquo;</span></a>
+                                                                                </li>
                                                                             </ul>
                                                                         </nav>
                                                                     </div>
@@ -3138,7 +4993,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                 </div>
 
-                                <div id="mainPanelTabPaneAbout" role="tabpanel" class="tab-pane" style="padding: 40px 0 20px 0;">
+                                <div id="mainPanelTabPaneAbout" role="tabpanel" class="tab-pane"
+                                    style="padding: 40px 0 20px 0;">
 
                                     <div class="about" style="text-align: center;">
                                         <img src="img/logo.png" alt="Technitium Logo" />
@@ -3146,32 +5002,53 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <p>Version <span id="lblAboutVersion"></span></p>
                                         <p>Server up since <span id="lblAboutUptime"></span></p>
                                         <p style="max-width: 800px; margin: 0 auto 10px auto;">
-                                            Copyright (C) 2025  Shreyas Zare (shreyas@technitium.com)<br />
-                                            This program comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it under certain conditions.<br />
+                                            Copyright (C) 2025 Shreyas Zare (shreyas@technitium.com)<br />
+                                            This program comes with ABSOLUTELY NO WARRANTY. This is free software, and
+                                            you are welcome to redistribute it under certain conditions.<br />
                                         </p>
-                                        <p>Source code available under <a href="https://go.technitium.com/?id=24" target="_blank">GNU General Public License v3.0</a> on <a href="https://github.com/TechnitiumSoftware/DnsServer" target="_blank"><i class="fa fa-github"></i>&nbsp;GitHub</a></p>
+                                        <p>Source code available under <a href="https://go.technitium.com/?id=24"
+                                                target="_blank">GNU General Public License v3.0</a> on <a
+                                                href="https://github.com/TechnitiumSoftware/DnsServer"
+                                                target="_blank"><i class="fa fa-github"></i>&nbsp;GitHub</a></p>
 
-                                        <h3 style="margin-top: 40px;"><a href="https://go.technitium.com/?id=23" target="_blank">What's New?</a></h3>
-                                        <p>Read the <a href="https://go.technitium.com/?id=23" target="_blank">change log</a> to know what's new in this release.</p>
+                                        <h3 style="margin-top: 40px;"><a href="https://go.technitium.com/?id=23"
+                                                target="_blank">What's New?</a></h3>
+                                        <p>Read the <a href="https://go.technitium.com/?id=23" target="_blank">change
+                                                log</a> to know what's new in this release.</p>
 
-                                        <h3 style="margin-top: 40px;"><a href="https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md" target="_blank">API Documentation</a></h3>
-                                        <p>The DNS server HTTP API allows any 3rd party app or script to configure the DNS server. The HTTP API is used by this web console and thus all the actions that this web console does can be performed via the API. Read the <a href="https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md" target="_blank">HTTP API documentation</a> for complete details.</p>
+                                        <h3 style="margin-top: 40px;"><a
+                                                href="https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md"
+                                                target="_blank">API Documentation</a></h3>
+                                        <p>The DNS server HTTP API allows any 3rd party app or script to configure the
+                                            DNS server. The HTTP API is used by this web console and thus all the
+                                            actions that this web console does can be performed via the API. Read the <a
+                                                href="https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md"
+                                                target="_blank">HTTP API documentation</a> for complete details.</p>
 
-                                        <h3 style="margin-top: 40px;"><a href="https://go.technitium.com/?id=25" target="_blank">Help Topics</a></h3>
-                                        <p>Read the latest <a href="https://go.technitium.com/?id=25" target="_blank">online help topics</a> which contains the DNS Server user manual and covers frequently asked questions.</p>
+                                        <h3 style="margin-top: 40px;"><a href="https://go.technitium.com/?id=25"
+                                                target="_blank">Help Topics</a></h3>
+                                        <p>Read the latest <a href="https://go.technitium.com/?id=25"
+                                                target="_blank">online help topics</a> which contains the DNS Server
+                                            user manual and covers frequently asked questions.</p>
 
                                         <h3 style="margin-top: 40px;">Support</h3>
-                                        <p>For support, send an email to <a href="mailto:support@technitium.com" target="_blank">support@technitium.com</a>.</p>
+                                        <p>For support, send an email to <a href="mailto:support@technitium.com"
+                                                target="_blank">support@technitium.com</a>.</p>
                                         <p>
-                                            Follow <a href="https://mastodon.social/@technitium" target="_blank">@technitium@mastodon.social</a> on Mastodon.<br />
-                                            Checkout <a href="https://blog.technitium.com/" target="_blank">Technitium Blog</a>.
+                                            Follow <a href="https://mastodon.social/@technitium"
+                                                target="_blank">@technitium@mastodon.social</a> on Mastodon.<br />
+                                            Checkout <a href="https://blog.technitium.com/" target="_blank">Technitium
+                                                Blog</a>.
                                         </p>
                                         <p>
-                                            Join <a href="https://www.reddit.com/r/technitium/" target="_blank">/r/technitium</a> on Reddit.
+                                            Join <a href="https://www.reddit.com/r/technitium/"
+                                                target="_blank">/r/technitium</a> on Reddit.
                                         </p>
 
-                                        <h3 style="margin-top: 40px;"><a href="https://go.technitium.com/?id=35" target="_blank">Donate</a></h3>
-                                        <p>Make a contribution to Technitium and help making new software, updates, and features possible.</p>
+                                        <h3 style="margin-top: 40px;"><a href="https://go.technitium.com/?id=35"
+                                                target="_blank">Donate</a></h3>
+                                        <p>Make a contribution to Technitium and help making new software, updates, and
+                                            features possible.</p>
                                         <p>
                                             <a href="https://go.technitium.com/?id=35" target="_blank">Donate Now!</a>
                                         </p>
@@ -3193,7 +5070,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="modal-dialog" role="document" style="width: 940px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">My Profile</h4>
                     </div>
                     <div class="modal-body">
@@ -3201,18 +5079,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                         <div id="divMyProfileLoader" style="height: 500px;"></div>
 
-                        <div id="divMyProfileViewer" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                        <div id="divMyProfileViewer"
+                            style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                             <div class="form-group">
                                 <label for="txtMyProfileDisplayName" class="col-sm-4 control-label">Display Name</label>
                                 <div class="col-sm-7">
-                                    <input id="txtMyProfileDisplayName" type="text" class="form-control" placeholder="display name" maxlength="255">
+                                    <input id="txtMyProfileDisplayName" type="text" class="form-control"
+                                        placeholder="display name" maxlength="255">
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label for="txtMyProfileUsername" class="col-sm-4 control-label">Username</label>
                                 <div class="col-sm-7">
-                                    <input id="txtMyProfileUsername" type="text" class="form-control" placeholder="username" disabled>
+                                    <input id="txtMyProfileUsername" type="text" class="form-control"
+                                        placeholder="username" disabled>
                                 </div>
                             </div>
 
@@ -3224,9 +5105,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             </div>
 
                             <div class="form-group">
-                                <label for="txtMyProfileSessionTimeout" class="col-sm-4 control-label">Session Timeout</label>
+                                <label for="txtMyProfileSessionTimeout" class="col-sm-4 control-label">Session
+                                    Timeout</label>
                                 <div class="col-sm-7">
-                                    <input id="txtMyProfileSessionTimeout" type="number" class="form-control" placeholder="1800" style="width: 100px; display: inline;">
+                                    <input id="txtMyProfileSessionTimeout" type="number" class="form-control"
+                                        placeholder="1800" style="width: 100px; display: inline;">
                                     <span>seconds (valid range 0-604800; default 1800; set 0 to disable)</span>
                                 </div>
                             </div>
@@ -3237,13 +5120,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     <table class="table table-hover" style="margin-bottom: 0px;">
                                         <thead>
                                             <tr>
-                                                <th><a href="#" onclick="sortTable('tbodyMyProfileMemberOf', 0); return false;">Group</a></th>
+                                                <th><a href="#"
+                                                        onclick="sortTable('tbodyMyProfileMemberOf', 0); return false;">Group</a>
+                                                </th>
                                             </tr>
                                         </thead>
                                         <tbody id="tbodyMyProfileMemberOf">
                                         </tbody>
                                         <tfoot>
-                                            <tr><th colspan="1" id="tfootMyProfileMemberOf"></th></tr>
+                                            <tr>
+                                                <th colspan="1" id="tfootMyProfileMemberOf"></th>
+                                            </tr>
                                         </tfoot>
                                     </table>
                                 </div>
@@ -3251,20 +5138,31 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                             <div class="well well-sm" style="background-color: #fbfbfb;">
                                 <p style="font-size: 16px; font-weight: bold;">Active Sessions</p>
-                                <table id="tableMyProfileActiveSessions" class="table table-hover" style="margin-bottom: 0px;">
+                                <table id="tableMyProfileActiveSessions" class="table table-hover"
+                                    style="margin-bottom: 0px;">
                                     <thead>
                                         <tr>
-                                            <th><a href="#" onclick="sortTable('tbodyMyProfileActiveSessions', 0); return false;">Session</a></th>
-                                            <th><a href="#" onclick="sortTable('tbodyMyProfileActiveSessions', 1); return false;">Last Seen</a></th>
-                                            <th><a href="#" onclick="sortTable('tbodyMyProfileActiveSessions', 2); return false;">Remote Address</a></th>
-                                            <th><a href="#" onclick="sortTable('tbodyMyProfileActiveSessions', 3); return false;">User Agent</a></th>
+                                            <th><a href="#"
+                                                    onclick="sortTable('tbodyMyProfileActiveSessions', 0); return false;">Session</a>
+                                            </th>
+                                            <th><a href="#"
+                                                    onclick="sortTable('tbodyMyProfileActiveSessions', 1); return false;">Last
+                                                    Seen</a></th>
+                                            <th><a href="#"
+                                                    onclick="sortTable('tbodyMyProfileActiveSessions', 2); return false;">Remote
+                                                    Address</a></th>
+                                            <th><a href="#"
+                                                    onclick="sortTable('tbodyMyProfileActiveSessions', 3); return false;">User
+                                                    Agent</a></th>
                                             <th style="width: 36px;"></th>
                                         </tr>
                                     </thead>
                                     <tbody id="tbodyMyProfileActiveSessions">
                                     </tbody>
                                     <tfoot>
-                                        <tr><th colspan="5" id="tfootMyProfileActiveSessions"></th></tr>
+                                        <tr>
+                                            <th colspan="5" id="tfootMyProfileActiveSessions"></th>
+                                        </tr>
                                     </tfoot>
                                 </table>
                             </div>
@@ -3272,7 +5170,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-primary" data-loading-text="Saving..." onclick="saveMyProfile(this); return false;">Save</button>
+                        <button type="submit" class="btn btn-primary" data-loading-text="Saving..."
+                            onclick="saveMyProfile(this); return false;">Save</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -3285,7 +5184,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="modal-dialog" role="document" style="width: 780px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Create API Token</h4>
                     </div>
                     <div class="modal-body">
@@ -3297,7 +5197,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <div class="form-group">
                                 <label for="txtCreateApiTokenUsername" class="col-sm-4 control-label">Username</label>
                                 <div class="col-sm-7">
-                                    <input id="txtCreateApiTokenUsername" type="text" class="form-control" placeholder="username" disabled>
+                                    <input id="txtCreateApiTokenUsername" type="text" class="form-control"
+                                        placeholder="username" disabled>
                                     <select id="optCreateApiTokenUsername" class="form-control"></select>
                                 </div>
                             </div>
@@ -3305,27 +5206,34 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <div class="form-group" id="divCreateApiTokenPassword">
                                 <label for="txtCreateApiTokenPassword" class="col-sm-4 control-label">Password</label>
                                 <div class="col-sm-7">
-                                    <input id="txtCreateApiTokenPassword" type="password" class="form-control" placeholder="password" maxlength="255">
+                                    <input id="txtCreateApiTokenPassword" type="password" class="form-control"
+                                        placeholder="password" maxlength="255">
                                 </div>
                             </div>
 
                             <div class="form-group" id="divCreateApiToken2FAOTP">
                                 <label for="txtCreateApiToken2FATOTP" class="col-sm-4 control-label">Enter OTP</label>
                                 <div class="col-sm-7">
-                                    <input id="txtCreateApiToken2FATOTP" type="text" class="form-control" style="width: 100px;" placeholder="OTP" maxlength="6">
-                                    <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator app.</div>
+                                    <input id="txtCreateApiToken2FATOTP" type="text" class="form-control"
+                                        style="width: 100px;" placeholder="OTP" maxlength="6">
+                                    <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator
+                                        app.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label for="txtCreateApiTokenName" class="col-sm-4 control-label">Token Name</label>
                                 <div class="col-sm-7">
-                                    <input id="txtCreateApiTokenName" type="text" class="form-control" placeholder="token name" maxlength="255">
+                                    <input id="txtCreateApiTokenName" type="text" class="form-control"
+                                        placeholder="token name" maxlength="255">
                                 </div>
                             </div>
 
                             <div>
-                                <b>Warning!</b> The token allows access to API calls with the same privileges as that of the user account. Thus its recommended to create a separate user account with limited permissions as required by the specific task that the token will be used for. The token cannot be used to change the user's password, or update the user profile details.
+                                <b>Warning!</b> The token allows access to API calls with the same privileges as that of
+                                the user account. Thus its recommended to create a separate user account with limited
+                                permissions as required by the specific task that the token will be used for. The token
+                                cannot be used to change the user's password, or update the user profile details.
                             </div>
                         </div>
 
@@ -3340,7 +5248,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <div class="form-group">
                                 <label class="col-sm-3 control-label">Token Name</label>
                                 <div class="col-sm-9">
-                                    <div id="lblCreateApiTokenOutputTokenName" style="padding-top: 7px; word-wrap: anywhere;"></div>
+                                    <div id="lblCreateApiTokenOutputTokenName"
+                                        style="padding-top: 7px; word-wrap: anywhere;"></div>
                                 </div>
                             </div>
 
@@ -3352,12 +5261,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             </div>
 
                             <div>
-                                <b>Warning!</b> The token value above will not be displayed later. You must copy the token value immediately and save it for later use.
+                                <b>Warning!</b> The token value above will not be displayed later. You must copy the
+                                token value immediately and save it for later use.
                             </div>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnCreateApiToken" type="submit" class="btn btn-primary" data-loading-text="Creating...">Create</button>
+                        <button id="btnCreateApiToken" type="submit" class="btn btn-primary"
+                            data-loading-text="Creating...">Create</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -3370,7 +5281,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 id="titleChangePassword" class="modal-title">Change Password</h4>
                     </div>
                     <div class="modal-body">
@@ -3379,41 +5291,51 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <div class="form-group">
                             <label for="txtChangePasswordUsername" class="col-sm-4 control-label">Username</label>
                             <div class="col-sm-7">
-                                <input id="txtChangePasswordUsername" type="text" class="form-control" placeholder="username" disabled>
+                                <input id="txtChangePasswordUsername" type="text" class="form-control"
+                                    placeholder="username" disabled>
                             </div>
                         </div>
 
                         <div id="divChangePasswordCurrentPassword" class="form-group">
-                            <label for="txtChangePasswordCurrentPassword" class="col-sm-4 control-label">Current Password</label>
+                            <label for="txtChangePasswordCurrentPassword" class="col-sm-4 control-label">Current
+                                Password</label>
                             <div class="col-sm-7">
-                                <input id="txtChangePasswordCurrentPassword" type="password" class="form-control" placeholder="current password" maxlength="255">
+                                <input id="txtChangePasswordCurrentPassword" type="password" class="form-control"
+                                    placeholder="current password" maxlength="255">
                             </div>
                         </div>
 
                         <div class="form-group">
-                            <label for="txtChangePasswordNewPassword" class="col-sm-4 control-label">New Password</label>
+                            <label for="txtChangePasswordNewPassword" class="col-sm-4 control-label">New
+                                Password</label>
                             <div class="col-sm-7">
-                                <input id="txtChangePasswordNewPassword" type="password" class="form-control" placeholder="new password" maxlength="255">
+                                <input id="txtChangePasswordNewPassword" type="password" class="form-control"
+                                    placeholder="new password" maxlength="255">
                             </div>
                         </div>
 
                         <div class="form-group">
-                            <label for="txtChangePasswordConfirmPassword" class="col-sm-4 control-label">Confirm Password</label>
+                            <label for="txtChangePasswordConfirmPassword" class="col-sm-4 control-label">Confirm
+                                Password</label>
                             <div class="col-sm-7">
-                                <input id="txtChangePasswordConfirmPassword" type="password" class="form-control" placeholder="confirm password" maxlength="255">
+                                <input id="txtChangePasswordConfirmPassword" type="password" class="form-control"
+                                    placeholder="confirm password" maxlength="255">
                             </div>
                         </div>
 
                         <div id="divChangePassword2FATOTP" class="form-group">
                             <label for="txtChangePassword2FATOTP" class="col-sm-4 control-label">Enter OTP</label>
                             <div class="col-sm-7">
-                                <input id="txtChangePassword2FATOTP" type="text" class="form-control" style="width: 100px;" placeholder="OTP" maxlength="6">
-                                <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator app.</div>
+                                <input id="txtChangePassword2FATOTP" type="text" class="form-control"
+                                    style="width: 100px;" placeholder="OTP" maxlength="6">
+                                <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator app.
+                                </div>
                             </div>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnChangePassword" type="submit" class="btn btn-primary" data-loading-text="Working...">Change</button>
+                        <button id="btnChangePassword" type="submit" class="btn btn-primary"
+                            data-loading-text="Working...">Change</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -3426,7 +5348,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="modal-dialog" role="document" style="width: 750px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Configure Two-factor Authentication (2FA)</h4>
                     </div>
                     <div class="modal-body">
@@ -3436,13 +5359,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                         <div id="divConfigure2FAViewer">
                             <div>
-                                <p>When you enable Two-factor Authentication (2FA) using Time-based One-time Password (TOTP), you will be required to enter a one-time password (OTP) in addition to your password when you login. You will need to use an authenticator app like <b>Microsoft Authenticator</b> or <b>Google Authenticator</b> to generate the OTP when you login.</p>
+                                <p>When you enable Two-factor Authentication (2FA) using Time-based One-time Password
+                                    (TOTP), you will be required to enter a one-time password (OTP) in addition to your
+                                    password when you login. You will need to use an authenticator app like <b>Microsoft
+                                        Authenticator</b> or <b>Google Authenticator</b> to generate the OTP when you
+                                    login.</p>
                             </div>
 
                             <div class="form-group">
                                 <label for="txtConfigure2FAUsername" class="col-sm-3 control-label">Username</label>
                                 <div class="col-sm-7">
-                                    <input id="txtConfigure2FAUsername" type="text" class="form-control" placeholder="username" disabled>
+                                    <input id="txtConfigure2FAUsername" type="text" class="form-control"
+                                        placeholder="username" disabled>
                                 </div>
                             </div>
 
@@ -3458,24 +5386,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     <label class="col-sm-3 control-label">Secret Key</label>
                                     <div class="col-sm-8">
                                         <div id="lblConfigure2FAQRCode" style="margin: -6px 0px 0px -12px;"></div>
-                                        <div id="lblConfigure2FASecret" style="padding: 4px 0; font-weight: bold;"></div>
-                                        <div style="padding-top: 5px;">Scan the QR Code or manually enter the secret key (spaces don't matter) given above in your authenticator app.</div>
+                                        <div id="lblConfigure2FASecret" style="padding: 4px 0; font-weight: bold;">
+                                        </div>
+                                        <div style="padding-top: 5px;">Scan the QR Code or manually enter the secret key
+                                            (spaces don't matter) given above in your authenticator app.</div>
                                     </div>
                                 </div>
 
                                 <div class="form-group">
                                     <label for="txtConfigure2FATOTP" class="col-sm-3 control-label">Enter OTP</label>
                                     <div class="col-sm-8">
-                                        <input id="txtConfigure2FATOTP" type="text" class="form-control" style="width: 100px;" placeholder="OTP" maxlength="6">
-                                        <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator app.</div>
+                                        <input id="txtConfigure2FATOTP" type="text" class="form-control"
+                                            style="width: 100px;" placeholder="OTP" maxlength="6">
+                                        <div style="padding-top: 5px;">Enter the 6-digit code you see in your
+                                            authenticator app.</div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnEnable2FA" type="submit" class="btn btn-primary" data-loading-text="Working..." onclick="enable2FA(this); return false;">Enable</button>
-                        <button id="btnDisable2FA" type="button" class="btn btn-warning" data-loading-text="Working..." onclick="disable2FA(this); return false;">Disable</button>
+                        <button id="btnEnable2FA" type="submit" class="btn btn-primary" data-loading-text="Working..."
+                            onclick="enable2FA(this); return false;">Enable</button>
+                        <button id="btnDisable2FA" type="button" class="btn btn-warning" data-loading-text="Working..."
+                            onclick="disable2FA(this); return false;">Disable</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -3487,7 +5421,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div class="modal-dialog" role="document" style="width: 780px;">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Forgot Password?</h4>
                 </div>
                 <div class="modal-body">
@@ -3495,14 +5430,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <p>If you are an administrator, follow these steps to reset the 'admin' user's password:</p>
                     <ol>
                         <li>Stop the DNS server.</li>
-                        <li>Find the DNS Server config folder and locate the <b>auth.config</b> file. The config folder will be found where the DNS Server is installed on Windows or /etc/dns/ folder on Linux.</li>
+                        <li>Find the DNS Server config folder and locate the <b>auth.config</b> file. The config folder
+                            will be found where the DNS Server is installed on Windows or /etc/dns/ folder on Linux.
+                        </li>
                         <li>Rename the <b>auth.config</b> file as <b>resetadmin.config</b></li>
                         <li>Start the DNS Server.</li>
-                        <li>Just refresh this web page in the web browser to auto login with default credentials and quickly change the password.</li>
+                        <li>Just refresh this web page in the web browser to auto login with default credentials and
+                            quickly change the password.</li>
                     </ol>
-                    <p>On Linux, stop the DNS server by running 'sudo systemctl stop dns' command and 'sudo systemctl start dns' command to start it.</p>
-                    <p>On Windows, press Win+R to open Run, enter 'services.msc', and press enter to open Services console. Find service named 'Technitium DNS Server' and use the Action menu to start/stop it.</p>
-                    <p><b>Note: </b>To reset 'admin' password, you will need file system access on the server running this DNS Server. If the 'admin' user does not exists then it will be created automatically. If the 'admin' user has Two-factor Authentication (2FA) configured then it will be disabled too.</p>
+                    <p>On Linux, stop the DNS server by running 'sudo systemctl stop dns' command and 'sudo systemctl
+                        start dns' command to start it.</p>
+                    <p>On Windows, press Win+R to open Run, enter 'services.msc', and press enter to open Services
+                        console. Find service named 'Technitium DNS Server' and use the Action menu to start/stop it.
+                    </p>
+                    <p><b>Note: </b>To reset 'admin' password, you will need file system access on the server running
+                        this DNS Server. If the 'admin' user does not exists then it will be created automatically. If
+                        the 'admin' user has Two-factor Authentication (2FA) configured then it will be disabled too.
+                    </p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -3515,27 +5459,32 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title" id="lblUpdateAvailableTitle">New Update Available</h4>
                 </div>
                 <div class="modal-body">
                     <div style="margin-bottom: 20px;">
                         <div id="lblUpdateMessage" style="margin-bottom: 10px;"></div>
-                        <a id="lnkUpdateDownload" href="#" target="_blank" style="font-weight: bold; font-size: 18px;">Download Now!</a>
-                        <a id="lnkUpdateInstructions" href="#" target="_blank" style="font-weight: bold; font-size: 18px;">Update Instructions</a>
+                        <a id="lnkUpdateDownload" href="#" target="_blank"
+                            style="font-weight: bold; font-size: 18px;">Download Now!</a>
+                        <a id="lnkUpdateInstructions" href="#" target="_blank"
+                            style="font-weight: bold; font-size: 18px;">Update Instructions</a>
                     </div>
                     <div style="margin-bottom: 10px;">
                         <div style="font-weight: bold;">Update Version: <span id="lblUpdateVersion"></span></div>
                         <div>Current Version: <span id="lblCurrentVersion"></span></div>
                     </div>
                     <div style="margin-bottom: 10px;">
-                        <a id="lnkUpdateChangeLog" href="#" target="_blank" style="font-weight: bold;">Read Change Logs</a>
+                        <a id="lnkUpdateChangeLog" href="#" target="_blank" style="font-weight: bold;">Read Change
+                            Logs</a>
                     </div>
                     <div style="margin-bottom: 10px;">
                         Note! It is highly recommended to Backup Settings before installing the update.
                     </div>
                     <div>
-                        Note! You will have to refresh this web page manually after updating the DNS server so that new UI changes are loaded.
+                        Note! You will have to refresh this web page manually after updating the DNS server so that new
+                        UI changes are loaded.
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -3551,7 +5500,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="modal-dialog" role="document" style="width: 780px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Add Zone</h4>
                     </div>
                     <div class="modal-body">
@@ -3561,7 +5511,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <div class="form-group">
                                 <label for="txtAddZone" class="col-sm-4 control-label">Zone</label>
                                 <div class="col-sm-7">
-                                    <input id="txtAddZone" type="text" class="form-control" placeholder="example.com or 192.168.0.0/24 or 2001:db8::/64" maxlength="255">
+                                    <input id="txtAddZone" type="text" class="form-control"
+                                        placeholder="example.com or 192.168.0.0/24 or 2001:db8::/64" maxlength="255">
                                 </div>
                             </div>
 
@@ -3570,7 +5521,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 <div class="col-sm-7">
                                     <div class="radio">
                                         <label>
-                                            <input type="radio" name="rdAddZoneType" id="rdAddZoneTypePrimary" value="Primary" checked>
+                                            <input type="radio" name="rdAddZoneType" id="rdAddZoneTypePrimary"
+                                                value="Primary" checked>
                                             Primary Zone (default)
                                         </label>
                                     </div>
@@ -3613,7 +5565,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     <div class="radio">
                                         <label>
                                             <input type="radio" name="rdAddZoneType" value="SecondaryRoot">
-                                            Secondary ROOT Zone (<a href="https://datatracker.ietf.org/doc/rfc8806/" target="_blank">RFC 8806</a>)
+                                            Secondary ROOT Zone (<a href="https://datatracker.ietf.org/doc/rfc8806/"
+                                                target="_blank">RFC 8806</a>)
                                         </label>
                                     </div>
                                 </div>
@@ -3624,7 +5577,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 <label class="col-sm-4 control-label">Catalog Zone</label>
                                 <div class="col-sm-7">
                                     <select id="optAddZoneCatalogZoneName" class="form-control"></select>
-                                    <div style="padding-top: 5px;">Select a Catalog zone to register as its member zone.</div>
+                                    <div style="padding-top: 5px;">Select a Catalog zone to register as its member zone.
+                                    </div>
                                 </div>
                             </div>
 
@@ -3634,7 +5588,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 <div class="col-sm-7">
                                     <div class="checkbox" style="margin-bottom: 6px;">
                                         <label>
-                                            <input id="chkAddZoneInitializeForwarder" type="checkbox"> Initialize Forwarder (FWD) Record
+                                            <input id="chkAddZoneInitializeForwarder" type="checkbox"> Initialize
+                                            Forwarder (FWD) Record
                                         </label>
                                     </div>
                                 </div>
@@ -3642,7 +5597,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
                             <div id="divAddZoneImportZoneFile" class="form-group">
-                                <label for="fileAddZoneImportZone" class="col-sm-4 control-label">Import Zone File (Optional)</label>
+                                <label for="fileAddZoneImportZone" class="col-sm-4 control-label">Import Zone File
+                                    (Optional)</label>
                                 <div class="col-sm-7">
                                     <input type="file" class="form-control" id="fileAddZoneImportZone">
                                 </div>
@@ -3654,7 +5610,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 <div class="col-sm-7">
                                     <div class="checkbox">
                                         <label>
-                                            <input id="chkAddZoneUseSoaSerialDateScheme" type="checkbox"> Use SOA Serial Date Scheme
+                                            <input id="chkAddZoneUseSoaSerialDateScheme" type="checkbox"> Use SOA Serial
+                                            Date Scheme
                                         </label>
                                     </div>
                                 </div>
@@ -3662,14 +5619,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
                             <div class="form-group" id="divAddZonePrimaryNameServerAddresses">
-                                <label id="lblAddZonePrimaryNameServerAddresses" for="txtAddZonePrimaryNameServerAddresses" class="col-sm-4 control-label">Primary Name Server Addresses (Optional)</label>
+                                <label id="lblAddZonePrimaryNameServerAddresses"
+                                    for="txtAddZonePrimaryNameServerAddresses" class="col-sm-4 control-label">Primary
+                                    Name Server Addresses (Optional)</label>
                                 <div class="col-sm-7">
-                                    <textarea id="txtAddZonePrimaryNameServerAddresses" class="form-control" rows="4" spellcheck="false" placeholder="192.168.1.1
+                                    <textarea id="txtAddZonePrimaryNameServerAddresses" class="form-control" rows="4"
+                                        spellcheck="false" placeholder="192.168.1.1
 2001:db8::
 ns1.example.com (192.168.1.1)
 ns1.example.com ([2001:db8::])
 "></textarea>
-                                    <div id="divAddZonePrimaryNameServerAddressesInfo" style="padding-top: 5px;">Enter the primary name server addresses to sync the zone from. When unspecified, the SOA Primary Name Server will be resolved and used.</div>
+                                    <div id="divAddZonePrimaryNameServerAddressesInfo" style="padding-top: 5px;">Enter
+                                        the primary name server addresses to sync the zone from. When unspecified, the
+                                        SOA Primary Name Server will be resolved and used.</div>
                                 </div>
                             </div>
 
@@ -3678,7 +5640,8 @@ ns1.example.com ([2001:db8::])
                                 <div class="col-sm-7">
                                     <div class="radio">
                                         <label>
-                                            <input type="radio" name="rdAddZoneZoneTransferProtocol" id="rdAddZoneZoneTransferProtocolTcp" value="Tcp" checked>
+                                            <input type="radio" name="rdAddZoneZoneTransferProtocol"
+                                                id="rdAddZoneZoneTransferProtocolTcp" value="Tcp" checked>
                                             XFR-over-TCP (default)
                                         </label>
                                     </div>
@@ -3699,7 +5662,8 @@ ns1.example.com ([2001:db8::])
 
 
                             <div class="form-group" id="divAddZoneTsigKeyName">
-                                <label for="optAddZoneTsigKeyName" class="col-sm-4 control-label">TSIG Key Name (Optional)</label>
+                                <label for="optAddZoneTsigKeyName" class="col-sm-4 control-label">TSIG Key Name
+                                    (Optional)</label>
                                 <div class="col-sm-7">
                                     <select id="optAddZoneTsigKeyName" class="form-control"></select>
                                 </div>
@@ -3711,9 +5675,14 @@ ns1.example.com ([2001:db8::])
                                 <div class="col-sm-7">
                                     <div class="checkbox">
                                         <label>
-                                            <input id="chkAddZoneValidateZone" type="checkbox"> Use <a href="https://datatracker.ietf.org/doc/rfc8976/" target="_blank">ZONEMD</a> to Validate Zone
+                                            <input id="chkAddZoneValidateZone" type="checkbox"> Use <a
+                                                href="https://datatracker.ietf.org/doc/rfc8976/"
+                                                target="_blank">ZONEMD</a> to Validate Zone
                                         </label>
-                                        <div style="padding-top: 5px; padding-left: 20px;">When enabled, the secondary zone will be validated using the ZONEMD record after every zone transfer. The zone will get disabled if the validation fails. The zone must be DNSSEC signed for the validation to work.</div>
+                                        <div style="padding-top: 5px; padding-left: 20px;">When enabled, the secondary
+                                            zone will be validated using the ZONEMD record after every zone transfer.
+                                            The zone will get disabled if the validation fails. The zone must be DNSSEC
+                                            signed for the validation to work.</div>
                                     </div>
                                 </div>
                             </div>
@@ -3724,7 +5693,8 @@ ns1.example.com ([2001:db8::])
                                 <div class="col-sm-7">
                                     <div class="radio">
                                         <label>
-                                            <input type="radio" name="rdAddZoneForwarderProtocol" id="rdAddZoneForwarderProtocolUdp" value="Udp" checked>
+                                            <input type="radio" name="rdAddZoneForwarderProtocol"
+                                                id="rdAddZoneForwarderProtocolUdp" value="Udp" checked>
                                             DNS-over-UDP (default)
                                         </label>
                                     </div>
@@ -3760,16 +5730,22 @@ ns1.example.com ([2001:db8::])
                                 <div class="col-sm-7">
                                     <div class="checkbox">
                                         <label>
-                                            <input id="chkAddZoneForwarderThisServer" type="checkbox" onclick="updateAddZoneFormForwarderThisServer();"> Use "This Server"
+                                            <input id="chkAddZoneForwarderThisServer" type="checkbox"
+                                                onclick="updateAddZoneFormForwarderThisServer();"> Use "This Server"
                                         </label>
                                     </div>
                                     <div style="padding-top: 5px; padding-left: 20px; padding-bottom: 10px;">
-                                        When using "This Server", if a record does not exists in the zone then the request is forwarded to the DNS server's resolver internally. This allows you to override any record for the forwarded domain name or control its DNSSEC validation.
+                                        When using "This Server", if a record does not exists in the zone then the
+                                        request is forwarded to the DNS server's resolver internally. This allows you to
+                                        override any record for the forwarded domain name or control its DNSSEC
+                                        validation.
                                     </div>
 
-                                    <input id="txtAddZoneForwarder" type="text" class="form-control" placeholder="8.8.8.8">
+                                    <input id="txtAddZoneForwarder" type="text" class="form-control"
+                                        placeholder="8.8.8.8">
 
-                                    <div style="padding-top: 5px;">Enter a forwarder server address above. You can add more forwarders by adding FWD records after the zone is added.</div>
+                                    <div style="padding-top: 5px;">Enter a forwarder server address above. You can add
+                                        more forwarders by adding FWD records after the zone is added.</div>
                                 </div>
                             </div>
 
@@ -3778,7 +5754,8 @@ ns1.example.com ([2001:db8::])
                                 <div class="col-sm-7">
                                     <div class="checkbox" style="margin-bottom: 6px;">
                                         <label>
-                                            <input id="chkAddZoneForwarderDnssecValidation" type="checkbox"> Enable DNSSEC Validation
+                                            <input id="chkAddZoneForwarderDnssecValidation" type="checkbox"> Enable
+                                            DNSSEC Validation
                                         </label>
                                     </div>
                                 </div>
@@ -3796,7 +5773,9 @@ ns1.example.com ([2001:db8::])
                                         </div>
                                         <div class="radio">
                                             <label>
-                                                <input type="radio" name="rdAddZoneForwarderProxyType" id="rdAddZoneForwarderProxyTypeDefaultProxy" value="DefaultProxy" checked>
+                                                <input type="radio" name="rdAddZoneForwarderProxyType"
+                                                    id="rdAddZoneForwarderProxyTypeDefaultProxy" value="DefaultProxy"
+                                                    checked>
                                                 Default Proxy (default)
                                             </label>
                                         </div>
@@ -3816,30 +5795,38 @@ ns1.example.com ([2001:db8::])
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="txtAddZoneForwarderProxyAddress" class="col-sm-4 control-label">Proxy Server Address</label>
+                                    <label for="txtAddZoneForwarderProxyAddress" class="col-sm-4 control-label">Proxy
+                                        Server Address</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddZoneForwarderProxyAddress" type="text" class="form-control" placeholder="domain name or IP address">
+                                        <input id="txtAddZoneForwarderProxyAddress" type="text" class="form-control"
+                                            placeholder="domain name or IP address">
                                     </div>
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="txtAddZoneForwarderProxyPort" class="col-sm-4 control-label">Proxy Server Port</label>
+                                    <label for="txtAddZoneForwarderProxyPort" class="col-sm-4 control-label">Proxy
+                                        Server Port</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddZoneForwarderProxyPort" type="number" class="form-control" placeholder="port" style="width: 100px;">
+                                        <input id="txtAddZoneForwarderProxyPort" type="number" class="form-control"
+                                            placeholder="port" style="width: 100px;">
                                     </div>
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="txtAddZoneForwarderProxyUsername" class="col-sm-4 control-label">Proxy Server Username</label>
+                                    <label for="txtAddZoneForwarderProxyUsername" class="col-sm-4 control-label">Proxy
+                                        Server Username</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddZoneForwarderProxyUsername" type="text" class="form-control" placeholder="username">
+                                        <input id="txtAddZoneForwarderProxyUsername" type="text" class="form-control"
+                                            placeholder="username">
                                     </div>
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="txtAddZoneForwarderProxyPassword" class="col-sm-4 control-label">Proxy Server Password</label>
+                                    <label for="txtAddZoneForwarderProxyPassword" class="col-sm-4 control-label">Proxy
+                                        Server Password</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddZoneForwarderProxyPassword" type="password" class="form-control" placeholder="password">
+                                        <input id="txtAddZoneForwarderProxyPassword" type="password"
+                                            class="form-control" placeholder="password">
                                     </div>
                                 </div>
                             </div>
@@ -3847,10 +5834,12 @@ ns1.example.com ([2001:db8::])
                     </div>
                     <div class="modal-footer">
                         <div class="pull-left" style="text-align: left;">
-                            <a href="https://blog.technitium.com/2022/06/how-to-self-host-your-own-domain-name.html" target="_blank">Help: How To Self Host Your Own Domain Name</a>
+                            <a href="https://blog.technitium.com/2022/06/how-to-self-host-your-own-domain-name.html"
+                                target="_blank">Help: How To Self Host Your Own Domain Name</a>
                         </div>
                         <div class="pull-right">
-                            <button id="btnAddZone" type="submit" class="btn btn-primary" data-loading-text="Adding..." onclick="addZone(); return false;">Add</button>
+                            <button id="btnAddZone" type="submit" class="btn btn-primary" data-loading-text="Adding..."
+                                onclick="addZone(); return false;">Add</button>
                             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                         </div>
                     </div>
@@ -3864,7 +5853,8 @@ ns1.example.com ([2001:db8::])
             <div class="modal-dialog" role="document" style="width: 780px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 id="titleAddEditRecord" class="modal-title">Add Edit Record</h4>
                     </div>
                     <div class="modal-body">
@@ -3876,14 +5866,16 @@ ns1.example.com ([2001:db8::])
                                 <label for="txtAddEditRecordName" class="col-sm-4 control-label">Name</label>
                                 <div class="col-sm-7">
                                     <input id="txtAddEditRecordName" type="text" class="form-control" placeholder="@">
-                                    <div style="margin-top: 6px; font-weight: 700;">.<span id="lblAddEditRecordZoneName">example.com</span></div>
+                                    <div style="margin-top: 6px; font-weight: 700;">.<span
+                                            id="lblAddEditRecordZoneName">example.com</span></div>
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label for="optAddEditRecordType" class="col-sm-4 control-label">Type</label>
                                 <div class="col-sm-7">
-                                    <select id="optAddEditRecordType" class="form-control" onchange="modifyAddRecordFormByType(true);" style="width: auto;">
+                                    <select id="optAddEditRecordType" class="form-control"
+                                        onchange="modifyAddRecordFormByType(true);" style="width: auto;">
                                         <option>A</option>
                                         <option>NS</option>
                                         <option id="optEditRecordTypeSoa">SOA</option>
@@ -3914,7 +5906,8 @@ ns1.example.com ([2001:db8::])
                             <div class="form-group">
                                 <label for="txtAddEditRecordTtl" class="col-sm-4 control-label">TTL</label>
                                 <div class="col-sm-7">
-                                    <input id="txtAddEditRecordTtl" type="text" class="form-control" placeholder="3600" style="width: 100px; display: inline;">
+                                    <input id="txtAddEditRecordTtl" type="text" class="form-control" placeholder="3600"
+                                        style="width: 100px; display: inline;">
                                     <span id="spanAddEditRecordTtlUnit">seconds (default 3600/1h)</span>
                                 </div>
                             </div>
@@ -3922,14 +5915,17 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordData">
                                 <div id="divAddEditRecordDataUnknownType" class="form-group">
-                                    <label for="txtAddEditRecordDataUnknownType" class="col-sm-4 control-label">RR Type</label>
+                                    <label for="txtAddEditRecordDataUnknownType" class="col-sm-4 control-label">RR
+                                        Type</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddEditRecordDataUnknownType" type="text" class="form-control" placeholder="type" style="width: 100px;">
+                                        <input id="txtAddEditRecordDataUnknownType" type="text" class="form-control"
+                                            placeholder="type" style="width: 100px;">
                                     </div>
                                 </div>
 
                                 <div class="form-group">
-                                    <label id="lblAddEditRecordDataValue" for="txtAddEditRecordDataValue" class="col-sm-4 control-label">Value</label>
+                                    <label id="lblAddEditRecordDataValue" for="txtAddEditRecordDataValue"
+                                        class="col-sm-4 control-label">Value</label>
                                     <div class="col-sm-7">
                                         <input id="txtAddEditRecordDataValue" type="text" class="form-control">
                                     </div>
@@ -3939,13 +5935,15 @@ ns1.example.com ([2001:db8::])
                                     <div class="col-sm-offset-4 col-sm-7">
                                         <div class="checkbox">
                                             <label>
-                                                <input id="chkAddEditRecordDataPtr" type="checkbox"> <span id="chkAddEditRecordDataPtrLabel">Add reverse (PTR) record</span>
+                                                <input id="chkAddEditRecordDataPtr" type="checkbox"> <span
+                                                    id="chkAddEditRecordDataPtrLabel">Add reverse (PTR) record</span>
                                             </label>
                                         </div>
 
                                         <div class="checkbox">
                                             <label>
-                                                <input id="chkAddEditRecordDataCreatePtrZone" type="checkbox"> Create reverse zone for PTR record
+                                                <input id="chkAddEditRecordDataCreatePtrZone" type="checkbox"> Create
+                                                reverse zone for PTR record
                                             </label>
                                         </div>
                                     </div>
@@ -3955,15 +5953,18 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataNs" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataNsNameServer" class="col-sm-4 control-label">Name Server</label>
+                                    <label for="txtAddEditRecordDataNsNameServer" class="col-sm-4 control-label">Name
+                                        Server</label>
                                     <div class="col-sm-7">
                                         <input id="txtAddEditRecordDataNsNameServer" type="text" class="form-control">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataNsGlue" class="col-sm-4 control-label">Glue Addresses</label>
+                                    <label for="txtAddEditRecordDataNsGlue" class="col-sm-4 control-label">Glue
+                                        Addresses</label>
                                     <div class="col-sm-7">
-                                        <textarea id="txtAddEditRecordDataNsGlue" class="form-control" rows="3" spellcheck="false" placeholder="192.168.1.1
+                                        <textarea id="txtAddEditRecordDataNsGlue" class="form-control" rows="3"
+                                            spellcheck="false" placeholder="192.168.1.1
 2001:db8::"></textarea>
                                     </div>
                                 </div>
@@ -3972,55 +5973,69 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divEditRecordDataSoa" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtEditRecordDataSoaPrimaryNameServer" class="col-sm-4 control-label">Primary Name Server</label>
+                                    <label for="txtEditRecordDataSoaPrimaryNameServer"
+                                        class="col-sm-4 control-label">Primary Name Server</label>
                                     <div class="col-sm-7">
-                                        <input id="txtEditRecordDataSoaPrimaryNameServer" type="text" class="form-control">
+                                        <input id="txtEditRecordDataSoaPrimaryNameServer" type="text"
+                                            class="form-control">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtEditRecordDataSoaResponsiblePerson" class="col-sm-4 control-label">Responsible Person</label>
+                                    <label for="txtEditRecordDataSoaResponsiblePerson"
+                                        class="col-sm-4 control-label">Responsible Person</label>
                                     <div class="col-sm-7">
-                                        <input id="txtEditRecordDataSoaResponsiblePerson" type="text" class="form-control" placeholder="email address">
+                                        <input id="txtEditRecordDataSoaResponsiblePerson" type="text"
+                                            class="form-control" placeholder="email address">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtEditRecordDataSoaSerial" class="col-sm-4 control-label">Serial</label>
+                                    <label for="txtEditRecordDataSoaSerial"
+                                        class="col-sm-4 control-label">Serial</label>
                                     <div class="col-sm-7">
-                                        <input id="txtEditRecordDataSoaSerial" type="number" class="form-control" style="width: 150px;">
+                                        <input id="txtEditRecordDataSoaSerial" type="number" class="form-control"
+                                            style="width: 150px;">
                                     </div>
                                     <div id="divEditRecordDataSoaUseSerialDateScheme" class="col-sm-offset-4 col-sm-7">
                                         <div class="checkbox">
                                             <label>
-                                                <input id="chkEditRecordDataSoaUseSerialDateScheme" type="checkbox"> Use Serial Date Scheme
+                                                <input id="chkEditRecordDataSoaUseSerialDateScheme" type="checkbox"> Use
+                                                Serial Date Scheme
                                             </label>
                                         </div>
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtEditRecordDataSoaRefresh" class="col-sm-4 control-label">Refresh</label>
+                                    <label for="txtEditRecordDataSoaRefresh"
+                                        class="col-sm-4 control-label">Refresh</label>
                                     <div class="col-sm-7">
-                                        <input id="txtEditRecordDataSoaRefresh" type="text" class="form-control" style="width: 100px; display: inline;">
+                                        <input id="txtEditRecordDataSoaRefresh" type="text" class="form-control"
+                                            style="width: 100px; display: inline;">
                                         <span>seconds</span>
                                     </div>
                                 </div>
                                 <div class="form-group">
                                     <label for="txtEditRecordDataSoaRetry" class="col-sm-4 control-label">Retry</label>
                                     <div class="col-sm-7">
-                                        <input id="txtEditRecordDataSoaRetry" type="text" class="form-control" style="width: 100px; display: inline;">
+                                        <input id="txtEditRecordDataSoaRetry" type="text" class="form-control"
+                                            style="width: 100px; display: inline;">
                                         <span>seconds</span>
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtEditRecordDataSoaExpire" class="col-sm-4 control-label">Expire</label>
+                                    <label for="txtEditRecordDataSoaExpire"
+                                        class="col-sm-4 control-label">Expire</label>
                                     <div class="col-sm-7">
-                                        <input id="txtEditRecordDataSoaExpire" type="text" class="form-control" style="width: 100px; display: inline;">
+                                        <input id="txtEditRecordDataSoaExpire" type="text" class="form-control"
+                                            style="width: 100px; display: inline;">
                                         <span>seconds</span>
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtEditRecordDataSoaMinimum" class="col-sm-4 control-label">Minimum</label>
+                                    <label for="txtEditRecordDataSoaMinimum"
+                                        class="col-sm-4 control-label">Minimum</label>
                                     <div class="col-sm-7">
-                                        <input id="txtEditRecordDataSoaMinimum" type="text" class="form-control" style="width: 100px; display: inline;">
+                                        <input id="txtEditRecordDataSoaMinimum" type="text" class="form-control"
+                                            style="width: 100px; display: inline;">
                                         <span>seconds</span>
                                     </div>
                                 </div>
@@ -4029,13 +6044,16 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataMx" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataMxPreference" class="col-sm-4 control-label">Preference</label>
+                                    <label for="txtAddEditRecordDataMxPreference"
+                                        class="col-sm-4 control-label">Preference</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddEditRecordDataMxPreference" type="number" class="form-control" placeholder="1" style="width: 100px;">
+                                        <input id="txtAddEditRecordDataMxPreference" type="number" class="form-control"
+                                            placeholder="1" style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataMxExchange" class="col-sm-4 control-label">Exchange</label>
+                                    <label for="txtAddEditRecordDataMxExchange"
+                                        class="col-sm-4 control-label">Exchange</label>
                                     <div class="col-sm-7">
                                         <input id="txtAddEditRecordDataMxExchange" type="text" class="form-control">
                                     </div>
@@ -4045,12 +6063,15 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataTxt" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataTxt" class="col-sm-4 control-label">Text Data</label>
+                                    <label for="txtAddEditRecordDataTxt" class="col-sm-4 control-label">Text
+                                        Data</label>
                                     <div class="col-sm-7">
-                                        <textarea id="txtAddEditRecordDataTxt" class="form-control" rows="5" spellcheck="false"></textarea>
+                                        <textarea id="txtAddEditRecordDataTxt" class="form-control" rows="5"
+                                            spellcheck="false"></textarea>
                                         <div class="checkbox">
                                             <label>
-                                                <input id="chkAddEditRecordDataTxtSplitText" type="checkbox"> Use New Line To Split Text Into Multiple Character-Strings
+                                                <input id="chkAddEditRecordDataTxtSplitText" type="checkbox"> Use New
+                                                Line To Split Text Into Multiple Character-Strings
                                             </label>
                                         </div>
                                     </div>
@@ -4060,15 +6081,19 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataRp" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataRpMailbox" class="col-sm-4 control-label">Mailbox</label>
+                                    <label for="txtAddEditRecordDataRpMailbox"
+                                        class="col-sm-4 control-label">Mailbox</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddEditRecordDataRpMailbox" type="text" class="form-control" placeholder="email address">
+                                        <input id="txtAddEditRecordDataRpMailbox" type="text" class="form-control"
+                                            placeholder="email address">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataRpTxtDomain" class="col-sm-4 control-label">TXT Domain</label>
+                                    <label for="txtAddEditRecordDataRpTxtDomain" class="col-sm-4 control-label">TXT
+                                        Domain</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddEditRecordDataRpTxtDomain" type="text" class="form-control" placeholder=".">
+                                        <input id="txtAddEditRecordDataRpTxtDomain" type="text" class="form-control"
+                                            placeholder=".">
                                     </div>
                                 </div>
                             </div>
@@ -4076,25 +6101,31 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataSrv" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataSrvPriority" class="col-sm-4 control-label">Priority</label>
+                                    <label for="txtAddEditRecordDataSrvPriority"
+                                        class="col-sm-4 control-label">Priority</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataSrvPriority" style="width: 100px;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataSrvPriority"
+                                            style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataSrvWeight" class="col-sm-4 control-label">Weight</label>
+                                    <label for="txtAddEditRecordDataSrvWeight"
+                                        class="col-sm-4 control-label">Weight</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataSrvWeight" style="width: 100px;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataSrvWeight"
+                                            style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
                                     <label for="txtAddEditRecordDataSrvPort" class="col-sm-4 control-label">Port</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataSrvPort" style="width: 100px;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataSrvPort"
+                                            style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataSrvTarget" class="col-sm-4 control-label">Target</label>
+                                    <label for="txtAddEditRecordDataSrvTarget"
+                                        class="col-sm-4 control-label">Target</label>
                                     <div class="col-sm-7">
                                         <input type="text" class="form-control" id="txtAddEditRecordDataSrvTarget">
                                     </div>
@@ -4104,39 +6135,48 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataNaptr" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataNaptrOrder" class="col-sm-4 control-label">Order</label>
+                                    <label for="txtAddEditRecordDataNaptrOrder"
+                                        class="col-sm-4 control-label">Order</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataNaptrOrder" style="width: 100px;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataNaptrOrder"
+                                            style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataNaptrPreference" class="col-sm-4 control-label">Preference</label>
+                                    <label for="txtAddEditRecordDataNaptrPreference"
+                                        class="col-sm-4 control-label">Preference</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataNaptrPreference" style="width: 100px;">
+                                        <input type="number" class="form-control"
+                                            id="txtAddEditRecordDataNaptrPreference" style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataNaptrFlags" class="col-sm-4 control-label">Flags</label>
+                                    <label for="txtAddEditRecordDataNaptrFlags"
+                                        class="col-sm-4 control-label">Flags</label>
                                     <div class="col-sm-7">
                                         <input type="text" class="form-control" id="txtAddEditRecordDataNaptrFlags">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataNaptrServices" class="col-sm-4 control-label">Services</label>
+                                    <label for="txtAddEditRecordDataNaptrServices"
+                                        class="col-sm-4 control-label">Services</label>
                                     <div class="col-sm-7">
                                         <input type="text" class="form-control" id="txtAddEditRecordDataNaptrServices">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataNaptrRegExp" class="col-sm-4 control-label">Regular Expression</label>
+                                    <label for="txtAddEditRecordDataNaptrRegExp" class="col-sm-4 control-label">Regular
+                                        Expression</label>
                                     <div class="col-sm-7">
                                         <input type="text" class="form-control" id="txtAddEditRecordDataNaptrRegExp">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataNaptrReplacement" class="col-sm-4 control-label">Replacement</label>
+                                    <label for="txtAddEditRecordDataNaptrReplacement"
+                                        class="col-sm-4 control-label">Replacement</label>
                                     <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="txtAddEditRecordDataNaptrReplacement">
+                                        <input type="text" class="form-control"
+                                            id="txtAddEditRecordDataNaptrReplacement">
                                     </div>
                                 </div>
                             </div>
@@ -4144,13 +6184,16 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataDs" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataDsKeyTag" class="col-sm-4 control-label">Key Tag</label>
+                                    <label for="txtAddEditRecordDataDsKeyTag" class="col-sm-4 control-label">Key
+                                        Tag</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataDsKeyTag" placeholder="key tag" style="width: 100px;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataDsKeyTag"
+                                            placeholder="key tag" style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataDsAlgorithm" class="col-sm-4 control-label">DNSSEC Algorithm</label>
+                                    <label for="optAddEditRecordDataDsAlgorithm" class="col-sm-4 control-label">DNSSEC
+                                        Algorithm</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataDsAlgorithm" class="form-control">
                                             <option value="RSAMD5">RSAMD5 (1)</option>
@@ -4165,7 +6208,8 @@ ns1.example.com ([2001:db8::])
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataDsDigestType" class="col-sm-4 control-label">Digest Type</label>
+                                    <label for="optAddEditRecordDataDsDigestType" class="col-sm-4 control-label">Digest
+                                        Type</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataDsDigestType" class="form-control">
                                             <option value="SHA1">SHA1 (1)</option>
@@ -4175,9 +6219,11 @@ ns1.example.com ([2001:db8::])
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataDsDigest" class="col-sm-4 control-label">Digest</label>
+                                    <label for="txtAddEditRecordDataDsDigest"
+                                        class="col-sm-4 control-label">Digest</label>
                                     <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="txtAddEditRecordDataDsDigest" placeholder="hash string">
+                                        <input type="text" class="form-control" id="txtAddEditRecordDataDsDigest"
+                                            placeholder="hash string">
                                     </div>
                                 </div>
                             </div>
@@ -4185,7 +6231,8 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataSshfp" style="display: none;">
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataSshfpAlgorithm" class="col-sm-4 control-label">Algorithm</label>
+                                    <label for="optAddEditRecordDataSshfpAlgorithm"
+                                        class="col-sm-4 control-label">Algorithm</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataSshfpAlgorithm" class="form-control">
                                             <option>RSA</option>
@@ -4197,7 +6244,8 @@ ns1.example.com ([2001:db8::])
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataSshfpFingerprintType" class="col-sm-4 control-label">Fingerprint Type</label>
+                                    <label for="optAddEditRecordDataSshfpFingerprintType"
+                                        class="col-sm-4 control-label">Fingerprint Type</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataSshfpFingerprintType" class="form-control">
                                             <option>SHA1</option>
@@ -4206,9 +6254,11 @@ ns1.example.com ([2001:db8::])
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataSshfpFingerprint" class="col-sm-4 control-label">Fingerprint</label>
+                                    <label for="txtAddEditRecordDataSshfpFingerprint"
+                                        class="col-sm-4 control-label">Fingerprint</label>
                                     <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="txtAddEditRecordDataSshfpFingerprint" placeholder="hash string">
+                                        <input type="text" class="form-control"
+                                            id="txtAddEditRecordDataSshfpFingerprint" placeholder="hash string">
                                     </div>
                                 </div>
                             </div>
@@ -4216,7 +6266,8 @@ ns1.example.com ([2001:db8::])
 
                             <div id="divAddEditRecordDataTlsa" style="display: none;">
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataTlsaCertificateUsage" class="col-sm-4 control-label">Certificate Usage</label>
+                                    <label for="optAddEditRecordDataTlsaCertificateUsage"
+                                        class="col-sm-4 control-label">Certificate Usage</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataTlsaCertificateUsage" class="form-control">
                                             <option>PKIX-TA</option>
@@ -4227,7 +6278,8 @@ ns1.example.com ([2001:db8::])
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataTlsaSelector" class="col-sm-4 control-label">Selector</label>
+                                    <label for="optAddEditRecordDataTlsaSelector"
+                                        class="col-sm-4 control-label">Selector</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataTlsaSelector" class="form-control">
                                             <option>Cert</option>
@@ -4236,7 +6288,8 @@ ns1.example.com ([2001:db8::])
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataTlsaMatchingType" class="col-sm-4 control-label">Matching Type</label>
+                                    <label for="optAddEditRecordDataTlsaMatchingType"
+                                        class="col-sm-4 control-label">Matching Type</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataTlsaMatchingType" class="form-control">
                                             <option>Full</option>
@@ -4246,15 +6299,20 @@ ns1.example.com ([2001:db8::])
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataTlsaCertificateAssociationData" class="col-sm-4 control-label">Certificate Association Data</label>
+                                    <label for="txtAddEditRecordDataTlsaCertificateAssociationData"
+                                        class="col-sm-4 control-label">Certificate Association Data</label>
                                     <div class="col-sm-7">
-                                        <textarea id="txtAddEditRecordDataTlsaCertificateAssociationData" class="form-control" rows="6" spellcheck="false" placeholder="5F95253A20A0957648DEBAAEB032F7C5720CD4F0DCF928840C55650687921DAE
+                                        <textarea id="txtAddEditRecordDataTlsaCertificateAssociationData"
+                                            class="form-control" rows="6" spellcheck="false" placeholder="5F95253A20A0957648DEBAAEB032F7C5720CD4F0DCF928840C55650687921DAE
           OR
 -----BEGIN CERTIFICATE-----
 MII...
 -----END CERTIFICATE-----
 "></textarea>
-                                        <div style="padding-top: 5px;">Enter either a hash value that you have independently generated, OR enter the certificate in PEM format to automatically generate the association data based on the Selector and Matching Type values.</div>
+                                        <div style="padding-top: 5px;">Enter either a hash value that you have
+                                            independently generated, OR enter the certificate in PEM format to
+                                            automatically generate the association data based on the Selector and
+                                            Matching Type values.</div>
                                     </div>
                                 </div>
                             </div>
@@ -4262,14 +6320,17 @@ MII...
 
                             <div id="divAddEditRecordDataSvcb" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataSvcbPriority" class="col-sm-4 control-label">Priority</label>
+                                    <label for="txtAddEditRecordDataSvcbPriority"
+                                        class="col-sm-4 control-label">Priority</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataSvcbPriority" style="width: 100px; display: inline;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataSvcbPriority"
+                                            style="width: 100px; display: inline;">
                                         <span>(set 0 for alias mode)</span>
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataSvcbTargetName" class="col-sm-4 control-label">Target Name</label>
+                                    <label for="txtAddEditRecordDataSvcbTargetName"
+                                        class="col-sm-4 control-label">Target Name</label>
                                     <div class="col-sm-7">
                                         <input type="text" class="form-control" id="txtAddEditRecordDataSvcbTargetName">
                                     </div>
@@ -4283,7 +6344,9 @@ MII...
                                                     <th>Key</th>
                                                     <th>Value</th>
                                                     <th style="width: 94px;">
-                                                        <button type="button" class="btn btn-default" style="padding: 0px 25px;" onclick="addSvcbRecordParamEditRow('', '');">Add</button>
+                                                        <button type="button" class="btn btn-default"
+                                                            style="padding: 0px 25px;"
+                                                            onclick="addSvcbRecordParamEditRow('', '');">Add</button>
                                                     </th>
                                                 </tr>
                                             </thead>
@@ -4297,14 +6360,16 @@ MII...
                                     <div class="col-sm-7">
                                         <div class="checkbox">
                                             <label>
-                                                <input id="chkAddEditRecordDataSvcbAutoIpv4Hint" type="checkbox"> Use Automatic IPv4 Hint
+                                                <input id="chkAddEditRecordDataSvcbAutoIpv4Hint" type="checkbox"> Use
+                                                Automatic IPv4 Hint
                                             </label>
                                         </div>
                                     </div>
                                     <div class="col-sm-offset-4 col-sm-7">
                                         <div class="checkbox">
                                             <label>
-                                                <input id="chkAddEditRecordDataSvcbAutoIpv6Hint" type="checkbox"> Use Automatic IPv6 Hint
+                                                <input id="chkAddEditRecordDataSvcbAutoIpv6Hint" type="checkbox"> Use
+                                                Automatic IPv6 Hint
                                             </label>
                                         </div>
                                     </div>
@@ -4314,15 +6379,19 @@ MII...
 
                             <div id="divAddEditRecordDataUri" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataUriPriority" class="col-sm-4 control-label">Priority</label>
+                                    <label for="txtAddEditRecordDataUriPriority"
+                                        class="col-sm-4 control-label">Priority</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataUriPriority" style="width: 100px;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataUriPriority"
+                                            style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataUriWeight" class="col-sm-4 control-label">Weight</label>
+                                    <label for="txtAddEditRecordDataUriWeight"
+                                        class="col-sm-4 control-label">Weight</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataUriWeight" style="width: 100px;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataUriWeight"
+                                            style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
@@ -4336,19 +6405,23 @@ MII...
 
                             <div id="divAddEditRecordDataCaa" style="display: none;">
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataCaaFlags" class="col-sm-4 control-label">Flags</label>
+                                    <label for="txtAddEditRecordDataCaaFlags"
+                                        class="col-sm-4 control-label">Flags</label>
                                     <div class="col-sm-7">
-                                        <input type="number" class="form-control" id="txtAddEditRecordDataCaaFlags" placeholder="0" style="width: 100px;">
+                                        <input type="number" class="form-control" id="txtAddEditRecordDataCaaFlags"
+                                            placeholder="0" style="width: 100px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
                                     <label for="txtAddEditRecordDataCaaTag" class="col-sm-4 control-label">Tag</label>
                                     <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="txtAddEditRecordDataCaaTag" placeholder="issue" style="width: 150px;">
+                                        <input type="text" class="form-control" id="txtAddEditRecordDataCaaTag"
+                                            placeholder="issue" style="width: 150px;">
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataCaaValue" class="col-sm-4 control-label">Authority</label>
+                                    <label for="txtAddEditRecordDataCaaValue"
+                                        class="col-sm-4 control-label">Authority</label>
                                     <div class="col-sm-7">
                                         <input type="text" class="form-control" id="txtAddEditRecordDataCaaValue">
                                     </div>
@@ -4362,31 +6435,36 @@ MII...
                                     <div class="col-sm-7">
                                         <div class="radio">
                                             <label>
-                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol" id="rdAddEditRecordDataForwarderProtocolUdp" value="Udp" checked>
+                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol"
+                                                    id="rdAddEditRecordDataForwarderProtocolUdp" value="Udp" checked>
                                                 DNS-over-UDP (default)
                                             </label>
                                         </div>
                                         <div class="radio">
                                             <label>
-                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol" id="rdAddEditRecordDataForwarderProtocolTcp" value="Tcp">
+                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol"
+                                                    id="rdAddEditRecordDataForwarderProtocolTcp" value="Tcp">
                                                 DNS-over-TCP
                                             </label>
                                         </div>
                                         <div class="radio">
                                             <label>
-                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol" id="rdAddEditRecordDataForwarderProtocolTls" value="Tls">
+                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol"
+                                                    id="rdAddEditRecordDataForwarderProtocolTls" value="Tls">
                                                 DNS-over-TLS
                                             </label>
                                         </div>
                                         <div class="radio">
                                             <label>
-                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol" id="rdAddEditRecordDataForwarderProtocolHttps" value="Https">
+                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol"
+                                                    id="rdAddEditRecordDataForwarderProtocolHttps" value="Https">
                                                 DNS-over-HTTPS
                                             </label>
                                         </div>
                                         <div class="radio">
                                             <label>
-                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol" id="rdAddEditRecordDataForwarderProtocolQuic" value="Quic">
+                                                <input type="radio" name="rdAddEditRecordDataForwarderProtocol"
+                                                    id="rdAddEditRecordDataForwarderProtocolQuic" value="Quic">
                                                 DNS-over-QUIC
                                             </label>
                                         </div>
@@ -4394,29 +6472,38 @@ MII...
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataForwarder" class="col-sm-4 control-label">Forwarder</label>
+                                    <label for="txtAddEditRecordDataForwarder"
+                                        class="col-sm-4 control-label">Forwarder</label>
                                     <div class="col-sm-7">
                                         <div class="checkbox">
                                             <label>
-                                                <input id="chkAddEditRecordDataForwarderThisServer" type="checkbox" onclick="updateAddEditFormForwarderThisServer();"> Use "This Server"
+                                                <input id="chkAddEditRecordDataForwarderThisServer" type="checkbox"
+                                                    onclick="updateAddEditFormForwarderThisServer();"> Use "This Server"
                                             </label>
                                         </div>
                                         <div style="padding-top: 5px; padding-left: 20px; padding-bottom: 10px;">
-                                            When using "This Server", if a record does not exists in the zone then the request is forwarded to the DNS server's resolver internally. This allows you to override any record for the forwarded domain name or control its DNSSEC validation.
+                                            When using "This Server", if a record does not exists in the zone then the
+                                            request is forwarded to the DNS server's resolver internally. This allows
+                                            you to override any record for the forwarded domain name or control its
+                                            DNSSEC validation.
                                         </div>
 
-                                        <input id="txtAddEditRecordDataForwarder" type="text" class="form-control" placeholder="8.8.8.8">
+                                        <input id="txtAddEditRecordDataForwarder" type="text" class="form-control"
+                                            placeholder="8.8.8.8">
                                     </div>
                                 </div>
 
                                 <div class="form-group">
                                     <label class="col-sm-4 control-label">Priority</label>
                                     <div class="col-sm-7">
-                                        <input id="txtAddEditRecordDataForwarderPriority" type="number" class="form-control" placeholder="0" style="width: 100px; display: inline;">
+                                        <input id="txtAddEditRecordDataForwarderPriority" type="number"
+                                            class="form-control" placeholder="0" style="width: 100px; display: inline;">
                                         <span>(valid range 0-255; default 0)</span>
                                     </div>
                                     <div class="col-sm-offset-4 col-sm-8" style="padding-top: 5px;">
-                                        Forwarders are sorted by priority value i.e. forwarder with low priority value will be queried before trying for forwarder with high priority value. Forwarders with the same priority value will be queried concurrently.
+                                        Forwarders are sorted by priority value i.e. forwarder with low priority value
+                                        will be queried before trying for forwarder with high priority value. Forwarders
+                                        with the same priority value will be queried concurrently.
                                     </div>
                                 </div>
 
@@ -4425,7 +6512,8 @@ MII...
                                     <div class="col-sm-7">
                                         <div class="checkbox" style="margin-bottom: 6px;">
                                             <label>
-                                                <input id="chkAddEditRecordDataForwarderDnssecValidation" type="checkbox"> Enable DNSSEC Validation
+                                                <input id="chkAddEditRecordDataForwarderDnssecValidation"
+                                                    type="checkbox"> Enable DNSSEC Validation
                                             </label>
                                         </div>
                                     </div>
@@ -4437,25 +6525,31 @@ MII...
                                         <div class="col-sm-7">
                                             <div class="radio">
                                                 <label>
-                                                    <input type="radio" name="rdAddEditRecordDataForwarderProxyType" id="rdAddEditRecordDataForwarderProxyTypeNoProxy" value="NoProxy">
+                                                    <input type="radio" name="rdAddEditRecordDataForwarderProxyType"
+                                                        id="rdAddEditRecordDataForwarderProxyTypeNoProxy"
+                                                        value="NoProxy">
                                                     No Proxy
                                                 </label>
                                             </div>
                                             <div class="radio">
                                                 <label>
-                                                    <input type="radio" name="rdAddEditRecordDataForwarderProxyType" id="rdAddEditRecordDataForwarderProxyTypeDefaultProxy" value="DefaultProxy" checked>
+                                                    <input type="radio" name="rdAddEditRecordDataForwarderProxyType"
+                                                        id="rdAddEditRecordDataForwarderProxyTypeDefaultProxy"
+                                                        value="DefaultProxy" checked>
                                                     Default Proxy (default)
                                                 </label>
                                             </div>
                                             <div class="radio">
                                                 <label>
-                                                    <input type="radio" name="rdAddEditRecordDataForwarderProxyType" id="rdAddEditRecordDataForwarderProxyTypeHttp" value="Http">
+                                                    <input type="radio" name="rdAddEditRecordDataForwarderProxyType"
+                                                        id="rdAddEditRecordDataForwarderProxyTypeHttp" value="Http">
                                                     HTTP Proxy
                                                 </label>
                                             </div>
                                             <div class="radio">
                                                 <label>
-                                                    <input type="radio" name="rdAddEditRecordDataForwarderProxyType" id="rdAddEditRecordDataForwarderProxyTypeSocks5" value="Socks5">
+                                                    <input type="radio" name="rdAddEditRecordDataForwarderProxyType"
+                                                        id="rdAddEditRecordDataForwarderProxyTypeSocks5" value="Socks5">
                                                     SOCKS5 Proxy
                                                 </label>
                                             </div>
@@ -4463,30 +6557,38 @@ MII...
                                     </div>
 
                                     <div class="form-group">
-                                        <label for="txtAddEditRecordDataForwarderProxyAddress" class="col-sm-4 control-label">Proxy Server Address</label>
+                                        <label for="txtAddEditRecordDataForwarderProxyAddress"
+                                            class="col-sm-4 control-label">Proxy Server Address</label>
                                         <div class="col-sm-7">
-                                            <input id="txtAddEditRecordDataForwarderProxyAddress" type="text" class="form-control" placeholder="domain name or IP address">
+                                            <input id="txtAddEditRecordDataForwarderProxyAddress" type="text"
+                                                class="form-control" placeholder="domain name or IP address">
                                         </div>
                                     </div>
 
                                     <div class="form-group">
-                                        <label for="txtAddEditRecordDataForwarderProxyPort" class="col-sm-4 control-label">Proxy Server Port</label>
+                                        <label for="txtAddEditRecordDataForwarderProxyPort"
+                                            class="col-sm-4 control-label">Proxy Server Port</label>
                                         <div class="col-sm-7">
-                                            <input id="txtAddEditRecordDataForwarderProxyPort" type="number" class="form-control" placeholder="port" style="width: 100px;">
+                                            <input id="txtAddEditRecordDataForwarderProxyPort" type="number"
+                                                class="form-control" placeholder="port" style="width: 100px;">
                                         </div>
                                     </div>
 
                                     <div class="form-group">
-                                        <label for="txtAddEditRecordDataForwarderProxyUsername" class="col-sm-4 control-label">Proxy Server Username</label>
+                                        <label for="txtAddEditRecordDataForwarderProxyUsername"
+                                            class="col-sm-4 control-label">Proxy Server Username</label>
                                         <div class="col-sm-7">
-                                            <input id="txtAddEditRecordDataForwarderProxyUsername" type="text" class="form-control" placeholder="username">
+                                            <input id="txtAddEditRecordDataForwarderProxyUsername" type="text"
+                                                class="form-control" placeholder="username">
                                         </div>
                                     </div>
 
                                     <div class="form-group">
-                                        <label for="txtAddEditRecordDataForwarderProxyPassword" class="col-sm-4 control-label">Proxy Server Password</label>
+                                        <label for="txtAddEditRecordDataForwarderProxyPassword"
+                                            class="col-sm-4 control-label">Proxy Server Password</label>
                                         <div class="col-sm-7">
-                                            <input id="txtAddEditRecordDataForwarderProxyPassword" type="password" class="form-control" placeholder="password">
+                                            <input id="txtAddEditRecordDataForwarderProxyPassword" type="password"
+                                                class="form-control" placeholder="password">
                                         </div>
                                     </div>
                                 </div>
@@ -4495,23 +6597,27 @@ MII...
 
                             <div id="divAddEditRecordDataApplication" style="display: none;">
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataAppName" class="col-sm-4 control-label">App Name</label>
+                                    <label for="optAddEditRecordDataAppName" class="col-sm-4 control-label">App
+                                        Name</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataAppName" class="form-control"></select>
                                     </div>
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="optAddEditRecordDataClassPath" class="col-sm-4 control-label">Class Path</label>
+                                    <label for="optAddEditRecordDataClassPath" class="col-sm-4 control-label">Class
+                                        Path</label>
                                     <div class="col-sm-7">
                                         <select id="optAddEditRecordDataClassPath" class="form-control"></select>
                                     </div>
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="txtAddEditRecordDataData" class="col-sm-4 control-label">Record Data (if any)</label>
+                                    <label for="txtAddEditRecordDataData" class="col-sm-4 control-label">Record Data (if
+                                        any)</label>
                                     <div class="col-sm-7">
-                                        <textarea id="txtAddEditRecordDataData" class="form-control" rows="6" spellcheck="false"></textarea>
+                                        <textarea id="txtAddEditRecordDataData" class="form-control" rows="6"
+                                            spellcheck="false"></textarea>
                                     </div>
                                 </div>
                             </div>
@@ -4521,7 +6627,8 @@ MII...
                                 <div class="col-sm-offset-4 col-sm-7">
                                     <div class="checkbox">
                                         <label>
-                                            <input id="chkAddEditRecordOverwrite" type="checkbox"> Overwrite existing records
+                                            <input id="chkAddEditRecordOverwrite" type="checkbox"> Overwrite existing
+                                            records
                                         </label>
                                     </div>
                                 </div>
@@ -4530,23 +6637,28 @@ MII...
                             <div class="form-group">
                                 <label for="txtAddEditRecordComments" class="col-sm-4 control-label">Comments</label>
                                 <div class="col-sm-7">
-                                    <textarea id="txtAddEditRecordComments" class="form-control" rows="3" maxlength="255"></textarea>
+                                    <textarea id="txtAddEditRecordComments" class="form-control" rows="3"
+                                        maxlength="255"></textarea>
                                 </div>
                             </div>
 
                             <div class="form-group" id="divAddEditRecordExpiryTtl">
                                 <label for="txtAddEditRecordExpiryTtl" class="col-sm-4 control-label">Expiry TTL</label>
                                 <div class="col-sm-7">
-                                    <input id="txtAddEditRecordExpiryTtl" type="text" class="form-control" placeholder="0" style="width: 100px; display: inline;">
+                                    <input id="txtAddEditRecordExpiryTtl" type="text" class="form-control"
+                                        placeholder="0" style="width: 100px; display: inline;">
                                     <span>seconds (set 0 to disable)</span>
                                 </div>
-                                <div class="col-sm-offset-4 col-sm-7" style="padding-top: 5px;">Set to automatically delete the record when the value in seconds elapses since the record’s last modified time.</div>
+                                <div class="col-sm-offset-4 col-sm-7" style="padding-top: 5px;">Set to automatically
+                                    delete the record when the value in seconds elapses since the record’s last modified
+                                    time.</div>
                             </div>
 
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-primary" id="btnAddEditRecord" data-loading-text="Saving...">Save</button>
+                        <button type="submit" class="btn btn-primary" id="btnAddEditRecord"
+                            data-loading-text="Saving...">Save</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -4558,7 +6670,8 @@ MII...
         <div class="modal-dialog" role="document" style="width: 780px;">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Import - <span id="lblImportZoneName"></span></h4>
                 </div>
                 <div class="modal-body">
@@ -4572,13 +6685,16 @@ MII...
                                     <label>
                                         <input id="chkImportZoneOverwrite" type="checkbox"> Overwrite existing records
                                     </label>
-                                    <div style="padding-top: 5px; padding-left: 20px;">Enable this option to overwrite existing records for the record types being imported.</div>
+                                    <div style="padding-top: 5px; padding-left: 20px;">Enable this option to overwrite
+                                        existing records for the record types being imported.</div>
                                 </div>
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkImportZoneOverwriteSoaSerial" type="checkbox"> Overwrite SOA Serial
+                                        <input id="chkImportZoneOverwriteSoaSerial" type="checkbox"> Overwrite SOA
+                                        Serial
                                     </label>
-                                    <div style="padding-top: 5px; padding-left: 20px;">Enable this option to overwrite existing SOA record serial with the imported SOA record serial.</div>
+                                    <div style="padding-top: 5px; padding-left: 20px;">Enable this option to overwrite
+                                        existing SOA record serial with the imported SOA record serial.</div>
                                 </div>
                             </div>
                         </div>
@@ -4588,13 +6704,15 @@ MII...
                             <div class="col-sm-8">
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdImportZoneType" id="rdImportZoneTypeFile" value="File">
+                                        <input type="radio" name="rdImportZoneType" id="rdImportZoneTypeFile"
+                                            value="File">
                                         Zone File
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdImportZoneType" id="rdImportZoneTypeText" value="Text">
+                                        <input type="radio" name="rdImportZoneType" id="rdImportZoneTypeText"
+                                            value="Text">
                                         Text Editor
                                     </label>
                                 </div>
@@ -4612,16 +6730,21 @@ MII...
                     <div id="divImportZoneTextEditor">
                         <div class="form-group">
                             <label for="txtImportZoneText" class="control-label">Text Editor</label>
-                            <textarea id="txtImportZoneText" class="form-control" rows="15" spellcheck="false"></textarea>
-                            <div style="padding-top: 5px;">Enter the records to be imported above in standard zone file format.</div>
+                            <textarea id="txtImportZoneText" class="form-control" rows="15"
+                                spellcheck="false"></textarea>
+                            <div style="padding-top: 5px;">Enter the records to be imported above in standard zone file
+                                format.</div>
                         </div>
                     </div>
 
-                    <p>Note! The <code>$ORIGIN</code> and <code>$TTL</code> values will be automatically set if not specified.</p>
-                    <p>Warning! Overwrite SOA serial option when used to set a lower SOA serial value than the current SOA serial will cause secondary zones to fail to sync.</p>
+                    <p>Note! The <code>$ORIGIN</code> and <code>$TTL</code> values will be automatically set if not
+                        specified.</p>
+                    <p>Warning! Overwrite SOA serial option when used to set a lower SOA serial value than the current
+                        SOA serial will cause secondary zones to fail to sync.</p>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnImportZone" type="submit" class="btn btn-primary" data-loading-text="Importing..." onclick="importZone(); return false;">Import</button>
+                    <button id="btnImportZone" type="submit" class="btn btn-primary" data-loading-text="Importing..."
+                        onclick="importZone(); return false;">Import</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -4633,14 +6756,16 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Clone Zone - <span id="lblCloneZoneZoneName"></span></h4>
                     </div>
                     <div class="modal-body">
                         <div id="divCloneZoneAlert"></div>
                         <div class="form-horizontal">
                             <div class="form-group">
-                                <label for="txtCloneZoneSourceZoneName" class="col-sm-4 control-label">Source Zone</label>
+                                <label for="txtCloneZoneSourceZoneName" class="col-sm-4 control-label">Source
+                                    Zone</label>
                                 <div class="col-sm-7">
                                     <input id="txtCloneZoneSourceZoneName" type="text" class="form-control" disabled>
                                 </div>
@@ -4648,13 +6773,15 @@ MII...
                             <div class="form-group">
                                 <label for="txtCloneZoneZoneName" class="col-sm-4 control-label">New Zone</label>
                                 <div class="col-sm-7">
-                                    <input id="txtCloneZoneZoneName" type="text" class="form-control" placeholder="example.com">
+                                    <input id="txtCloneZoneZoneName" type="text" class="form-control"
+                                        placeholder="example.com">
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnCloneZone" type="submit" class="btn btn-primary" data-loading-text="Cloning..." onclick="cloneZone(this); return false;">Clone Zone</button>
+                        <button id="btnCloneZone" type="submit" class="btn btn-primary" data-loading-text="Cloning..."
+                            onclick="cloneZone(this); return false;">Clone Zone</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -4666,7 +6793,8 @@ MII...
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Convert Zone - <span id="lblConvertZoneZoneName"></span></h4>
                 </div>
                 <div class="modal-body">
@@ -4677,19 +6805,22 @@ MII...
                             <div class="col-sm-8">
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdConvertZoneToType" id="rdConvertZoneToTypePrimary" value="Primary" />
+                                        <input type="radio" name="rdConvertZoneToType" id="rdConvertZoneToTypePrimary"
+                                            value="Primary" />
                                         Primary Zone
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdConvertZoneToType" id="rdConvertZoneToTypeForwarder" value="Forwarder" />
+                                        <input type="radio" name="rdConvertZoneToType" id="rdConvertZoneToTypeForwarder"
+                                            value="Forwarder" />
                                         Conditional Forwarder Zone
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdConvertZoneToType" id="rdConvertZoneToTypeCatalog" value="Catalog" />
+                                        <input type="radio" name="rdConvertZoneToType" id="rdConvertZoneToTypeCatalog"
+                                            value="Catalog" />
                                         Catalog Zone
                                     </label>
                                 </div>
@@ -4697,12 +6828,16 @@ MII...
                         </div>
 
                         <p>
-                            <b>Note!</b> The conversion process may take a while depending on the number of records the zone has. When converting a Secondary Catalog zone to a Catalog zone, all member zones too will be converted to either Primary or Conditional Forwarder zone depending on their existing zone type. Please be patient till the conversion process completes.
+                            <b>Note!</b> The conversion process may take a while depending on the number of records the
+                            zone has. When converting a Secondary Catalog zone to a Catalog zone, all member zones too
+                            will be converted to either Primary or Conditional Forwarder zone depending on their
+                            existing zone type. Please be patient till the conversion process completes.
                         </p>
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnConvertZone" type="submit" class="btn btn-warning" data-loading-text="Converting..." onclick="convertZone(this); return false;">Convert Zone</button>
+                    <button id="btnConvertZone" type="submit" class="btn btn-warning" data-loading-text="Converting..."
+                        onclick="convertZone(this); return false;">Convert Zone</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -4713,7 +6848,8 @@ MII...
         <div class="modal-dialog" role="document" style="width: 780px;">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Zone Options - <span id="lblZoneOptionsZoneName"></span></h4>
                 </div>
                 <div class="modal-body">
@@ -4725,21 +6861,37 @@ MII...
 
                         <div>
                             <ul class="nav nav-tabs" role="tablist">
-                                <li id="tabListZoneOptionsGeneral" role="presentation" class="active"><a href="#tabPaneZoneOptionsGeneral" aria-controls="tabPaneZoneOptionsGeneral" role="tab" data-toggle="tab">General</a></li>
-                                <li id="tabListZoneOptionsQueryAccess" role="presentation"><a href="#tabPaneZoneOptionsQueryAccess" aria-controls="tabPaneZoneOptionsQueryAccess" role="tab" data-toggle="tab">Query Access</a></li>
-                                <li id="tabListZoneOptionsZoneTranfer" role="presentation"><a href="#tabPaneZoneOptionsZoneTransfer" aria-controls="tabPaneZoneOptionsZoneTransfer" role="tab" data-toggle="tab">Zone Transfer</a></li>
-                                <li id="tabListZoneOptionsNotify" role="presentation"><a href="#tabPaneZoneOptionsNotify" aria-controls="tabPaneZoneOptionsNotify" role="tab" data-toggle="tab">Notify</a></li>
-                                <li id="tabListZoneOptionsUpdate" role="presentation"><a href="#tabPaneZoneOptionsUpdate" aria-controls="tabPaneZoneOptionsUpdate" role="tab" data-toggle="tab">Dynamic Updates (RFC 2136)</a></li>
+                                <li id="tabListZoneOptionsGeneral" role="presentation" class="active"><a
+                                        href="#tabPaneZoneOptionsGeneral" aria-controls="tabPaneZoneOptionsGeneral"
+                                        role="tab" data-toggle="tab">General</a></li>
+                                <li id="tabListZoneOptionsQueryAccess" role="presentation"><a
+                                        href="#tabPaneZoneOptionsQueryAccess"
+                                        aria-controls="tabPaneZoneOptionsQueryAccess" role="tab" data-toggle="tab">Query
+                                        Access</a></li>
+                                <li id="tabListZoneOptionsZoneTranfer" role="presentation"><a
+                                        href="#tabPaneZoneOptionsZoneTransfer"
+                                        aria-controls="tabPaneZoneOptionsZoneTransfer" role="tab" data-toggle="tab">Zone
+                                        Transfer</a></li>
+                                <li id="tabListZoneOptionsNotify" role="presentation"><a
+                                        href="#tabPaneZoneOptionsNotify" aria-controls="tabPaneZoneOptionsNotify"
+                                        role="tab" data-toggle="tab">Notify</a></li>
+                                <li id="tabListZoneOptionsUpdate" role="presentation"><a
+                                        href="#tabPaneZoneOptionsUpdate" aria-controls="tabPaneZoneOptionsUpdate"
+                                        role="tab" data-toggle="tab">Dynamic Updates (RFC 2136)</a></li>
                             </ul>
 
                             <div class="tab-content">
-                                <div id="tabPaneZoneOptionsGeneral" role="tabpanel" class="tab-pane active" style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden;">
+                                <div id="tabPaneZoneOptionsGeneral" role="tabpanel" class="tab-pane active"
+                                    style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden;">
                                     <div class="well well-sm form-horizontal" id="divZoneOptionsGeneralCatalogZone">
                                         <div class="form-group">
-                                            <label for="optZoneOptionsCatalogZoneName" class="col-sm-4 control-label">Catalog Zone</label>
+                                            <label for="optZoneOptionsCatalogZoneName"
+                                                class="col-sm-4 control-label">Catalog Zone</label>
                                             <div class="col-sm-7">
-                                                <select id="optZoneOptionsCatalogZoneName" class="form-control"></select>
-                                                <div style="padding-top: 5px;">Select a Catalog zone to register as its member zone.</div>
+                                                <select id="optZoneOptionsCatalogZoneName"
+                                                    class="form-control"></select>
+                                                <div style="padding-top: 5px;">Select a Catalog zone to register as its
+                                                    member zone.</div>
                                             </div>
                                         </div>
 
@@ -4748,45 +6900,62 @@ MII...
                                             <div class="col-sm-7">
                                                 <div class="checkbox">
                                                     <label>
-                                                        <input id="chkZoneOptionsCatalogOverrideQueryAccess" type="checkbox"> Override Query Access Option
+                                                        <input id="chkZoneOptionsCatalogOverrideQueryAccess"
+                                                            type="checkbox"> Override Query Access Option
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Enable to override Query Access option in the Catalog zone.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Enable to
+                                                        override Query Access option in the Catalog zone.</div>
                                                 </div>
                                                 <div class="checkbox" id="divZoneOptionsCatalogOverrideZoneTransfer">
                                                     <label>
-                                                        <input id="chkZoneOptionsCatalogOverrideZoneTransfer" type="checkbox"> Override Zone Transfer Option
+                                                        <input id="chkZoneOptionsCatalogOverrideZoneTransfer"
+                                                            type="checkbox"> Override Zone Transfer Option
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Enable to override Zone Transfer option in the Catalog zone.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Enable to
+                                                        override Zone Transfer option in the Catalog zone.</div>
                                                 </div>
                                                 <div class="checkbox" id="divZoneOptionsCatalogOverrideNotify">
                                                     <label>
-                                                        <input id="chkZoneOptionsCatalogOverrideNotify" type="checkbox"> Override Notify Option
+                                                        <input id="chkZoneOptionsCatalogOverrideNotify" type="checkbox">
+                                                        Override Notify Option
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Enable to override Notify option in the Catalog zone.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Enable to
+                                                        override Notify option in the Catalog zone.</div>
                                                 </div>
                                             </div>
                                         </div>
 
-                                        <div id="divZoneOptionsCatalogNotifyFailedNameServers" class="form-group" style="display: none;">
+                                        <div id="divZoneOptionsCatalogNotifyFailedNameServers" class="form-group"
+                                            style="display: none;">
                                             <label class="col-sm-4 control-label">Notify Failed Name Servers</label>
                                             <div class="col-sm-7">
-                                                <span id="lblZoneOptionsCatalogNotifyFailedNameServers" class="form-control" style="height: auto;"></span>
+                                                <span id="lblZoneOptionsCatalogNotifyFailedNameServers"
+                                                    class="form-control" style="height: auto;"></span>
                                             </div>
                                         </div>
 
-                                        <div>Note! When a zone becomes a member of a Catalog zone, all of the Catalog zone's Options are inherited unless they are explicitly overridden using the Override Options.</div>
+                                        <div>Note! When a zone becomes a member of a Catalog zone, all of the Catalog
+                                            zone's Options are inherited unless they are explicitly overridden using the
+                                            Override Options.</div>
                                     </div>
 
                                     <div class="well well-sm form-horizontal" id="divZoneOptionsGeneralPrimaryServer">
                                         <div class="form-group">
-                                            <label id="lblZoneOptionsPrimaryNameServerAddresses" for="txtZoneOptionsPrimaryNameServerAddresses" class="col-sm-4 control-label">Primary Name Server Addresses (Optional)</label>
+                                            <label id="lblZoneOptionsPrimaryNameServerAddresses"
+                                                for="txtZoneOptionsPrimaryNameServerAddresses"
+                                                class="col-sm-4 control-label">Primary Name Server Addresses
+                                                (Optional)</label>
                                             <div class="col-sm-7">
-                                                <textarea id="txtZoneOptionsPrimaryNameServerAddresses" class="form-control" rows="4" spellcheck="false" placeholder="192.168.1.1
+                                                <textarea id="txtZoneOptionsPrimaryNameServerAddresses"
+                                                    class="form-control" rows="4" spellcheck="false" placeholder="192.168.1.1
 2001:db8::
 ns1.example.com (192.168.1.1)
 ns1.example.com ([2001:db8::])
 "></textarea>
-                                                <div id="divZoneOptionsPrimaryNameServerAddressesInfo" style="padding-top: 5px;">Enter the primary name server addresses to sync the zone from. When unspecified, the SOA Primary Name Server will be resolved and used.</div>
+                                                <div id="divZoneOptionsPrimaryNameServerAddressesInfo"
+                                                    style="padding-top: 5px;">Enter the primary name server addresses to
+                                                    sync the zone from. When unspecified, the SOA Primary Name Server
+                                                    will be resolved and used.</div>
                                             </div>
                                         </div>
 
@@ -4795,19 +6964,22 @@ ns1.example.com ([2001:db8::])
                                             <div class="col-sm-7">
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdPrimaryZoneTransferProtocol" id="rdPrimaryZoneTransferProtocolTcp" value="Tcp" checked>
+                                                        <input type="radio" name="rdPrimaryZoneTransferProtocol"
+                                                            id="rdPrimaryZoneTransferProtocolTcp" value="Tcp" checked>
                                                         XFR-over-TCP (default)
                                                     </label>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdPrimaryZoneTransferProtocol" id="rdPrimaryZoneTransferProtocolTls" value="Tls">
+                                                        <input type="radio" name="rdPrimaryZoneTransferProtocol"
+                                                            id="rdPrimaryZoneTransferProtocolTls" value="Tls">
                                                         XFR-over-TLS
                                                     </label>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdPrimaryZoneTransferProtocol" id="rdPrimaryZoneTransferProtocolQuic" value="Quic">
+                                                        <input type="radio" name="rdPrimaryZoneTransferProtocol"
+                                                            id="rdPrimaryZoneTransferProtocolQuic" value="Quic">
                                                         XFR-over-QUIC
                                                     </label>
                                                 </div>
@@ -4815,9 +6987,11 @@ ns1.example.com ([2001:db8::])
                                         </div>
 
                                         <div class="form-group" id="divZoneOptionsPrimaryServerZoneTransferTsigKeyName">
-                                            <label for="optZoneOptionsPrimaryZoneTransferTsigKeyName" class="col-sm-4 control-label">TSIG Key Name (Optional)</label>
+                                            <label for="optZoneOptionsPrimaryZoneTransferTsigKeyName"
+                                                class="col-sm-4 control-label">TSIG Key Name (Optional)</label>
                                             <div class="col-sm-7">
-                                                <select id="optZoneOptionsPrimaryZoneTransferTsigKeyName" class="form-control"></select>
+                                                <select id="optZoneOptionsPrimaryZoneTransferTsigKeyName"
+                                                    class="form-control"></select>
                                             </div>
                                         </div>
 
@@ -4826,270 +7000,398 @@ ns1.example.com ([2001:db8::])
                                             <div class="col-sm-7">
                                                 <div class="checkbox">
                                                     <label>
-                                                        <input id="chkZoneOptionsValidateZone" type="checkbox"> Use <a href="https://datatracker.ietf.org/doc/rfc8976/" target="_blank">ZONEMD</a> to Validate Zone
+                                                        <input id="chkZoneOptionsValidateZone" type="checkbox"> Use <a
+                                                            href="https://datatracker.ietf.org/doc/rfc8976/"
+                                                            target="_blank">ZONEMD</a> to Validate Zone
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">When enabled, the secondary zone will be validated using the ZONEMD record after every zone transfer. The zone will get disabled if the validation fails. The zone must be DNSSEC signed for the validation to work.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">When enabled, the
+                                                        secondary zone will be validated using the ZONEMD record after
+                                                        every zone transfer. The zone will get disabled if the
+                                                        validation fails. The zone must be DNSSEC signed for the
+                                                        validation to work.</div>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
 
-                                <div id="tabPaneZoneOptionsQueryAccess" role="tabpanel" class="tab-pane" style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden;">
+                                <div id="tabPaneZoneOptionsQueryAccess" role="tabpanel" class="tab-pane"
+                                    style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden;">
                                     <div class="well well-sm form-horizontal">
                                         <div class="form-group">
                                             <label class="col-sm-3 control-label">Query Access</label>
                                             <div class="col-sm-8">
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdQueryAccess" id="rdQueryAccessDeny" value="Deny">
+                                                        <input type="radio" name="rdQueryAccess" id="rdQueryAccessDeny"
+                                                            value="Deny">
                                                         Deny
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Denies everyone from querying the zone by refusing the request.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Denies everyone
+                                                        from querying the zone by refusing the request.</div>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdQueryAccess" id="rdQueryAccessAllow" value="Allow">
+                                                        <input type="radio" name="rdQueryAccess" id="rdQueryAccessAllow"
+                                                            value="Allow">
                                                         Allow (default)
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows everyone to query the zone.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows everyone
+                                                        to query the zone.</div>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdQueryAccess" id="rdQueryAccessAllowOnlyPrivateNetworks" value="AllowOnlyPrivateNetworks">
+                                                        <input type="radio" name="rdQueryAccess"
+                                                            id="rdQueryAccessAllowOnlyPrivateNetworks"
+                                                            value="AllowOnlyPrivateNetworks">
                                                         Allow Only Private Networks
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows only private networks to query the zone. Any request from a public network will be refused.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows only
+                                                        private networks to query the zone. Any request from a public
+                                                        network will be refused.</div>
                                                 </div>
                                                 <div class="radio" id="divQueryAccessAllowOnlyZoneNameServers">
                                                     <label>
-                                                        <input type="radio" name="rdQueryAccess" id="rdQueryAccessAllowOnlyZoneNameServers" value="AllowOnlyZoneNameServers">
+                                                        <input type="radio" name="rdQueryAccess"
+                                                            id="rdQueryAccessAllowOnlyZoneNameServers"
+                                                            value="AllowOnlyZoneNameServers">
                                                         Allow Only Name Servers In Zone
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows only the name servers with an NS record in the zone to query the zone.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows only the
+                                                        name servers with an NS record in the zone to query the zone.
+                                                    </div>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdQueryAccess" id="rdQueryAccessUseSpecifiedNetworkACL" value="UseSpecifiedNetworkACL">
+                                                        <input type="radio" name="rdQueryAccess"
+                                                            id="rdQueryAccessUseSpecifiedNetworkACL"
+                                                            value="UseSpecifiedNetworkACL">
                                                         Use Specified Network Access Control List (ACL)
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses the specified network access control list to allow/deny to query the zone.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses the
+                                                        specified network access control list to allow/deny to query the
+                                                        zone.</div>
                                                 </div>
-                                                <div class="radio" id="divQueryAccessAllowZoneNameServersAndUseSpecifiedNetworkACL">
+                                                <div class="radio"
+                                                    id="divQueryAccessAllowZoneNameServersAndUseSpecifiedNetworkACL">
                                                     <label>
-                                                        <input type="radio" name="rdQueryAccess" id="rdQueryAccessAllowZoneNameServersAndUseSpecifiedNetworkACL" value="AllowZoneNameServersAndUseSpecifiedNetworkACL">
-                                                        Allow Zone Name Servers And Use Specified Network Access Control List (ACL)
+                                                        <input type="radio" name="rdQueryAccess"
+                                                            id="rdQueryAccessAllowZoneNameServersAndUseSpecifiedNetworkACL"
+                                                            value="AllowZoneNameServersAndUseSpecifiedNetworkACL">
+                                                        Allow Zone Name Servers And Use Specified Network Access Control
+                                                        List (ACL)
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows zone's name servers and uses specified network access control list to allow/deny to query the zone.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows zone's
+                                                        name servers and uses specified network access control list to
+                                                        allow/deny to query the zone.</div>
                                                 </div>
                                             </div>
                                         </div>
 
                                         <div class="form-group">
-                                            <label for="txtQueryAccessNetworkACL" class="col-sm-3 control-label">Network Access Control List (ACL)</label>
+                                            <label for="txtQueryAccessNetworkACL" class="col-sm-3 control-label">Network
+                                                Access Control List (ACL)</label>
                                             <div class="col-sm-8">
-                                                <textarea id="txtQueryAccessNetworkACL" class="form-control" rows="5" spellcheck="false"></textarea>
-                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses one below another to allow access. Add <code>!</code> character at the start to deny access, e.g. <code>!192.168.10.0/24</code> will deny entire subnet. The ACL is processed in the same order its listed. If no networks match, the default policy is to deny all.</div>
+                                                <textarea id="txtQueryAccessNetworkACL" class="form-control" rows="5"
+                                                    spellcheck="false"></textarea>
+                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses
+                                                    one below another to allow access. Add <code>!</code> character at
+                                                    the start to deny access, e.g. <code>!192.168.10.0/24</code> will
+                                                    deny entire subnet. The ACL is processed in the same order its
+                                                    listed. If no networks match, the default policy is to deny all.
+                                                </div>
                                             </div>
                                         </div>
 
-                                        <div>Note! The zone can always be queried from loopback IP addresses and internally by the DNS server irrespective of the Query Access configuration.</div>
+                                        <div>Note! The zone can always be queried from loopback IP addresses and
+                                            internally by the DNS server irrespective of the Query Access configuration.
+                                        </div>
                                     </div>
                                 </div>
 
-                                <div id="tabPaneZoneOptionsZoneTransfer" role="tabpanel" class="tab-pane" style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden;">
+                                <div id="tabPaneZoneOptionsZoneTransfer" role="tabpanel" class="tab-pane"
+                                    style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden;">
                                     <div class="well well-sm form-horizontal">
                                         <div class="form-group">
                                             <label class="col-sm-3 control-label">Zone Transfer</label>
                                             <div class="col-sm-8">
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdZoneTransfer" id="rdZoneTransferDeny" value="Deny">
+                                                        <input type="radio" name="rdZoneTransfer"
+                                                            id="rdZoneTransferDeny" value="Deny">
                                                         Deny
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Denies everyone from performing a zone transfer.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Denies everyone
+                                                        from performing a zone transfer.</div>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdZoneTransfer" id="rdZoneTransferAllow" value="Allow">
+                                                        <input type="radio" name="rdZoneTransfer"
+                                                            id="rdZoneTransferAllow" value="Allow">
                                                         Allow
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows everyone to perform a zone transfer.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows everyone
+                                                        to perform a zone transfer.</div>
                                                 </div>
                                                 <div class="radio" id="divZoneTransferAllowOnlyZoneNameServers">
                                                     <label>
-                                                        <input type="radio" name="rdZoneTransfer" id="rdZoneTransferAllowOnlyZoneNameServers" value="AllowOnlyZoneNameServers">
+                                                        <input type="radio" name="rdZoneTransfer"
+                                                            id="rdZoneTransferAllowOnlyZoneNameServers"
+                                                            value="AllowOnlyZoneNameServers">
                                                         Allow Only Name Servers In Zone
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows only the name servers with an NS record in the zone to perform a zone transfer.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows only the
+                                                        name servers with an NS record in the zone to perform a zone
+                                                        transfer.</div>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdZoneTransfer" id="rdZoneTransferUseSpecifiedNetworkACL" value="UseSpecifiedNetworkACL">
+                                                        <input type="radio" name="rdZoneTransfer"
+                                                            id="rdZoneTransferUseSpecifiedNetworkACL"
+                                                            value="UseSpecifiedNetworkACL">
                                                         Use Specified Network Access Control List (ACL)
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses the specified network access control list to allow/deny to perform a zone transfer.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses the
+                                                        specified network access control list to allow/deny to perform a
+                                                        zone transfer.</div>
                                                 </div>
-                                                <div class="radio" id="divZoneTransferAllowZoneNameServersAndUseSpecifiedNetworkACL">
+                                                <div class="radio"
+                                                    id="divZoneTransferAllowZoneNameServersAndUseSpecifiedNetworkACL">
                                                     <label>
-                                                        <input type="radio" name="rdZoneTransfer" id="rdZoneTransferAllowZoneNameServersAndUseSpecifiedNetworkACL" value="AllowZoneNameServersAndUseSpecifiedNetworkACL">
-                                                        Allow Zone Name Servers And Use Specified Network Access Control List (ACL)
+                                                        <input type="radio" name="rdZoneTransfer"
+                                                            id="rdZoneTransferAllowZoneNameServersAndUseSpecifiedNetworkACL"
+                                                            value="AllowZoneNameServersAndUseSpecifiedNetworkACL">
+                                                        Allow Zone Name Servers And Use Specified Network Access Control
+                                                        List (ACL)
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows zone's name servers and uses specified network access control list to allow/deny to perform a zone transfer.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows zone's
+                                                        name servers and uses specified network access control list to
+                                                        allow/deny to perform a zone transfer.</div>
                                                 </div>
                                             </div>
                                         </div>
 
                                         <div class="form-group">
-                                            <label for="txtZoneTransferNetworkACL" class="col-sm-3 control-label">Network Access Control List (ACL)</label>
+                                            <label for="txtZoneTransferNetworkACL"
+                                                class="col-sm-3 control-label">Network Access Control List (ACL)</label>
                                             <div class="col-sm-8">
-                                                <textarea id="txtZoneTransferNetworkACL" class="form-control" rows="5" spellcheck="false"></textarea>
-                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses one below another to allow access. Add <code>!</code> character at the start to deny access, e.g. <code>!192.168.10.0/24</code> will deny entire subnet. The ACL is processed in the same order its listed. If no networks match, the default policy is to deny all.</div>
+                                                <textarea id="txtZoneTransferNetworkACL" class="form-control" rows="5"
+                                                    spellcheck="false"></textarea>
+                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses
+                                                    one below another to allow access. Add <code>!</code> character at
+                                                    the start to deny access, e.g. <code>!192.168.10.0/24</code> will
+                                                    deny entire subnet. The ACL is processed in the same order its
+                                                    listed. If no networks match, the default policy is to deny all.
+                                                </div>
                                             </div>
                                         </div>
 
-                                        <div>Note! Zone transfer should be allowed only for trusted name servers to sync their secondary zone.</div>
+                                        <div>Note! Zone transfer should be allowed only for trusted name servers to sync
+                                            their secondary zone.</div>
                                     </div>
 
                                     <div class="well well-sm form-horizontal">
                                         <div class="form-group">
-                                            <label for="txtZoneOptionsZoneTransferTsigKeyNames" class="col-sm-3 control-label">Zone Transfer TSIG Key Names</label>
+                                            <label for="txtZoneOptionsZoneTransferTsigKeyNames"
+                                                class="col-sm-3 control-label">Zone Transfer TSIG Key Names</label>
                                             <div class="col-sm-8">
-                                                <textarea id="txtZoneOptionsZoneTransferTsigKeyNames" class="form-control" rows="3" spellcheck="false"></textarea>
+                                                <textarea id="txtZoneOptionsZoneTransferTsigKeyNames"
+                                                    class="form-control" rows="3" spellcheck="false"></textarea>
 
-                                                <label for="optZoneOptionsQuickTsigKeyNames" class="control-label">Quick Add</label>
+                                                <label for="optZoneOptionsQuickTsigKeyNames" class="control-label">Quick
+                                                    Add</label>
                                                 <select id="optZoneOptionsQuickTsigKeyNames" class="form-control">
                                                 </select>
                                             </div>
                                         </div>
 
-                                        <div>Note! TSIG key names must be configured from the Settings before using them here. Entering one or more TSIG key names above will cause the DNS server to authenticate all zone transfer requests. A secondary zone must be configured with one of the above keys to be able to perform a zone transfer.</div>
+                                        <div>Note! TSIG key names must be configured from the Settings before using them
+                                            here. Entering one or more TSIG key names above will cause the DNS server to
+                                            authenticate all zone transfer requests. A secondary zone must be configured
+                                            with one of the above keys to be able to perform a zone transfer.</div>
                                     </div>
                                 </div>
 
-                                <div id="tabPaneZoneOptionsNotify" role="tabpanel" class="tab-pane" style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden; ">
+                                <div id="tabPaneZoneOptionsNotify" role="tabpanel" class="tab-pane"
+                                    style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden; ">
                                     <div class="well well-sm form-horizontal">
                                         <div class="form-group">
                                             <label class="col-sm-3 control-label">Notify</label>
                                             <div class="col-sm-8">
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdZoneNotify" id="rdZoneNotifyNone" value="None">
+                                                        <input type="radio" name="rdZoneNotify" id="rdZoneNotifyNone"
+                                                            value="None">
                                                         None
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Does not notify any name server when the zone is updated.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Does not notify
+                                                        any name server when the zone is updated.</div>
                                                 </div>
                                                 <div class="radio" id="divZoneNotifyZoneNameServers">
                                                     <label>
-                                                        <input type="radio" name="rdZoneNotify" id="rdZoneNotifyZoneNameServers" value="ZoneNameServers">
+                                                        <input type="radio" name="rdZoneNotify"
+                                                            id="rdZoneNotifyZoneNameServers" value="ZoneNameServers">
                                                         Name Servers In Zone
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Notifies only the name servers with an NS record in the zone when the zone is updated.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Notifies only the
+                                                        name servers with an NS record in the zone when the zone is
+                                                        updated.</div>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdZoneNotify" id="rdZoneNotifySpecifiedNameServers" value="SpecifiedNameServers">
+                                                        <input type="radio" name="rdZoneNotify"
+                                                            id="rdZoneNotifySpecifiedNameServers"
+                                                            value="SpecifiedNameServers">
                                                         Specified Name Servers
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Notifies only the specified name servers when the zone is updated.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Notifies only the
+                                                        specified name servers when the zone is updated.</div>
                                                 </div>
                                                 <div class="radio" id="divZoneNotifyBothZoneAndSpecifiedNameServers">
                                                     <label>
-                                                        <input type="radio" name="rdZoneNotify" id="rdZoneNotifyBothZoneAndSpecifiedNameServers" value="BothZoneAndSpecifiedNameServers">
+                                                        <input type="radio" name="rdZoneNotify"
+                                                            id="rdZoneNotifyBothZoneAndSpecifiedNameServers"
+                                                            value="BothZoneAndSpecifiedNameServers">
                                                         Both Zone Name Servers And Specified Name Servers
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Notifies both the zone's name servers and the specified name servers when the zone is updated.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Notifies both the
+                                                        zone's name servers and the specified name servers when the zone
+                                                        is updated.</div>
                                                 </div>
-                                                <div class="radio" id="divZoneNotifySeparateNameServersForCatalogAndMemberZones">
+                                                <div class="radio"
+                                                    id="divZoneNotifySeparateNameServersForCatalogAndMemberZones">
                                                     <label>
-                                                        <input type="radio" name="rdZoneNotify" id="rdZoneNotifySeparateNameServersForCatalogAndMemberZones" value="SeparateNameServersForCatalogAndMemberZones">
+                                                        <input type="radio" name="rdZoneNotify"
+                                                            id="rdZoneNotifySeparateNameServersForCatalogAndMemberZones"
+                                                            value="SeparateNameServersForCatalogAndMemberZones">
                                                         Separate Name Servers For Catalog And Member Zones
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Notifies specified name servers for member zone updates and secondary catalog name servers for catalog zone updates.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Notifies
+                                                        specified name servers for member zone updates and secondary
+                                                        catalog name servers for catalog zone updates.</div>
                                                 </div>
                                             </div>
                                         </div>
 
                                         <div class="form-group">
-                                            <label for="txtZoneNotifyNameServers" class="col-sm-3 control-label">Specified Name Servers</label>
+                                            <label for="txtZoneNotifyNameServers"
+                                                class="col-sm-3 control-label">Specified Name Servers</label>
                                             <div class="col-sm-8">
-                                                <textarea id="txtZoneNotifyNameServers" class="form-control" rows="5" spellcheck="false"></textarea>
-                                                <div style="padding-top: 5px;">Enter only the IP addresses of the name servers above.</div>
+                                                <textarea id="txtZoneNotifyNameServers" class="form-control" rows="5"
+                                                    spellcheck="false"></textarea>
+                                                <div style="padding-top: 5px;">Enter only the IP addresses of the name
+                                                    servers above.</div>
                                             </div>
                                         </div>
 
                                         <div id="divZoneNotifySecondaryCatalogNameServers" class="form-group">
-                                            <label for="txtZoneNotifySecondaryCatalogNameServers" class="col-sm-3 control-label">Secondary Catalog Name Servers</label>
+                                            <label for="txtZoneNotifySecondaryCatalogNameServers"
+                                                class="col-sm-3 control-label">Secondary Catalog Name Servers</label>
                                             <div class="col-sm-8">
-                                                <textarea id="txtZoneNotifySecondaryCatalogNameServers" class="form-control" rows="5" spellcheck="false"></textarea>
-                                                <div style="padding-top: 5px;">Enter only the IP addresses of the Secondary Catalog name servers above.</div>
+                                                <textarea id="txtZoneNotifySecondaryCatalogNameServers"
+                                                    class="form-control" rows="5" spellcheck="false"></textarea>
+                                                <div style="padding-top: 5px;">Enter only the IP addresses of the
+                                                    Secondary Catalog name servers above.</div>
                                             </div>
                                         </div>
 
-                                        <div id="divZoneNotifyFailedNameServers" class="form-group" style="display: none;">
+                                        <div id="divZoneNotifyFailedNameServers" class="form-group"
+                                            style="display: none;">
                                             <label class="col-sm-3 control-label">Notify Failed Name Servers</label>
                                             <div class="col-sm-8">
-                                                <span id="lblZoneNotifyFailedNameServers" class="form-control" style="height: auto;"></span>
+                                                <span id="lblZoneNotifyFailedNameServers" class="form-control"
+                                                    style="height: auto;"></span>
                                             </div>
                                         </div>
 
-                                        <div>Note! Notification must be enabled to allow other name servers to trigger a zone transfer immediately when the zone is updated.</div>
+                                        <div>Note! Notification must be enabled to allow other name servers to trigger a
+                                            zone transfer immediately when the zone is updated.</div>
                                     </div>
                                 </div>
 
-                                <div id="tabPaneZoneOptionsUpdate" role="tabpanel" class="tab-pane" style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden;">
+                                <div id="tabPaneZoneOptionsUpdate" role="tabpanel" class="tab-pane"
+                                    style="padding: 0 6px 0 0; max-height: 450px; margin: 10px 0 0 0; overflow-y: auto; overflow-x: hidden;">
                                     <div class="well well-sm form-horizontal">
                                         <div class="form-group">
                                             <label class="col-sm-3 control-label">Dynamic Updates</label>
                                             <div class="col-sm-8">
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdDynamicUpdate" id="rdDynamicUpdateDeny" value="Deny">
+                                                        <input type="radio" name="rdDynamicUpdate"
+                                                            id="rdDynamicUpdateDeny" value="Deny">
                                                         Deny (default)
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Denies everyone from performing dynamic updates.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Denies everyone
+                                                        from performing dynamic updates.</div>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdDynamicUpdate" id="rdDynamicUpdateAllow" value="Allow">
+                                                        <input type="radio" name="rdDynamicUpdate"
+                                                            id="rdDynamicUpdateAllow" value="Allow">
                                                         Allow
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows everyone to perform dynamic updates.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows everyone
+                                                        to perform dynamic updates.</div>
                                                 </div>
                                                 <div class="radio" id="divDynamicUpdateAllowOnlyZoneNameServers">
                                                     <label>
-                                                        <input type="radio" name="rdDynamicUpdate" id="rdDynamicUpdateAllowOnlyZoneNameServers" value="AllowOnlyZoneNameServers">
+                                                        <input type="radio" name="rdDynamicUpdate"
+                                                            id="rdDynamicUpdateAllowOnlyZoneNameServers"
+                                                            value="AllowOnlyZoneNameServers">
                                                         Allow Only Name Servers In Zone
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows only the name servers with an NS record in the zone to perform dynamic updates.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows only the
+                                                        name servers with an NS record in the zone to perform dynamic
+                                                        updates.</div>
                                                 </div>
                                                 <div class="radio">
                                                     <label>
-                                                        <input type="radio" name="rdDynamicUpdate" id="rdDynamicUpdateUseSpecifiedNetworkACL" value="UseSpecifiedNetworkACL">
+                                                        <input type="radio" name="rdDynamicUpdate"
+                                                            id="rdDynamicUpdateUseSpecifiedNetworkACL"
+                                                            value="UseSpecifiedNetworkACL">
                                                         Use Specified Network Access Control List (ACL)
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses the specified network access control list to allow/deny to perform dynamic updates.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Uses the
+                                                        specified network access control list to allow/deny to perform
+                                                        dynamic updates.</div>
                                                 </div>
-                                                <div class="radio" id="divDynamicUpdateAllowZoneNameServersAndUseSpecifiedNetworkACL">
+                                                <div class="radio"
+                                                    id="divDynamicUpdateAllowZoneNameServersAndUseSpecifiedNetworkACL">
                                                     <label>
-                                                        <input type="radio" name="rdDynamicUpdate" id="rdDynamicUpdateAllowZoneNameServersAndUseSpecifiedNetworkACL" value="AllowZoneNameServersAndUseSpecifiedNetworkACL">
-                                                        Allow Zone Name Servers And Use Specified Network Access Control List (ACL)
+                                                        <input type="radio" name="rdDynamicUpdate"
+                                                            id="rdDynamicUpdateAllowZoneNameServersAndUseSpecifiedNetworkACL"
+                                                            value="AllowZoneNameServersAndUseSpecifiedNetworkACL">
+                                                        Allow Zone Name Servers And Use Specified Network Access Control
+                                                        List (ACL)
                                                     </label>
-                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows zone's name servers and uses specified network access control list to allow/deny to perform dynamic updates.</div>
+                                                    <div style="padding-top: 5px; padding-left: 20px;">Allows zone's
+                                                        name servers and uses specified network access control list to
+                                                        allow/deny to perform dynamic updates.</div>
                                                 </div>
                                             </div>
                                         </div>
 
                                         <div class="form-group">
-                                            <label for="txtDynamicUpdateNetworkACL" class="col-sm-3 control-label">Network Access Control List (ACL)</label>
+                                            <label for="txtDynamicUpdateNetworkACL"
+                                                class="col-sm-3 control-label">Network Access Control List (ACL)</label>
                                             <div class="col-sm-8">
-                                                <textarea id="txtDynamicUpdateNetworkACL" class="form-control" rows="5" spellcheck="false"></textarea>
-                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses one below another to allow access. Add <code>!</code> character at the start to deny access, e.g. <code>!192.168.10.0/24</code> will deny entire subnet. The ACL is processed in the same order its listed. If no networks match, the default policy is to deny all.</div>
+                                                <textarea id="txtDynamicUpdateNetworkACL" class="form-control" rows="5"
+                                                    spellcheck="false"></textarea>
+                                                <div style="padding-top: 5px;">Enter IP addresses or network addresses
+                                                    one below another to allow access. Add <code>!</code> character at
+                                                    the start to deny access, e.g. <code>!192.168.10.0/24</code> will
+                                                    deny entire subnet. The ACL is processed in the same order its
+                                                    listed. If no networks match, the default policy is to deny all.
+                                                </div>
                                             </div>
                                         </div>
 
-                                        <div>Note! Dynamic updates should be allowed only to trusted IP addresses since they will be able to add/delete records in the zone.</div>
-                                        <div style="padding-top: 10px;">Warning! If no security policy is configured in the Primary Zone then access will be provided only based on the options selected here. Thus setting up a security policy in the Primary Zone is highly recommended.</div>
+                                        <div>Note! Dynamic updates should be allowed only to trusted IP addresses since
+                                            they will be able to add/delete records in the zone.</div>
+                                        <div style="padding-top: 10px;">Warning! If no security policy is configured in
+                                            the Primary Zone then access will be provided only based on the options
+                                            selected here. Thus setting up a security policy in the Primary Zone is
+                                            highly recommended.</div>
                                     </div>
 
                                     <div id="divDynamicUpdateSecurityPolicy" class="well well-sm form-horizontal">
@@ -5102,14 +7404,22 @@ ns1.example.com ([2001:db8::])
                                                     <th>Domain Name</th>
                                                     <th>Allowed Record Types</th>
                                                     <th style="width: 84px;">
-                                                        <button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addZoneOptionsDynamicUpdatesSecurityPolicyRow();">Add</button>
+                                                        <button type="button" class="btn btn-default"
+                                                            style="padding: 0px 20px;"
+                                                            onclick="addZoneOptionsDynamicUpdatesSecurityPolicyRow();">Add</button>
                                                     </th>
                                                 </tr>
                                             </thead>
                                             <tbody id="tbodyDynamicUpdateSecurityPolicy"></tbody>
                                         </table>
 
-                                        <div>Note! Configuring a security policy above will cause the DNS server to authenticate all dynamic update requests. A TSIG key can add/delete records only for the specified domain name and allowed record types. TSIG key names must be configured from the Settings before using them here. Use wildcard domain name to specify all sub domain names. Use a comma separator to specify more than one record type. Use ANY to specify all record types.</div>
+                                        <div>Note! Configuring a security policy above will cause the DNS server to
+                                            authenticate all dynamic update requests. A TSIG key can add/delete records
+                                            only for the specified domain name and allowed record types. TSIG key names
+                                            must be configured from the Settings before using them here. Use wildcard
+                                            domain name to specify all sub domain names. Use a comma separator to
+                                            specify more than one record type. Use ANY to specify all record types.
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -5117,7 +7427,8 @@ ns1.example.com ([2001:db8::])
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnSaveZoneOptions" type="submit" class="btn btn-primary" data-loading-text="Saving..." onclick="saveZoneOptions(); return false;">Save</button>
+                    <button id="btnSaveZoneOptions" type="submit" class="btn btn-primary" data-loading-text="Saving..."
+                        onclick="saveZoneOptions(); return false;">Save</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -5128,31 +7439,36 @@ ns1.example.com ([2001:db8::])
         <div class="modal-dialog" role="document" style="width: 780px;">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Sign Zone - <span id="lblDnssecSignZoneZoneName"></span></h4>
                 </div>
                 <div class="modal-body">
                     <div id="divDnssecSignZoneAlert"></div>
 
-                    <div class="form-horizontal" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                    <div class="form-horizontal"
+                        style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                         <div class="form-group">
                             <label class="col-sm-4 control-label">DNSKEY Algorithm</label>
                             <div class="col-sm-8">
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneAlgorithm" id="rdDnssecSignZoneAlgorithmRsa" value="RSA">
+                                        <input type="radio" name="rdDnssecSignZoneAlgorithm"
+                                            id="rdDnssecSignZoneAlgorithmRsa" value="RSA">
                                         RSA
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneAlgorithm" id="rdDnssecSignZoneAlgorithmEcdsa" value="ECDSA">
+                                        <input type="radio" name="rdDnssecSignZoneAlgorithm"
+                                            id="rdDnssecSignZoneAlgorithmEcdsa" value="ECDSA">
                                         ECDSA (recommended)
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneAlgorithm" id="rdDnssecSignZoneAlgorithmEddsa" value="EDDSA">
+                                        <input type="radio" name="rdDnssecSignZoneAlgorithm"
+                                            id="rdDnssecSignZoneAlgorithmEddsa" value="EDDSA">
                                         EdDSA
                                     </label>
                                 </div>
@@ -5161,9 +7477,11 @@ ns1.example.com ([2001:db8::])
 
                         <div id="divDnssecSignZoneRsaParameters">
                             <div class="form-group">
-                                <label for="optDnssecSignZoneRsaHashAlgorithm" class="col-sm-4 control-label">Hash Algorithm</label>
+                                <label for="optDnssecSignZoneRsaHashAlgorithm" class="col-sm-4 control-label">Hash
+                                    Algorithm</label>
                                 <div class="col-sm-8">
-                                    <select id="optDnssecSignZoneRsaHashAlgorithm" class="form-control" style="width: auto;">
+                                    <select id="optDnssecSignZoneRsaHashAlgorithm" class="form-control"
+                                        style="width: auto;">
                                         <option value="MD5">MD5 (obsolete)</option>
                                         <option value="SHA1">SHA1 (obsolete)</option>
                                         <option value="SHA256">SHA256 (default)</option>
@@ -5175,7 +7493,8 @@ ns1.example.com ([2001:db8::])
 
                         <div id="divDnssecSignZoneEcdsaParameters">
                             <div class="form-group">
-                                <label for="optDnssecSignZoneEcdsaCurve" class="col-sm-4 control-label">ECDSA Curve</label>
+                                <label for="optDnssecSignZoneEcdsaCurve" class="col-sm-4 control-label">ECDSA
+                                    Curve</label>
                                 <div class="col-sm-8">
                                     <select id="optDnssecSignZoneEcdsaCurve" class="form-control" style="width: auto;">
                                         <option value="P256">P256 (default)</option>
@@ -5187,7 +7506,8 @@ ns1.example.com ([2001:db8::])
 
                         <div id="divDnssecSignZoneEddsaParameters">
                             <div class="form-group">
-                                <label for="optDnssecSignZoneEddsaCurve" class="col-sm-4 control-label">EdDSA Curve</label>
+                                <label for="optDnssecSignZoneEddsaCurve" class="col-sm-4 control-label">EdDSA
+                                    Curve</label>
                                 <div class="col-sm-8">
                                     <select id="optDnssecSignZoneEddsaCurve" class="form-control" style="width: auto;">
                                         <option value="ED25519">Ed25519 (default)</option>
@@ -5202,13 +7522,15 @@ ns1.example.com ([2001:db8::])
                             <div class="col-sm-8">
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneKskGeneration" id="rdDnssecSignZoneKskGenerationAutomatic" value="Automatic">
+                                        <input type="radio" name="rdDnssecSignZoneKskGeneration"
+                                            id="rdDnssecSignZoneKskGenerationAutomatic" value="Automatic">
                                         Automatic Private Key Generation (default)
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneKskGeneration" id="rdDnssecSignZoneKskGenerationUseSpecified" value="UseSpecified">
+                                        <input type="radio" name="rdDnssecSignZoneKskGeneration"
+                                            id="rdDnssecSignZoneKskGenerationUseSpecified" value="UseSpecified">
                                         Use Specified Private Key
                                     </label>
                                 </div>
@@ -5217,9 +7539,11 @@ ns1.example.com ([2001:db8::])
 
                         <div id="divDnssecSignZoneRsaKskKeySize">
                             <div class="form-group">
-                                <label for="optDnssecSignZoneRsaKskKeySize" class="col-sm-4 control-label">KSK Size</label>
+                                <label for="optDnssecSignZoneRsaKskKeySize" class="col-sm-4 control-label">KSK
+                                    Size</label>
                                 <div class="col-sm-8">
-                                    <select id="optDnssecSignZoneRsaKskKeySize" class="form-control" style="width: auto; display: inline;">
+                                    <select id="optDnssecSignZoneRsaKskKeySize" class="form-control"
+                                        style="width: auto; display: inline;">
                                         <option>1024</option>
                                         <option>1280</option>
                                         <option>1536</option>
@@ -5234,9 +7558,11 @@ ns1.example.com ([2001:db8::])
 
                         <div id="divDnssecSignZonePemKskPrivateKey">
                             <div class="form-group">
-                                <label for="txtDnssecSignZonePemKskPrivateKey" class="col-sm-4 control-label">KSK Private Key</label>
+                                <label for="txtDnssecSignZonePemKskPrivateKey" class="col-sm-4 control-label">KSK
+                                    Private Key</label>
                                 <div class="col-sm-7">
-                                    <textarea id="txtDnssecSignZonePemKskPrivateKey" class="form-control" rows="4" spellcheck="false" placeholder="-----BEGIN PRIVATE KEY-----
+                                    <textarea id="txtDnssecSignZonePemKskPrivateKey" class="form-control" rows="4"
+                                        spellcheck="false" placeholder="-----BEGIN PRIVATE KEY-----
 MII...
 -----END PRIVATE KEY-----"></textarea>
                                     <div style="padding-top: 5px;">Enter a private key in PEM format.</div>
@@ -5249,13 +7575,15 @@ MII...
                             <div class="col-sm-8">
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneZskGeneration" id="rdDnssecSignZoneZskGenerationAutomatic" value="Automatic">
+                                        <input type="radio" name="rdDnssecSignZoneZskGeneration"
+                                            id="rdDnssecSignZoneZskGenerationAutomatic" value="Automatic">
                                         Automatic Private Key Generation (default)
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneZskGeneration" id="rdDnssecSignZoneZskGenerationUseSpecified" value="UseSpecified">
+                                        <input type="radio" name="rdDnssecSignZoneZskGeneration"
+                                            id="rdDnssecSignZoneZskGenerationUseSpecified" value="UseSpecified">
                                         Use Specified Private Key
                                     </label>
                                 </div>
@@ -5264,9 +7592,11 @@ MII...
 
                         <div id="divDnssecSignZoneRsaZskKeySize">
                             <div class="form-group">
-                                <label for="optDnssecSignZoneRsaZskKeySize" class="col-sm-4 control-label">ZSK Size</label>
+                                <label for="optDnssecSignZoneRsaZskKeySize" class="col-sm-4 control-label">ZSK
+                                    Size</label>
                                 <div class="col-sm-8">
-                                    <select id="optDnssecSignZoneRsaZskKeySize" class="form-control" style="width: auto; display: inline;">
+                                    <select id="optDnssecSignZoneRsaZskKeySize" class="form-control"
+                                        style="width: auto; display: inline;">
                                         <option>1024</option>
                                         <option>1280</option>
                                         <option>1536</option>
@@ -5281,9 +7611,11 @@ MII...
 
                         <div id="divDnssecSignZonePemZskPrivateKey">
                             <div class="form-group">
-                                <label for="txtDnssecSignZonePemZskPrivateKey" class="col-sm-4 control-label">ZSK Private Key</label>
+                                <label for="txtDnssecSignZonePemZskPrivateKey" class="col-sm-4 control-label">ZSK
+                                    Private Key</label>
                                 <div class="col-sm-7">
-                                    <textarea id="txtDnssecSignZonePemZskPrivateKey" class="form-control" rows="4" spellcheck="false" placeholder="-----BEGIN PRIVATE KEY-----
+                                    <textarea id="txtDnssecSignZonePemZskPrivateKey" class="form-control" rows="4"
+                                        spellcheck="false" placeholder="-----BEGIN PRIVATE KEY-----
 MII...
 -----END PRIVATE KEY-----"></textarea>
                                     <div style="padding-top: 5px;">Enter a private key in PEM format.</div>
@@ -5296,20 +7628,26 @@ MII...
                             <div class="col-sm-8">
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneNxProof" id="rdDnssecSignZoneNxProofNSEC" value="NSEC">
+                                        <input type="radio" name="rdDnssecSignZoneNxProof"
+                                            id="rdDnssecSignZoneNxProofNSEC" value="NSEC">
                                         Next Secure (NSEC) (recommended)
                                     </label>
                                     <div style="padding-top: 5px; padding-left: 20px;">
-                                        With NSEC, all the records in your zone can be discovered by anyone using "zone walking" technique. NSEC is recommended if your zone does not contain any private/internal records.
+                                        With NSEC, all the records in your zone can be discovered by anyone using "zone
+                                        walking" technique. NSEC is recommended if your zone does not contain any
+                                        private/internal records.
                                     </div>
                                 </div>
                                 <div class="radio">
                                     <label>
-                                        <input type="radio" name="rdDnssecSignZoneNxProof" id="rdDnssecSignZoneNxProofNSEC3" value="NSEC3">
+                                        <input type="radio" name="rdDnssecSignZoneNxProof"
+                                            id="rdDnssecSignZoneNxProofNSEC3" value="NSEC3">
                                         Next Secure 3 (NSEC3)
                                     </label>
                                     <div style="padding-top: 5px; padding-left: 20px;">
-                                        NSEC3, makes it difficult to perform "zone walking" since it uses hashing with a random salt. NSEC3 should be used if your zone contains any private/internal records that you do not wish to be enumerable.
+                                        NSEC3, makes it difficult to perform "zone walking" since it uses hashing with a
+                                        random salt. NSEC3 should be used if your zone contains any private/internal
+                                        records that you do not wish to be enumerable.
                                     </div>
                                 </div>
                             </div>
@@ -5317,24 +7655,36 @@ MII...
 
                         <div id="divDnssecSignZoneNSEC3Parameters">
                             <div class="form-group">
-                                <label for="txtDnssecSignZoneNSEC3Iterations" class="col-sm-4 control-label">NSEC3 Iterations</label>
+                                <label for="txtDnssecSignZoneNSEC3Iterations" class="col-sm-4 control-label">NSEC3
+                                    Iterations</label>
                                 <div class="col-sm-8">
-                                    <input id="txtDnssecSignZoneNSEC3Iterations" type="number" class="form-control" placeholder="iterations" style="width: 100px; display: inline;">
+                                    <input id="txtDnssecSignZoneNSEC3Iterations" type="number" class="form-control"
+                                        placeholder="iterations" style="width: 100px; display: inline;">
                                     <span>(valid range 0-50, recommended 0)</span>
                                 </div>
                                 <div class="col-sm-offset-4 col-sm-8" style="padding-top: 5px;">
-                                    The number of iterations used by NSEC3 for hashing the domain names. It is recommended to use 0 iterations since more iterations will increase computational costs for both the DNS server and resolver while not providing much value against "zone walking" [<a href="https://www.rfc-editor.org/rfc/rfc9276.html#name-iterations" target="_blank">RFC 9276</a>].
+                                    The number of iterations used by NSEC3 for hashing the domain names. It is
+                                    recommended to use 0 iterations since more iterations will increase computational
+                                    costs for both the DNS server and resolver while not providing much value against
+                                    "zone walking" [<a
+                                        href="https://www.rfc-editor.org/rfc/rfc9276.html#name-iterations"
+                                        target="_blank">RFC 9276</a>].
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtDnssecSignZoneNSEC3SaltLength" class="col-sm-4 control-label">NSEC3 Salt Length</label>
+                                <label for="txtDnssecSignZoneNSEC3SaltLength" class="col-sm-4 control-label">NSEC3 Salt
+                                    Length</label>
                                 <div class="col-sm-8">
-                                    <input id="txtDnssecSignZoneNSEC3SaltLength" type="number" class="form-control" placeholder="length" style="width: 100px; display: inline;">
+                                    <input id="txtDnssecSignZoneNSEC3SaltLength" type="number" class="form-control"
+                                        placeholder="length" style="width: 100px; display: inline;">
                                     <span>bytes (valid range 0-32, recommended 0)</span>
                                 </div>
                                 <div class="col-sm-offset-4 col-sm-8" style="padding-top: 5px;">
-                                    The number of bytes of random salt to generate to be used with the NSEC3 hash computation. It is recommended to not use salt by setting the length to 0 [<a href="https://www.rfc-editor.org/rfc/rfc9276.html#name-salt" target="_blank">RFC 9276</a>].
+                                    The number of bytes of random salt to generate to be used with the NSEC3 hash
+                                    computation. It is recommended to not use salt by setting the length to 0 [<a
+                                        href="https://www.rfc-editor.org/rfc/rfc9276.html#name-salt" target="_blank">RFC
+                                        9276</a>].
                                 </div>
                             </div>
                         </div>
@@ -5342,32 +7692,40 @@ MII...
                         <div class="form-group">
                             <label for="txtDnssecSignZoneDnsKeyTtl" class="col-sm-4 control-label">DNSKEY TTL</label>
                             <div class="col-sm-8">
-                                <input id="txtDnssecSignZoneDnsKeyTtl" type="text" class="form-control" placeholder="ttl" style="width: 100px; display: inline;">
+                                <input id="txtDnssecSignZoneDnsKeyTtl" type="text" class="form-control"
+                                    placeholder="ttl" style="width: 100px; display: inline;">
                                 <span>seconds (default 3600/1h)</span>
                             </div>
                             <div class="col-sm-offset-4 col-sm-8" style="padding-top: 5px;">
-                                The TTL value to be used for DNSKEY records. A lower value will allow quicker addition or rollover to a new DNS Key at the cost of increased frequency of DNSKEY queries by resolvers.
+                                The TTL value to be used for DNSKEY records. A lower value will allow quicker addition
+                                or rollover to a new DNS Key at the cost of increased frequency of DNSKEY queries by
+                                resolvers.
                             </div>
                         </div>
 
                         <div class="form-group">
-                            <label for="txtDnssecSignZoneZskAutoRollover" class="col-sm-4 control-label">ZSK Automatic Rollover</label>
+                            <label for="txtDnssecSignZoneZskAutoRollover" class="col-sm-4 control-label">ZSK Automatic
+                                Rollover</label>
                             <div class="col-sm-8">
-                                <input id="txtDnssecSignZoneZskAutoRollover" type="number" class="form-control" placeholder="days" style="width: 100px; display: inline;">
+                                <input id="txtDnssecSignZoneZskAutoRollover" type="number" class="form-control"
+                                    placeholder="days" style="width: 100px; display: inline;">
                                 <span>days (valid range 0-365; default 30; set 0 to disable)</span>
                             </div>
                             <div class="col-sm-offset-4 col-sm-8" style="padding-top: 5px;">
-                                The frequency at which the DNS server must automatically rollover the Zone Signing Key (ZSK).
+                                The frequency at which the DNS server must automatically rollover the Zone Signing Key
+                                (ZSK).
                             </div>
                         </div>
                     </div>
                 </div>
                 <div class="modal-footer">
                     <div class="pull-left" style="padding: 6px 0;">
-                        <a href="https://blog.technitium.com/2022/07/how-to-secure-your-domain-name-with-.html" target="_blank">Help: How To Secure Your Domain Name With DNSSEC</a>
+                        <a href="https://blog.technitium.com/2022/07/how-to-secure-your-domain-name-with-.html"
+                            target="_blank">Help: How To Secure Your Domain Name With DNSSEC</a>
                     </div>
                     <div class="pull-right">
-                        <button id="btnDnssecSignZone" type="submit" class="btn btn-primary" data-loading-text="Signing..." onclick="signPrimaryZone(); return false;">Sign Zone</button>
+                        <button id="btnDnssecSignZone" type="submit" class="btn btn-primary"
+                            data-loading-text="Signing..." onclick="signPrimaryZone(); return false;">Sign Zone</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -5379,25 +7737,38 @@ MII...
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Unsign Zone - <span id="lblDnssecUnsignZoneZoneName"></span></h4>
                 </div>
                 <div class="modal-body">
                     <div id="divDnssecUnsignZoneAlert"></div>
 
-                    <p><b>Warning!</b> Unsigning the zone without removing all DS records from its parent zone will cause DNSSEC validating recursive resolvers to mark the zone as <b>bogus</b> and fail to resolve it.</p>
+                    <p><b>Warning!</b> Unsigning the zone without removing all DS records from its parent zone will
+                        cause DNSSEC validating recursive resolvers to mark the zone as <b>bogus</b> and fail to resolve
+                        it.</p>
 
-                    <p><b>Warning!</b> Make sure that you have removed all of the DS records from the parent zone and sufficient time has passed before unsigning this zone. You MUST wait for at least the number of seconds specified by the DS record's TTL value to elapse before unsigning the zone to ensure that all recursive resolvers would have expired the DS records from its cache. For example, if you have DS records at the parent zone with TTL value set to 86400 then you must wait for 86400 seconds (24 hours) to pass after you delete the DS records from the parent zone. Once you have ensured that you have waited for the appropriate time then you can unsign the zone safely.</p>
+                    <p><b>Warning!</b> Make sure that you have removed all of the DS records from the parent zone and
+                        sufficient time has passed before unsigning this zone. You MUST wait for at least the number of
+                        seconds specified by the DS record's TTL value to elapse before unsigning the zone to ensure
+                        that all recursive resolvers would have expired the DS records from its cache. For example, if
+                        you have DS records at the parent zone with TTL value set to 86400 then you must wait for 86400
+                        seconds (24 hours) to pass after you delete the DS records from the parent zone. Once you have
+                        ensured that you have waited for the appropriate time then you can unsign the zone safely.</p>
 
-                    <p><b>Note!</b> You can find out the TTL value of DS records for your zone by querying for DS records using the DNS Client tab.</p>
+                    <p><b>Note!</b> You can find out the TTL value of DS records for your zone by querying for DS
+                        records using the DNS Client tab.</p>
 
-                    <p><b>Warning!</b> Unsigning the zone will permanently delete all of the private keys associated with it. Consider taking a backup before proceeding.</p>
+                    <p><b>Warning!</b> Unsigning the zone will permanently delete all of the private keys associated
+                        with it. Consider taking a backup before proceeding.</p>
 
                     <p>&nbsp;</p>
                     <p>Are you sure you want to proceed to unsign the zone now?</p>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnDnssecUnsignZone" type="submit" class="btn btn-danger" data-loading-text="Unsigning..." onclick="unsignPrimaryZone(); return false;">Unsign Zone</button>
+                    <button id="btnDnssecUnsignZone" type="submit" class="btn btn-danger"
+                        data-loading-text="Unsigning..." onclick="unsignPrimaryZone(); return false;">Unsign
+                        Zone</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -5408,7 +7779,8 @@ MII...
         <div class="modal-dialog" role="document" style="width: 940px;">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">View DS Info - <span id="lblDnssecViewDsZoneName"></span></h4>
                 </div>
                 <div class="modal-body">
@@ -5416,15 +7788,25 @@ MII...
 
                     <div id="divDnssecViewDsLoader" style="height: 500px;"></div>
 
-                    <div id="divDnssecViewDs" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                    <div id="divDnssecViewDs"
+                        style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                         <p>
-                            Use the DNS Key data given below to add DS records for your zone. Before adding the DS records, you must read and understand the following points:
-                            <ul>
-                                <li>The Key State for a newly published DNS Key must be <code>Ready</code> before you can add a DS record for it. Adding DS record for a DNS Key with <code>Published</code> Key State may cause DNSSEC validation to fail for some DNS resolvers. A "ready by" timestamp is displayed to let you know when a DS record can be added for a DNS Key that is not "Ready" yet.</li>
-                                <li>You should add only one DS record for each Key Tag. That is, do not create multiple DS records for each Digest Type, instead use the Digest Type that is supported by your Domain Registrar.</li>
-                                <li>Use the provided Public Key if the Domain Registrar requires it instead of the Digest.</li>
-                                <li>When doing a Key Signing Key (KSK) rollover, you can immediately delete the old DS record after adding the new DS record.</li>
-                            </ul>
+                            Use the DNS Key data given below to add DS records for your zone. Before adding the DS
+                            records, you must read and understand the following points:
+                        <ul>
+                            <li>The Key State for a newly published DNS Key must be <code>Ready</code> before you can
+                                add a DS record for it. Adding DS record for a DNS Key with <code>Published</code> Key
+                                State may cause DNSSEC validation to fail for some DNS resolvers. A "ready by" timestamp
+                                is displayed to let you know when a DS record can be added for a DNS Key that is not
+                                "Ready" yet.</li>
+                            <li>You should add only one DS record for each Key Tag. That is, do not create multiple DS
+                                records for each Digest Type, instead use the Digest Type that is supported by your
+                                Domain Registrar.</li>
+                            <li>Use the provided Public Key if the Domain Registrar requires it instead of the Digest.
+                            </li>
+                            <li>When doing a Key Signing Key (KSK) rollover, you can immediately delete the old DS
+                                record after adding the new DS record.</li>
+                        </ul>
                         </p>
 
                         <table class="table well well-sm">
@@ -5453,7 +7835,8 @@ MII...
         <div class="modal-dialog" role="document" style="width: 940px;">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">DNSSEC Properties - <span id="lblDnssecPropertiesZoneName"></span></h4>
                 </div>
                 <div class="modal-body">
@@ -5461,17 +7844,30 @@ MII...
 
                     <div id="divDnssecPropertiesLoader" style="height: 500px;"></div>
 
-                    <div id="divDnssecProperties" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                    <div id="divDnssecProperties"
+                        style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                         <div class="well well-sm form-horizontal">
                             <table class="table table-hover" style="margin-bottom: 10px;">
                                 <thead>
                                     <tr>
-                                        <th><a href="#" onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 0); return false;">Key Tag</a></th>
-                                        <th><a href="#" onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 1); return false;">Key Type</a></th>
-                                        <th><a href="#" onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 2); return false;">Algorithm</a></th>
-                                        <th><a href="#" onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 3); return false;">State</a></th>
-                                        <th><a href="#" onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 4); return false;">State Changed</a></th>
-                                        <th><a href="#" onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 5); return false;">Rollover (days)</a></th>
+                                        <th><a href="#"
+                                                onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 0); return false;">Key
+                                                Tag</a></th>
+                                        <th><a href="#"
+                                                onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 1); return false;">Key
+                                                Type</a></th>
+                                        <th><a href="#"
+                                                onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 2); return false;">Algorithm</a>
+                                        </th>
+                                        <th><a href="#"
+                                                onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 3); return false;">State</a>
+                                        </th>
+                                        <th><a href="#"
+                                                onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 4); return false;">State
+                                                Changed</a></th>
+                                        <th><a href="#"
+                                                onclick="sortTable('tableDnssecPropertiesPrivateKeysBody', 5); return false;">Rollover
+                                                (days)</a></th>
                                         <th style="width: 36px;"></th>
                                     </tr>
                                 </thead>
@@ -5480,16 +7876,24 @@ MII...
                             </table>
 
                             <div>
-                                <button type="button" class="btn btn-primary" style="padding: 2px 0; width: 120px;" data-toggle="collapse" data-target="#divDnssecPropertiesAddKey" aria-expanded="false" aria-controls="divDnssecPropertiesAddKey">Add Private Key</button>
-                                <button id="btnDnssecPropertiesPublishKeys" type="button" class="btn btn-warning" style="padding: 2px 0; width: 120px;" data-loading-text="Publishing..." onclick="publishAllDnssecPrivateKeys(this);">Publish All Keys</button>
+                                <button type="button" class="btn btn-primary" style="padding: 2px 0; width: 120px;"
+                                    data-toggle="collapse" data-target="#divDnssecPropertiesAddKey"
+                                    aria-expanded="false" aria-controls="divDnssecPropertiesAddKey">Add Private
+                                    Key</button>
+                                <button id="btnDnssecPropertiesPublishKeys" type="button" class="btn btn-warning"
+                                    style="padding: 2px 0; width: 120px;" data-loading-text="Publishing..."
+                                    onclick="publishAllDnssecPrivateKeys(this);">Publish All Keys</button>
                             </div>
 
                             <div id="divDnssecPropertiesAddKey" class="collapse">
-                                <div class="panel panel-default" style="margin-bottom: 0px; margin-top: 10px; padding-top: 15px;">
+                                <div class="panel panel-default"
+                                    style="margin-bottom: 0px; margin-top: 10px; padding-top: 15px;">
                                     <div class="form-group">
-                                        <label for="optDnssecPropertiesAddKeyKeyType" class="col-sm-4 control-label">Key Type</label>
+                                        <label for="optDnssecPropertiesAddKeyKeyType" class="col-sm-4 control-label">Key
+                                            Type</label>
                                         <div class="col-sm-8">
-                                            <select id="optDnssecPropertiesAddKeyKeyType" class="form-control" style="width: auto;">
+                                            <select id="optDnssecPropertiesAddKeyKeyType" class="form-control"
+                                                style="width: auto;">
                                                 <option value="KeySigningKey">Key Signing Key (KSK)</option>
                                                 <option value="ZoneSigningKey">Zone Signing Key (ZSK)</option>
                                             </select>
@@ -5497,9 +7901,11 @@ MII...
                                     </div>
 
                                     <div class="form-group">
-                                        <label for="optDnssecPropertiesAddKeyAlgorithm" class="col-sm-4 control-label">Algorithm</label>
+                                        <label for="optDnssecPropertiesAddKeyAlgorithm"
+                                            class="col-sm-4 control-label">Algorithm</label>
                                         <div class="col-sm-8">
-                                            <select id="optDnssecPropertiesAddKeyAlgorithm" class="form-control" style="width: auto;">
+                                            <select id="optDnssecPropertiesAddKeyAlgorithm" class="form-control"
+                                                style="width: auto;">
                                                 <option>RSA</option>
                                                 <option value="ECDSA">ECDSA (recommended)</option>
                                                 <option value="EDDSA">EdDSA</option>
@@ -5509,9 +7915,11 @@ MII...
 
                                     <div id="divDnssecPropertiesAddKeyRsaParameters">
                                         <div class="form-group">
-                                            <label for="optDnssecPropertiesAddKeyRsaHashAlgorithm" class="col-sm-4 control-label">Hash Algorithm</label>
+                                            <label for="optDnssecPropertiesAddKeyRsaHashAlgorithm"
+                                                class="col-sm-4 control-label">Hash Algorithm</label>
                                             <div class="col-sm-8">
-                                                <select id="optDnssecPropertiesAddKeyRsaHashAlgorithm" class="form-control" style="width: auto;">
+                                                <select id="optDnssecPropertiesAddKeyRsaHashAlgorithm"
+                                                    class="form-control" style="width: auto;">
                                                     <option value="MD5">MD5 (obsolete)</option>
                                                     <option value="SHA1">SHA1 (obsolete)</option>
                                                     <option value="SHA256">SHA256 (default)</option>
@@ -5523,9 +7931,11 @@ MII...
 
                                     <div id="divDnssecPropertiesAddKeyEcdsaParameters">
                                         <div class="form-group">
-                                            <label for="optDnssecPropertiesAddKeyEcdsaCurve" class="col-sm-4 control-label">ECDSA Curve</label>
+                                            <label for="optDnssecPropertiesAddKeyEcdsaCurve"
+                                                class="col-sm-4 control-label">ECDSA Curve</label>
                                             <div class="col-sm-8">
-                                                <select id="optDnssecPropertiesAddKeyEcdsaCurve" class="form-control" style="width: auto;">
+                                                <select id="optDnssecPropertiesAddKeyEcdsaCurve" class="form-control"
+                                                    style="width: auto;">
                                                     <option value="P256">P256 (default)</option>
                                                     <option>P384</option>
                                                 </select>
@@ -5535,9 +7945,11 @@ MII...
 
                                     <div id="divDnssecPropertiesAddKeyEddsaParameters">
                                         <div class="form-group">
-                                            <label for="optDnssecPropertiesAddKeyEddsaCurve" class="col-sm-4 control-label">EdDSA Curve</label>
+                                            <label for="optDnssecPropertiesAddKeyEddsaCurve"
+                                                class="col-sm-4 control-label">EdDSA Curve</label>
                                             <div class="col-sm-8">
-                                                <select id="optDnssecPropertiesAddKeyEddsaCurve" class="form-control" style="width: auto;">
+                                                <select id="optDnssecPropertiesAddKeyEddsaCurve" class="form-control"
+                                                    style="width: auto;">
                                                     <option value="ED25519">Ed25519 (default)</option>
                                                     <option value="ED448">Ed448</option>
                                                 </select>
@@ -5550,13 +7962,16 @@ MII...
                                         <div class="col-sm-8">
                                             <div class="radio">
                                                 <label>
-                                                    <input type="radio" name="rdDnssecPropertiesKeyGeneration" id="rdDnssecPropertiesKeyGenerationAutomatic" value="Automatic">
+                                                    <input type="radio" name="rdDnssecPropertiesKeyGeneration"
+                                                        id="rdDnssecPropertiesKeyGenerationAutomatic" value="Automatic">
                                                     Automatic Private Key Generation (default)
                                                 </label>
                                             </div>
                                             <div class="radio">
                                                 <label>
-                                                    <input type="radio" name="rdDnssecPropertiesKeyGeneration" id="rdDnssecPropertiesKeyGenerationUseSpecified" value="UseSpecified">
+                                                    <input type="radio" name="rdDnssecPropertiesKeyGeneration"
+                                                        id="rdDnssecPropertiesKeyGenerationUseSpecified"
+                                                        value="UseSpecified">
                                                     Use Specified Private Key
                                                 </label>
                                             </div>
@@ -5565,9 +7980,11 @@ MII...
 
                                     <div id="divDnssecPropertiesAddKeyRsaKeySize">
                                         <div class="form-group">
-                                            <label for="optDnssecPropertiesAddKeyRsaKeySize" class="col-sm-4 control-label">Key Size</label>
+                                            <label for="optDnssecPropertiesAddKeyRsaKeySize"
+                                                class="col-sm-4 control-label">Key Size</label>
                                             <div class="col-sm-8">
-                                                <select id="optDnssecPropertiesAddKeyRsaKeySize" class="form-control" style="width: auto; display: inline;">
+                                                <select id="optDnssecPropertiesAddKeyRsaKeySize" class="form-control"
+                                                    style="width: auto; display: inline;">
                                                     <option>1024</option>
                                                     <option>1280</option>
                                                     <option>1536</option>
@@ -5582,9 +7999,11 @@ MII...
 
                                     <div id="divDnssecPropertiesPemPrivateKey">
                                         <div class="form-group">
-                                            <label for="txtDnssecPropertiesPemPrivateKey" class="col-sm-4 control-label">Private Key</label>
+                                            <label for="txtDnssecPropertiesPemPrivateKey"
+                                                class="col-sm-4 control-label">Private Key</label>
                                             <div class="col-sm-7">
-                                                <textarea id="txtDnssecPropertiesPemPrivateKey" class="form-control" rows="4" spellcheck="false" placeholder="-----BEGIN PRIVATE KEY-----
+                                                <textarea id="txtDnssecPropertiesPemPrivateKey" class="form-control"
+                                                    rows="4" spellcheck="false" placeholder="-----BEGIN PRIVATE KEY-----
 MII...
 -----END PRIVATE KEY-----"></textarea>
                                                 <div style="padding-top: 5px;">Enter a private key in PEM format.</div>
@@ -5593,10 +8012,13 @@ MII...
                                     </div>
 
                                     <div id="divDnssecPropertiesAddKeyAutomaticRollover" class="form-group">
-                                        <label for="txtDnssecPropertiesAddKeyAutomaticRollover" class="col-sm-4 control-label">Automatic Key Rollover</label>
+                                        <label for="txtDnssecPropertiesAddKeyAutomaticRollover"
+                                            class="col-sm-4 control-label">Automatic Key Rollover</label>
                                         <div class="col-sm-8">
                                             <div>
-                                                <input id="txtDnssecPropertiesAddKeyAutomaticRollover" type="number" class="form-control" placeholder="days" style="width: 100px; display: inline;">
+                                                <input id="txtDnssecPropertiesAddKeyAutomaticRollover" type="number"
+                                                    class="form-control" placeholder="days"
+                                                    style="width: 100px; display: inline;">
                                                 <span>days (valid range 0-365; default 30; set 0 to disable)</span>
                                             </div>
                                         </div>
@@ -5607,20 +8029,28 @@ MII...
 
                                     <div class="form-group">
                                         <div class="col-sm-offset-4 col-sm-8">
-                                            <button type="button" class="btn btn-primary" style="padding: 2px 10px;" data-loading-text="Generating..." onclick="addDnssecPrivateKey(this);">Add Key</button>
+                                            <button type="button" class="btn btn-primary" style="padding: 2px 10px;"
+                                                data-loading-text="Generating..."
+                                                onclick="addDnssecPrivateKey(this);">Add Key</button>
                                         </div>
                                     </div>
                                 </div>
                             </div>
 
                             <div id="divDnssecPropertiesNoteReadyBy" style="margin-top: 10px; display: none;">
-                                Note! The Key State for a newly published Key Signing Key (KSK) must be <code>Ready</code> before you can add a DS record for it. Use the <b>View DS Info</b> option for more details on adding DS record.
+                                Note! The Key State for a newly published Key Signing Key (KSK) must be
+                                <code>Ready</code> before you can add a DS record for it. Use the <b>View DS Info</b>
+                                option for more details on adding DS record.
                             </div>
                             <div id="divDnssecPropertiesNoteActiveBy" style="margin-top: 10px; display: none;">
-                                Note! The Key State for a Key Signing Key (KSK) will automatically switch from <code>Ready</code> to <code>Active</code> once you have added DS record for it and the DNS server is able to detect it. Use the <b>View DS Info</b> option for more details on adding DS record.
+                                Note! The Key State for a Key Signing Key (KSK) will automatically switch from
+                                <code>Ready</code> to <code>Active</code> once you have added DS record for it and the
+                                DNS server is able to detect it. Use the <b>View DS Info</b> option for more details on
+                                adding DS record.
                             </div>
                             <div id="divDnssecPropertiesNoteRetiredRevoked" style="margin-top: 10px; display: none;">
-                                Note! The keys with <code>Retired</code> or <code>Revoked</code> Key State will be automatically unpublished and removed when its safe to do so.
+                                Note! The keys with <code>Retired</code> or <code>Revoked</code> Key State will be
+                                automatically unpublished and removed when its safe to do so.
                             </div>
                         </div>
 
@@ -5630,20 +8060,26 @@ MII...
                                 <div class="col-sm-8">
                                     <div class="radio">
                                         <label>
-                                            <input type="radio" name="rdDnssecPropertiesNxProof" id="rdDnssecPropertiesNxProofNSEC" value="NSEC">
+                                            <input type="radio" name="rdDnssecPropertiesNxProof"
+                                                id="rdDnssecPropertiesNxProofNSEC" value="NSEC">
                                             Next Secure (NSEC) (recommended)
                                         </label>
                                         <div style="padding-top: 5px; padding-left: 20px;">
-                                            With NSEC, all the records in your zone can be discovered by anyone using "zone walking" technique. NSEC is recommended if your zone does not contain any private/internal records.
+                                            With NSEC, all the records in your zone can be discovered by anyone using
+                                            "zone walking" technique. NSEC is recommended if your zone does not contain
+                                            any private/internal records.
                                         </div>
                                     </div>
                                     <div class="radio">
                                         <label>
-                                            <input type="radio" name="rdDnssecPropertiesNxProof" id="rdDnssecPropertiesNxProofNSEC3" value="NSEC3">
+                                            <input type="radio" name="rdDnssecPropertiesNxProof"
+                                                id="rdDnssecPropertiesNxProofNSEC3" value="NSEC3">
                                             Next Secure 3 (NSEC3)
                                         </label>
                                         <div style="padding-top: 5px; padding-left: 20px;">
-                                            NSEC3, makes it difficult to perform "zone walking" since it uses hashing with a random salt. NSEC3 should be used if your zone contains any private/internal records that you do not wish to be enumerable.
+                                            NSEC3, makes it difficult to perform "zone walking" since it uses hashing
+                                            with a random salt. NSEC3 should be used if your zone contains any
+                                            private/internal records that you do not wish to be enumerable.
                                         </div>
                                     </div>
                                 </div>
@@ -5651,53 +8087,79 @@ MII...
 
                             <div id="divDnssecPropertiesNSEC3Parameters">
                                 <div class="form-group">
-                                    <label for="txtDnssecPropertiesNSEC3Iterations" class="col-sm-4 control-label">NSEC3 Iterations</label>
+                                    <label for="txtDnssecPropertiesNSEC3Iterations" class="col-sm-4 control-label">NSEC3
+                                        Iterations</label>
                                     <div class="col-sm-8">
-                                        <input id="txtDnssecPropertiesNSEC3Iterations" type="number" class="form-control" placeholder="iterations" style="width: 100px; display: inline;">
+                                        <input id="txtDnssecPropertiesNSEC3Iterations" type="number"
+                                            class="form-control" placeholder="iterations"
+                                            style="width: 100px; display: inline;">
                                         <span>(valid range 0-50, recommended 0)</span>
                                     </div>
                                     <div class="col-sm-offset-4 col-sm-8" style="padding-top: 5px;">
-                                        The number of iterations used by NSEC3 for hashing the domain names. It is recommended to use 0 iterations since more iterations will increase computational costs for both the DNS server and resolver while not providing much value against "zone walking" [<a href="https://www.rfc-editor.org/rfc/rfc9276.html#name-iterations" target="_blank">RFC 9276</a>].
+                                        The number of iterations used by NSEC3 for hashing the domain names. It is
+                                        recommended to use 0 iterations since more iterations will increase
+                                        computational costs for both the DNS server and resolver while not providing
+                                        much value against "zone walking" [<a
+                                            href="https://www.rfc-editor.org/rfc/rfc9276.html#name-iterations"
+                                            target="_blank">RFC 9276</a>].
                                     </div>
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="txtDnssecPropertiesNSEC3SaltLength" class="col-sm-4 control-label">NSEC3 Salt Length</label>
+                                    <label for="txtDnssecPropertiesNSEC3SaltLength" class="col-sm-4 control-label">NSEC3
+                                        Salt Length</label>
                                     <div class="col-sm-8">
-                                        <input id="txtDnssecPropertiesNSEC3SaltLength" type="number" class="form-control" placeholder="length" style="width: 100px; display: inline;">
+                                        <input id="txtDnssecPropertiesNSEC3SaltLength" type="number"
+                                            class="form-control" placeholder="length"
+                                            style="width: 100px; display: inline;">
                                         <span>bytes (valid range 0-32, recommended 0)</span>
                                     </div>
                                     <div class="col-sm-offset-4 col-sm-8" style="padding-top: 5px;">
-                                        The number of bytes of random salt to generate to be used with the NSEC3 hash computation. It is recommended to not use salt by setting the length to 0 [<a href="https://www.rfc-editor.org/rfc/rfc9276.html#name-salt" target="_blank">RFC 9276</a>].
+                                        The number of bytes of random salt to generate to be used with the NSEC3 hash
+                                        computation. It is recommended to not use salt by setting the length to 0 [<a
+                                            href="https://www.rfc-editor.org/rfc/rfc9276.html#name-salt"
+                                            target="_blank">RFC 9276</a>].
                                     </div>
                                 </div>
                             </div>
 
                             <div class="form-group" style="margin-bottom: 5px;">
                                 <div class="col-sm-offset-4 col-sm-8">
-                                    <button id="btnDnssecPropertiesChangeNxProof" type="button" class="btn btn-warning" style="padding: 2px 0; width: 100px;" data-loading-text="Changing..." onclick="changeDnssecNxProof(this);">Change</button>
+                                    <button id="btnDnssecPropertiesChangeNxProof" type="button" class="btn btn-warning"
+                                        style="padding: 2px 0; width: 100px;" data-loading-text="Changing..."
+                                        onclick="changeDnssecNxProof(this);">Change</button>
                                 </div>
                             </div>
                         </div>
 
                         <div class="well well-sm form-horizontal">
                             <div class="form-group" style="margin-bottom: 5px;">
-                                <label for="txtDnssecPropertiesDnsKeyTtl" class="col-sm-4 control-label">DNSKEY TTL</label>
+                                <label for="txtDnssecPropertiesDnsKeyTtl" class="col-sm-4 control-label">DNSKEY
+                                    TTL</label>
                                 <div class="col-sm-8">
                                     <div>
-                                        <input id="txtDnssecPropertiesDnsKeyTtl" type="text" class="form-control" placeholder="ttl" style="width: 100px; display: inline;">
+                                        <input id="txtDnssecPropertiesDnsKeyTtl" type="text" class="form-control"
+                                            placeholder="ttl" style="width: 100px; display: inline;">
                                         <span>seconds (default 3600/1h)</span>
                                     </div>
                                     <div style="margin-top: 10px;">
-                                        <button type="button" class="btn btn-default" style="padding: 2px 0; width: 100px;" data-loading-text="Updating..." onclick="updateDnssecDnsKeyTtl(this);">Update TTL</button>
+                                        <button type="button" class="btn btn-default"
+                                            style="padding: 2px 0; width: 100px;" data-loading-text="Updating..."
+                                            onclick="updateDnssecDnsKeyTtl(this);">Update TTL</button>
                                     </div>
                                 </div>
                                 <div class="col-sm-offset-4 col-sm-8" style="padding-top: 5px;">
-                                    The TTL value to be used for DNSKEY records. A lower value will allow quicker addition or rollover to a new DNS Key at the cost of increased frequency of DNSKEY queries by resolvers.
+                                    The TTL value to be used for DNSKEY records. A lower value will allow quicker
+                                    addition or rollover to a new DNS Key at the cost of increased frequency of DNSKEY
+                                    queries by resolvers.
                                 </div>
                             </div>
                             <div style="margin-top: 10px;">
-                                Warning! You MUST wait for at least the number of seconds specified by the the old TTL value to elapse before making any changes to the DNS keys above to ensure that all recursive resolvers would have expired the DNSKEY records from its cache. For example, if the old TTL value was 3600, then you must wait for 3600 seconds (1 hour) to pass before making any changes to the DNS keys.
+                                Warning! You MUST wait for at least the number of seconds specified by the the old TTL
+                                value to elapse before making any changes to the DNS keys above to ensure that all
+                                recursive resolvers would have expired the DNSKEY records from its cache. For example,
+                                if the old TTL value was 3600, then you must wait for 3600 seconds (1 hour) to pass
+                                before making any changes to the DNS keys.
                             </div>
                         </div>
                     </div>
@@ -5714,7 +8176,8 @@ MII...
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Import Allowed Zones</h4>
                 </div>
                 <div class="modal-body">
@@ -5724,11 +8187,13 @@ MII...
 
                     <div class="form-group">
                         <label for="txtImportAllowedZones" class="control-label">Allowed Zones</label>
-                        <textarea id="txtImportAllowedZones" class="form-control" rows="15" spellcheck="false"></textarea>
+                        <textarea id="txtImportAllowedZones" class="form-control" rows="15"
+                            spellcheck="false"></textarea>
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnImportAllowedZones" type="submit" class="btn btn-primary" data-loading-text="Importing..." onclick="importAllowedZones(); return false;">Import</button>
+                    <button id="btnImportAllowedZones" type="submit" class="btn btn-primary"
+                        data-loading-text="Importing..." onclick="importAllowedZones(); return false;">Import</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -5739,7 +8204,8 @@ MII...
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Import Blocked Zones</h4>
                 </div>
                 <div class="modal-body">
@@ -5749,11 +8215,13 @@ MII...
 
                     <div class="form-group">
                         <label for="txtImportBlockedZones" class="control-label">Blocked Zones</label>
-                        <textarea id="txtImportBlockedZones" class="form-control" rows="15" spellcheck="false"></textarea>
+                        <textarea id="txtImportBlockedZones" class="form-control" rows="15"
+                            spellcheck="false"></textarea>
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnImportBlockedZones" type="submit" class="btn btn-primary" data-loading-text="Importing..." onclick="importBlockedZones(); return false;">Import</button>
+                    <button id="btnImportBlockedZones" type="submit" class="btn btn-primary"
+                        data-loading-text="Importing..." onclick="importBlockedZones(); return false;">Import</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -5766,7 +8234,8 @@ MII...
             <div class="modal-dialog" role="document" style="width: 800px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">DNS App Store</h4>
                     </div>
                     <div class="modal-body">
@@ -5778,14 +8247,18 @@ MII...
                             <table class="table table-hover">
                                 <thead>
                                     <tr>
-                                        <th style="min-width: 120px;"><a href="#" onclick="sortTable('tableStoreAppsBody', 0); return false;">Store Apps</a></th>
+                                        <th style="min-width: 120px;"><a href="#"
+                                                onclick="sortTable('tableStoreAppsBody', 0); return false;">Store
+                                                Apps</a></th>
                                         <th style="width: 96px;"></th>
                                     </tr>
                                 </thead>
                                 <tbody id="tableStoreAppsBody">
                                 </tbody>
                                 <tfoot id="tableStoreAppsFooter">
-                                    <tr><td colspan="3"><b>Total Apps: 0</b></td></tr>
+                                    <tr>
+                                        <td colspan="3"><b>Total Apps: 0</b></td>
+                                    </tr>
                                 </tfoot>
                             </table>
                         </div>
@@ -5803,7 +8276,8 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Install App</h4>
                     </div>
                     <div class="modal-body">
@@ -5825,7 +8299,8 @@ MII...
 
                     </div>
                     <div class="modal-footer">
-                        <button id="btnInstallApp" type="submit" class="btn btn-primary" data-loading-text="Installing..." onclick="installApp(); return false;">Install</button>
+                        <button id="btnInstallApp" type="submit" class="btn btn-primary"
+                            data-loading-text="Installing..." onclick="installApp(); return false;">Install</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -5838,7 +8313,8 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Update App</h4>
                     </div>
                     <div class="modal-body">
@@ -5860,7 +8336,8 @@ MII...
 
                     </div>
                     <div class="modal-footer">
-                        <button id="btnUpdateApp" type="submit" class="btn btn-primary" data-loading-text="Updating..." onclick="updateApp(); return false;">Update</button>
+                        <button id="btnUpdateApp" type="submit" class="btn btn-primary" data-loading-text="Updating..."
+                            onclick="updateApp(); return false;">Update</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -5872,7 +8349,8 @@ MII...
         <div class="modal-dialog" role="document" style="width: 780px;">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">App Config - <span id="lblAppConfigName"></span></h4>
                 </div>
                 <div class="modal-body">
@@ -5888,7 +8366,8 @@ MII...
                     <p>Note: The app will reload the config automatically after you save it.</p>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnAppConfig" type="submit" class="btn btn-primary" data-loading-text="Saving..." onclick="saveAppConfig(); return false;">Save</button>
+                    <button id="btnAppConfig" type="submit" class="btn btn-primary" data-loading-text="Saving..."
+                        onclick="saveAppConfig(); return false;">Save</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -5900,7 +8379,8 @@ MII...
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Backup Settings</h4>
                 </div>
                 <div class="modal-body">
@@ -5913,31 +8393,36 @@ MII...
                             <div style="padding-left: 40px;">
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupAuthConfig" type="checkbox" checked> Authentication Config File (auth.config)
+                                        <input id="chkBackupAuthConfig" type="checkbox" checked> Authentication Config
+                                        File (auth.config)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupClusterConfig" type="checkbox" checked> Cluster Config File (cluster.config)
+                                        <input id="chkBackupClusterConfig" type="checkbox" checked> Cluster Config File
+                                        (cluster.config)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupWebServiceConfig" type="checkbox" checked> Web Service Config And Certificate File (webservice.config, *.pfx &amp; *.p12)
+                                        <input id="chkBackupWebServiceConfig" type="checkbox" checked> Web Service
+                                        Config And Certificate File (webservice.config, *.pfx &amp; *.p12)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupDnsConfig" type="checkbox" checked> DNS Config And Certificate File (dns.config, *.pfx &amp; *.p12)
+                                        <input id="chkBackupDnsConfig" type="checkbox" checked> DNS Config And
+                                        Certificate File (dns.config, *.pfx &amp; *.p12)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupLogConfig" type="checkbox" checked> Log Config File (log.config)
+                                        <input id="chkBackupLogConfig" type="checkbox" checked> Log Config File
+                                        (log.config)
                                     </label>
                                 </div>
 
@@ -5949,19 +8434,22 @@ MII...
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupAllowedZones" type="checkbox" checked> Allowed Zones File (allowed.config)
+                                        <input id="chkBackupAllowedZones" type="checkbox" checked> Allowed Zones File
+                                        (allowed.config)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupBlockedZones" type="checkbox" checked> Blocked Zones File (blocked.config)
+                                        <input id="chkBackupBlockedZones" type="checkbox" checked> Blocked Zones File
+                                        (blocked.config)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupBlockLists" type="checkbox" checked> Block List Config And Cache Files (blocklist.config)
+                                        <input id="chkBackupBlockLists" type="checkbox" checked> Block List Config And
+                                        Cache Files (blocklist.config)
                                     </label>
                                 </div>
 
@@ -5979,7 +8467,8 @@ MII...
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkBackupStats" type="checkbox" checked> Dashboard Stats Files (*.stat, *.dstat)
+                                        <input id="chkBackupStats" type="checkbox" checked> Dashboard Stats Files
+                                        (*.stat, *.dstat)
                                     </label>
                                 </div>
 
@@ -5992,13 +8481,16 @@ MII...
                         </div>
                     </div>
 
-                    <p><b>Note!</b> The Web Service or Optional Protocols TLS certificate (.pfx or .p12) files will be included in the backup only if they exist within the DNS server's config folder.</p>
+                    <p><b>Note!</b> The Web Service or Optional Protocols TLS certificate (.pfx or .p12) files will be
+                        included in the backup only if they exist within the DNS server's config folder.</p>
 
-                    <p><b>Note!</b> It may take several minutes to generate the backup zip file if log files are selected to be backed up which will depend on the size of the log files on the disk.</p>
+                    <p><b>Note!</b> It may take several minutes to generate the backup zip file if log files are
+                        selected to be backed up which will depend on the size of the log files on the disk.</p>
 
                 </div>
                 <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary" data-loading-text="Backup" onclick="backupSettings(); return false;">Backup</button>
+                    <button type="submit" class="btn btn-primary" data-loading-text="Backup"
+                        onclick="backupSettings(); return false;">Backup</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -6009,7 +8501,8 @@ MII...
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Restore Settings</h4>
                 </div>
                 <div class="modal-body">
@@ -6029,31 +8522,36 @@ MII...
                             <div style="padding-left: 40px;">
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreAuthConfig" type="checkbox" checked> Authentication Config File (auth.config)
+                                        <input id="chkRestoreAuthConfig" type="checkbox" checked> Authentication Config
+                                        File (auth.config)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreClusterConfig" type="checkbox" checked> Cluster Config File (cluster.config)
+                                        <input id="chkRestoreClusterConfig" type="checkbox" checked> Cluster Config File
+                                        (cluster.config)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreWebServiceConfig" type="checkbox" checked> Web Service Config And Certificate File (webservice.config, *.pfx &amp; *.p12)
+                                        <input id="chkRestoreWebServiceConfig" type="checkbox" checked> Web Service
+                                        Config And Certificate File (webservice.config, *.pfx &amp; *.p12)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreDnsConfig" type="checkbox" checked> DNS Config And Certificate File (dns.config, *.pfx &amp; *.p12)
+                                        <input id="chkRestoreDnsConfig" type="checkbox" checked> DNS Config And
+                                        Certificate File (dns.config, *.pfx &amp; *.p12)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreLogConfig" type="checkbox" checked> Log Config File (log.config)
+                                        <input id="chkRestoreLogConfig" type="checkbox" checked> Log Config File
+                                        (log.config)
                                     </label>
                                 </div>
 
@@ -6065,19 +8563,22 @@ MII...
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreAllowedZones" type="checkbox" checked> Allowed Zones File (allowed.config)
+                                        <input id="chkRestoreAllowedZones" type="checkbox" checked> Allowed Zones File
+                                        (allowed.config)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreBlockedZones" type="checkbox" checked> Blocked Zones File (blocked.config)
+                                        <input id="chkRestoreBlockedZones" type="checkbox" checked> Blocked Zones File
+                                        (blocked.config)
                                     </label>
                                 </div>
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreBlockLists" type="checkbox" checked> Block List Config And Cache Files (blocklist.config)
+                                        <input id="chkRestoreBlockLists" type="checkbox" checked> Block List Config And
+                                        Cache Files (blocklist.config)
                                     </label>
                                 </div>
 
@@ -6095,7 +8596,8 @@ MII...
 
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkRestoreStats" type="checkbox" checked> Dashboard Stats Files (*.stat, *.dstat)
+                                        <input id="chkRestoreStats" type="checkbox" checked> Dashboard Stats Files
+                                        (*.stat, *.dstat)
                                     </label>
                                 </div>
 
@@ -6113,7 +8615,8 @@ MII...
                             <div style="padding-left: 40px;">
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkDeleteExistingFiles" type="checkbox" checked> Delete Existing Files For Selected Items
+                                        <input id="chkDeleteExistingFiles" type="checkbox" checked> Delete Existing
+                                        Files For Selected Items
                                     </label>
                                 </div>
                             </div>
@@ -6121,10 +8624,13 @@ MII...
 
                     </div>
 
-                    <p><b>Warning!</b> The restore process will overwrite existing config files on disk for above selected items and reload new settings including user accounts from the backup. The current logged in user account and current session will be added automatically.</p>
+                    <p><b>Warning!</b> The restore process will overwrite existing config files on disk for above
+                        selected items and reload new settings including user accounts from the backup. The current
+                        logged in user account and current session will be added automatically.</p>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnRestoreSettings" type="submit" class="btn btn-primary" data-loading-text="Restoring..." onclick="restoreSettings(); return false;">Restore</button>
+                    <button id="btnRestoreSettings" type="submit" class="btn btn-primary"
+                        data-loading-text="Restoring..." onclick="restoreSettings(); return false;">Restore</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -6136,7 +8642,8 @@ MII...
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 id="lblTopStatsTitle" class="modal-title">Top Stats</h4>
                 </div>
                 <div class="modal-body">
@@ -6156,7 +8663,9 @@ MII...
                             <tbody id="tbodyTopStatsClients">
                             </tbody>
                             <tfoot>
-                                <tr><th colspan="3" id="tfootTopStatsClients"></th></tr>
+                                <tr>
+                                    <th colspan="3" id="tfootTopStatsClients"></th>
+                                </tr>
                             </tfoot>
                         </table>
 
@@ -6171,7 +8680,9 @@ MII...
                             <tbody id="tbodyTopStatsDomains">
                             </tbody>
                             <tfoot>
-                                <tr><th colspan="3" id="tfootTopStatsDomains"></th></tr>
+                                <tr>
+                                    <th colspan="3" id="tfootTopStatsDomains"></th>
+                                </tr>
                             </tfoot>
                         </table>
 
@@ -6186,7 +8697,9 @@ MII...
                             <tbody id="tbodyTopStatsBlockedDomains">
                             </tbody>
                             <tfoot>
-                                <tr><th colspan="3" id="tfootTopStatsBlockedDomains"></th></tr>
+                                <tr>
+                                    <th colspan="3" id="tfootTopStatsBlockedDomains"></th>
+                                </tr>
                             </tfoot>
                         </table>
                     </div>
@@ -6204,29 +8717,39 @@ MII...
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title">Remove Lease?</h4>
                 </div>
                 <div class="modal-body">
                     <div id="divDhcpRemoveLeaseAlert"></div>
 
-                    <p><b>Warning!</b> Removing a DHCP lease from the server side will NOT remove the allocated IP address from the client side. Make sure that the client assigned this lease is not connected to the network before proceeding.</p>
-                    <p><b>Warning!</b> Removing a DHCP lease may cause IP address conflict if the DHCP server assigns the same IP address to a new client while the old client is still connected to the network.</p>
-                    <p>It is not recommended to remove a DHCP lease when the client is still connected or may connect back later to the network before the lease expires. Use this option only as a last resort.</p>
+                    <p><b>Warning!</b> Removing a DHCP lease from the server side will NOT remove the allocated IP
+                        address from the client side. Make sure that the client assigned this lease is not connected to
+                        the network before proceeding.</p>
+                    <p><b>Warning!</b> Removing a DHCP lease may cause IP address conflict if the DHCP server assigns
+                        the same IP address to a new client while the old client is still connected to the network.</p>
+                    <p>It is not recommended to remove a DHCP lease when the client is still connected or may connect
+                        back later to the network before the lease expires. Use this option only as a last resort.</p>
                     <p>
                         Follow the recommendations below to avoid such a case that requires removing a DHCP lease:
-                        <ul>
-                            <li>Use a shorter lease time such that a dynamically allocated lease expires quickly when the client exits the network.</li>
-                            <li>Use Exclusions to exclude IP address ranges from being dynamically allocated that you plan to assign manually to some of the devices on the network.</li>
-                            <li>Use Exclusions to make sure that you have unallocated addresses available in the DHCP scope to be assigned as reserved leases in future.</li>
-                            <li>Rely less on the assigned IP addresses by configuring a domain name for the DHCP scope and accessing all the devices using their domain names.</li>
-                        </ul>
+                    <ul>
+                        <li>Use a shorter lease time such that a dynamically allocated lease expires quickly when the
+                            client exits the network.</li>
+                        <li>Use Exclusions to exclude IP address ranges from being dynamically allocated that you plan
+                            to assign manually to some of the devices on the network.</li>
+                        <li>Use Exclusions to make sure that you have unallocated addresses available in the DHCP scope
+                            to be assigned as reserved leases in future.</li>
+                        <li>Rely less on the assigned IP addresses by configuring a domain name for the DHCP scope and
+                            accessing all the devices using their domain names.</li>
+                    </ul>
                     </p>
                     <p>&nbsp;</p>
                     <p>Are you sure you want to remove the DHCP lease now?</p>
                 </div>
                 <div class="modal-footer">
-                    <button id="btnRemoveDhcpLease" type="button" class="btn btn-danger" data-loading-text="Removing...">Remove</button>
+                    <button id="btnRemoveDhcpLease" type="button" class="btn btn-danger"
+                        data-loading-text="Removing...">Remove</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
@@ -6239,7 +8762,8 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Add User</h4>
                     </div>
                     <div class="modal-body">
@@ -6248,33 +8772,39 @@ MII...
                         <div class="form-group">
                             <label for="txtAddUserDisplayName" class="col-sm-4 control-label">Display Name</label>
                             <div class="col-sm-7">
-                                <input id="txtAddUserDisplayName" type="text" class="form-control" placeholder="display name" maxlength="255">
+                                <input id="txtAddUserDisplayName" type="text" class="form-control"
+                                    placeholder="display name" maxlength="255">
                             </div>
                         </div>
 
                         <div class="form-group">
                             <label for="txtAddUserUsername" class="col-sm-4 control-label">Username</label>
                             <div class="col-sm-7">
-                                <input id="txtAddUserUsername" type="text" class="form-control" placeholder="username" maxlength="255">
+                                <input id="txtAddUserUsername" type="text" class="form-control" placeholder="username"
+                                    maxlength="255">
                             </div>
                         </div>
 
                         <div class="form-group">
                             <label for="txtAddUserPassword" class="col-sm-4 control-label">Password</label>
                             <div class="col-sm-7">
-                                <input id="txtAddUserPassword" type="password" class="form-control" placeholder="password" maxlength="255">
+                                <input id="txtAddUserPassword" type="password" class="form-control"
+                                    placeholder="password" maxlength="255">
                             </div>
                         </div>
 
                         <div class="form-group">
-                            <label for="txtAddUserConfirmPassword" class="col-sm-4 control-label">Confirm Password</label>
+                            <label for="txtAddUserConfirmPassword" class="col-sm-4 control-label">Confirm
+                                Password</label>
                             <div class="col-sm-7">
-                                <input id="txtAddUserConfirmPassword" type="password" class="form-control" placeholder="confirm password" maxlength="255">
+                                <input id="txtAddUserConfirmPassword" type="password" class="form-control"
+                                    placeholder="confirm password" maxlength="255">
                             </div>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnAddUser" type="submit" class="btn btn-primary" data-loading-text="Adding..." onclick="addUser(this); return false;">Add</button>
+                        <button id="btnAddUser" type="submit" class="btn btn-primary" data-loading-text="Adding..."
+                            onclick="addUser(this); return false;">Add</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6287,7 +8817,8 @@ MII...
             <div class="modal-dialog" role="document" style="width: 940px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">User Details</h4>
                     </div>
                     <div class="modal-body">
@@ -6295,18 +8826,22 @@ MII...
 
                         <div id="divUserDetailsLoader" style="height: 500px;"></div>
 
-                        <div id="divUserDetailsViewer" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                        <div id="divUserDetailsViewer"
+                            style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                             <div class="form-group">
-                                <label for="txtUserDetailsDisplayName" class="col-sm-4 control-label">Display Name</label>
+                                <label for="txtUserDetailsDisplayName" class="col-sm-4 control-label">Display
+                                    Name</label>
                                 <div class="col-sm-7">
-                                    <input id="txtUserDetailsDisplayName" type="text" class="form-control" placeholder="display name" maxlength="255">
+                                    <input id="txtUserDetailsDisplayName" type="text" class="form-control"
+                                        placeholder="display name" maxlength="255">
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label for="txtUserDetailsUsername" class="col-sm-4 control-label">Username</label>
                                 <div class="col-sm-7">
-                                    <input id="txtUserDetailsUsername" type="text" class="form-control" placeholder="username" maxlength="255">
+                                    <input id="txtUserDetailsUsername" type="text" class="form-control"
+                                        placeholder="username" maxlength="255">
                                 </div>
                             </div>
 
@@ -6321,16 +8856,19 @@ MII...
                                 <div class="col-sm-offset-4 col-sm-7">
                                     <div class="checkbox" style="padding: 0px;">
                                         <label>
-                                            <input id="chkUserDetailsDisableAccount" type="checkbox"> Disable User Account
+                                            <input id="chkUserDetailsDisableAccount" type="checkbox"> Disable User
+                                            Account
                                         </label>
                                     </div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtUserDetailsSessionTimeout" class="col-sm-4 control-label">Session Timeout</label>
+                                <label for="txtUserDetailsSessionTimeout" class="col-sm-4 control-label">Session
+                                    Timeout</label>
                                 <div class="col-sm-7">
-                                    <input id="txtUserDetailsSessionTimeout" type="number" class="form-control" placeholder="1800" style="width: 100px; display: inline;">
+                                    <input id="txtUserDetailsSessionTimeout" type="number" class="form-control"
+                                        placeholder="1800" style="width: 100px; display: inline;">
                                     <span>seconds (valid range 0-604800; default 1800; set 0 to disable)</span>
                                 </div>
                             </div>
@@ -6346,20 +8884,31 @@ MII...
 
                             <div class="well well-sm" style="background-color: #fbfbfb;">
                                 <p style="font-size: 16px; font-weight: bold;">Active Sessions</p>
-                                <table id="tableUserDetailsActiveSessions" class="table table-hover" style="margin-bottom: 0px;">
+                                <table id="tableUserDetailsActiveSessions" class="table table-hover"
+                                    style="margin-bottom: 0px;">
                                     <thead>
                                         <tr>
-                                            <th><a href="#" onclick="sortTable('tbodyUserDetailsActiveSessions', 0); return false;">Session</a></th>
-                                            <th><a href="#" onclick="sortTable('tbodyUserDetailsActiveSessions', 1); return false;">Last Seen</a></th>
-                                            <th><a href="#" onclick="sortTable('tbodyUserDetailsActiveSessions', 2); return false;">Remote Address</a></th>
-                                            <th><a href="#" onclick="sortTable('tbodyUserDetailsActiveSessions', 3); return false;">User Agent</a></th>
+                                            <th><a href="#"
+                                                    onclick="sortTable('tbodyUserDetailsActiveSessions', 0); return false;">Session</a>
+                                            </th>
+                                            <th><a href="#"
+                                                    onclick="sortTable('tbodyUserDetailsActiveSessions', 1); return false;">Last
+                                                    Seen</a></th>
+                                            <th><a href="#"
+                                                    onclick="sortTable('tbodyUserDetailsActiveSessions', 2); return false;">Remote
+                                                    Address</a></th>
+                                            <th><a href="#"
+                                                    onclick="sortTable('tbodyUserDetailsActiveSessions', 3); return false;">User
+                                                    Agent</a></th>
                                             <th style="width: 36px;"></th>
                                         </tr>
                                     </thead>
                                     <tbody id="tbodyUserDetailsActiveSessions">
                                     </tbody>
                                     <tfoot>
-                                        <tr><th colspan="5" id="tfootUserDetailsActiveSessions"></th></tr>
+                                        <tr>
+                                            <th colspan="5" id="tfootUserDetailsActiveSessions"></th>
+                                        </tr>
                                     </tfoot>
                                 </table>
                             </div>
@@ -6367,7 +8916,8 @@ MII...
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnUserDetailsSave" type="submit" class="btn btn-primary" data-loading-text="Saving..." onclick="saveUserDetails(this); return false;">Save</button>
+                        <button id="btnUserDetailsSave" type="submit" class="btn btn-primary"
+                            data-loading-text="Saving..." onclick="saveUserDetails(this); return false;">Save</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6380,7 +8930,8 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Add Group</h4>
                     </div>
                     <div class="modal-body">
@@ -6389,19 +8940,22 @@ MII...
                         <div class="form-group">
                             <label for="txtAddGroupName" class="col-sm-4 control-label">Name</label>
                             <div class="col-sm-7">
-                                <input id="txtAddGroupName" type="text" class="form-control" placeholder="group name" maxlength="255">
+                                <input id="txtAddGroupName" type="text" class="form-control" placeholder="group name"
+                                    maxlength="255">
                             </div>
                         </div>
 
                         <div class="form-group">
                             <label for="txtAddGroupDescription" class="col-sm-4 control-label">Description</label>
                             <div class="col-sm-7">
-                                <textarea id="txtAddGroupDescription" class="form-control" rows="5" maxlength="255"></textarea>
+                                <textarea id="txtAddGroupDescription" class="form-control" rows="5"
+                                    maxlength="255"></textarea>
                             </div>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnAddGroup" type="submit" class="btn btn-primary" data-loading-text="Adding..." onclick="addGroup(this); return false;">Add</button>
+                        <button id="btnAddGroup" type="submit" class="btn btn-primary" data-loading-text="Adding..."
+                            onclick="addGroup(this); return false;">Add</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6414,7 +8968,8 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Group Details</h4>
                     </div>
                     <div class="modal-body">
@@ -6422,18 +8977,22 @@ MII...
 
                         <div id="divGroupDetailsLoader" style="height: 500px;"></div>
 
-                        <div id="divGroupDetailsViewer" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                        <div id="divGroupDetailsViewer"
+                            style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                             <div class="form-group">
                                 <label for="txtGroupDetailsName" class="col-sm-4 control-label">Name</label>
                                 <div class="col-sm-7">
-                                    <input id="txtGroupDetailsName" type="text" class="form-control" placeholder="group name" maxlength="255">
+                                    <input id="txtGroupDetailsName" type="text" class="form-control"
+                                        placeholder="group name" maxlength="255">
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtGroupDetailsDescription" class="col-sm-4 control-label">Description</label>
+                                <label for="txtGroupDetailsDescription"
+                                    class="col-sm-4 control-label">Description</label>
                                 <div class="col-sm-7">
-                                    <textarea id="txtGroupDetailsDescription" class="form-control" rows="3" maxlength="255"></textarea>
+                                    <textarea id="txtGroupDetailsDescription" class="form-control" rows="3"
+                                        maxlength="255"></textarea>
                                 </div>
                             </div>
 
@@ -6448,7 +9007,8 @@ MII...
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnGroupDetailsSave" type="submit" class="btn btn-primary" data-loading-text="Saving..." onclick="saveGroupDetails(this); return false;">Save</button>
+                        <button id="btnGroupDetailsSave" type="submit" class="btn btn-primary"
+                            data-loading-text="Saving..." onclick="saveGroupDetails(this); return false;">Save</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6461,7 +9021,8 @@ MII...
             <div class="modal-dialog" role="document" style="width: 780px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Edit Permissions - <span id="lblEditPermissionsName"></span></h4>
                     </div>
                     <div class="modal-body">
@@ -6469,7 +9030,8 @@ MII...
 
                         <div id="divEditPermissionsLoader" style="height: 500px;"></div>
 
-                        <div id="divEditPermissionsViewer" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                        <div id="divEditPermissionsViewer"
+                            style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                             <div class="well well-sm" style="background-color: #fbfbfb;">
                                 <div class="form-group">
                                     <label class="col-sm-3 control-label">User Permissions</label>
@@ -6477,10 +9039,18 @@ MII...
                                         <table id="tableEditPermissionsUser" class="table table-hover">
                                             <thead>
                                                 <tr>
-                                                    <th><a href="#" onclick="sortTable('tbodyEditPermissionsUser', 0); return false;">Username</a></th>
-                                                    <th><a href="#" onclick="sortTable('tbodyEditPermissionsUser', 0); return false;" style="width: 65px;">View</a></th>
-                                                    <th><a href="#" onclick="sortTable('tbodyEditPermissionsUser', 0); return false;" style="width: 65px;">Modify</a></th>
-                                                    <th><a href="#" onclick="sortTable('tbodyEditPermissionsUser', 0); return false;" style="width: 65px;">Delete</a></th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tbodyEditPermissionsUser', 0); return false;">Username</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tbodyEditPermissionsUser', 0); return false;"
+                                                            style="width: 65px;">View</a></th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tbodyEditPermissionsUser', 0); return false;"
+                                                            style="width: 65px;">Modify</a></th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tbodyEditPermissionsUser', 0); return false;"
+                                                            style="width: 65px;">Delete</a></th>
                                                     <th style="width: 76px;"></th>
                                                 </tr>
                                             </thead>
@@ -6499,10 +9069,18 @@ MII...
                                         <table id="tableEditPermissionsGroup" class="table table-hover">
                                             <thead>
                                                 <tr>
-                                                    <th><a href="#" onclick="sortTable('tbodyEditPermissionsGroup', 0); return false;">Group</a></th>
-                                                    <th><a href="#" onclick="sortTable('tbodyEditPermissionsGroup', 0); return false;" style="width: 65px;">View</a></th>
-                                                    <th><a href="#" onclick="sortTable('tbodyEditPermissionsGroup', 0); return false;" style="width: 65px;">Modify</a></th>
-                                                    <th><a href="#" onclick="sortTable('tbodyEditPermissionsGroup', 0); return false;" style="width: 65px;">Delete</a></th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tbodyEditPermissionsGroup', 0); return false;">Group</a>
+                                                    </th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tbodyEditPermissionsGroup', 0); return false;"
+                                                            style="width: 65px;">View</a></th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tbodyEditPermissionsGroup', 0); return false;"
+                                                            style="width: 65px;">Modify</a></th>
+                                                    <th><a href="#"
+                                                            onclick="sortTable('tbodyEditPermissionsGroup', 0); return false;"
+                                                            style="width: 65px;">Delete</a></th>
                                                     <th style="width: 76px;"></th>
                                                 </tr>
                                             </thead>
@@ -6516,7 +9094,8 @@ MII...
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnEditPermissionsSave" type="submit" class="btn btn-primary" data-loading-text="Saving...">Save</button>
+                        <button id="btnEditPermissionsSave" type="submit" class="btn btn-primary"
+                            data-loading-text="Saving...">Save</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6529,7 +9108,8 @@ MII...
             <div class="modal-dialog" role="document" style="width: 780px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Initialize New Cluster</h4>
                     </div>
                     <div class="modal-body">
@@ -6537,55 +9117,89 @@ MII...
 
                         <div id="divInitializeNewClusterLoader" style="height: 350px;"></div>
 
-                        <div id="divInitializeNewClusterView" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                        <div id="divInitializeNewClusterView"
+                            style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                             <p>
-                                The initialization of a new Cluster will make the current DNS server its Primary node. You can add other DNS servers to this Cluster later which will get added as Secondary nodes. No data will be lost on this DNS server in this process.
+                                The initialization of a new Cluster will make the current DNS server its Primary node.
+                                You can add other DNS servers to this Cluster later which will get added as Secondary
+                                nodes. No data will be lost on this DNS server in this process.
                             </p>
 
                             <div class="form-group">
-                                <label for="txtInitializeNewClusterDomain" class="col-sm-4 control-label">Cluster Domain</label>
+                                <label for="txtInitializeNewClusterDomain" class="col-sm-4 control-label">Cluster
+                                    Domain</label>
                                 <div class="col-sm-7">
-                                    <input id="txtInitializeNewClusterDomain" type="text" class="form-control" placeholder="domain name" maxlength="255">
-                                    <div style="padding-top: 5px;">The fully qualified domain name to be used to identify the new Cluster.</div>
+                                    <input id="txtInitializeNewClusterDomain" type="text" class="form-control"
+                                        placeholder="domain name" maxlength="255">
+                                    <div style="padding-top: 5px;">The fully qualified domain name to be used to
+                                        identify the new Cluster.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtInitializeNewClusterPrimaryNodeIpAddresses" class="col-sm-4 control-label">Primary Node IP Addresses</label>
+                                <label for="txtInitializeNewClusterPrimaryNodeIpAddresses"
+                                    class="col-sm-4 control-label">Primary Node IP Addresses</label>
                                 <div class="col-sm-7">
-                                    <textarea id="txtInitializeNewClusterPrimaryNodeIpAddresses" class="form-control" rows="3" spellcheck="false"></textarea>
+                                    <textarea id="txtInitializeNewClusterPrimaryNodeIpAddresses" class="form-control"
+                                        rows="3" spellcheck="false"></textarea>
 
-                                    <label for="optInitializeNewClusterQuickIpAddresses" class="control-label">Quick Add</label>
+                                    <label for="optInitializeNewClusterQuickIpAddresses" class="control-label">Quick
+                                        Add</label>
                                     <select id="optInitializeNewClusterQuickIpAddresses" class="form-control"></select>
 
-                                    <div style="padding-top: 5px;">The static IP addresses of this DNS server that will be accessible by all other DNS Servers to be added later as Secondary nodes.</div>
-                                    <div style="padding-top: 5px;">Enter IP addresses one below another in the above text field or use the Quick Add list to add available IP addresses on the server.</div>
+                                    <div style="padding-top: 5px;">The static IP addresses of this DNS server that will
+                                        be accessible by all other DNS Servers to be added later as Secondary nodes.
+                                    </div>
+                                    <div style="padding-top: 5px;">Enter IP addresses one below another in the above
+                                        text field or use the Quick Add list to add available IP addresses on the
+                                        server.</div>
                                 </div>
                             </div>
 
                             <p>
-                                <b>Note!</b> When the Cluster is initialized, the DNS Server Domain Name will be changed such that the current hostname is a subdomain name of the Cluster Domain name specified above. For example, if the current DNS Server Domain Name is <code>ns1.mydomain.tld</code> or just <code>ns1</code> then the new domain name will be <code>ns1.mycluster.tld</code>.
+                                <b>Note!</b> When the Cluster is initialized, the DNS Server Domain Name will be changed
+                                such that the current hostname is a subdomain name of the Cluster Domain name specified
+                                above. For example, if the current DNS Server Domain Name is
+                                <code>ns1.mydomain.tld</code> or just <code>ns1</code> then the new domain name will be
+                                <code>ns1.mycluster.tld</code>.
                             </p>
 
                             <p>
-                                <b>Note!</b> If the web service does not have HTTPS enabled, then the initialization process will enable it automatically with a self-signed certificate. However, it is recommended to manually configure HTTPS with a valid certificate before initializing the Cluster. This certificate must include the new expected DNS Server Domain Name, as mentioned in the above note, as the Subject Common Name or Subject Alternative Name (SAN) so that it validates when a Secondary node tries to join the Cluster. Once a node joins the Cluster, it uses DANE-EE for server authentication and the domain name in the certificate is no longer required to match the DNS Server Domain Name.
+                                <b>Note!</b> If the web service does not have HTTPS enabled, then the initialization
+                                process will enable it automatically with a self-signed certificate. However, it is
+                                recommended to manually configure HTTPS with a valid certificate before initializing the
+                                Cluster. This certificate must include the new expected DNS Server Domain Name, as
+                                mentioned in the above note, as the Subject Common Name or Subject Alternative Name
+                                (SAN) so that it validates when a Secondary node tries to join the Cluster. Once a node
+                                joins the Cluster, it uses DANE-EE for server authentication and the domain name in the
+                                certificate is no longer required to match the DNS Server Domain Name.
                             </p>
 
                             <p>
-                                <b>Note!</b> The initialization process will create two zones if they do not exist. The first zone will be the Cluster Primary zone named as the Cluster Domain name specified above where the Cluster will automatically manage domain name records for all the nodes. The second zone will be the Cluster Catalog zone that uses <code>cluster-catalog</code> as the subdomain name of the Cluster Domain name. Use this Cluster Catalog zone for automatic provisioning of Secondary zones on all of the Cluster Secondary nodes.
+                                <b>Note!</b> The initialization process will create two zones if they do not exist. The
+                                first zone will be the Cluster Primary zone named as the Cluster Domain name specified
+                                above where the Cluster will automatically manage domain name records for all the nodes.
+                                The second zone will be the Cluster Catalog zone that uses <code>cluster-catalog</code>
+                                as the subdomain name of the Cluster Domain name. Use this Cluster Catalog zone for
+                                automatic provisioning of Secondary zones on all of the Cluster Secondary nodes.
                             </p>
 
                             <p>
-                                <b>Warning!</b> The Cluster Domain name cannot be changed later. Make sure that you enter the correct domain name before proceeding. You can update the DNS Server Domain Name later if needed from Settings but it must always be a subdomain name of the Cluster Domain name.
+                                <b>Warning!</b> The Cluster Domain name cannot be changed later. Make sure that you
+                                enter the correct domain name before proceeding. You can update the DNS Server Domain
+                                Name later if needed from Settings but it must always be a subdomain name of the Cluster
+                                Domain name.
                             </p>
                         </div>
                     </div>
                     <div class="modal-footer">
                         <div class="pull-left">
-                            <a href="https://blog.technitium.com/2025/11/understanding-clustering-and-how-to.html" target="_blank">Help: Understanding Clustering And How To Configure It</a>
+                            <a href="https://blog.technitium.com/2025/11/understanding-clustering-and-how-to.html"
+                                target="_blank">Help: Understanding Clustering And How To Configure It</a>
                         </div>
                         <div class="pull-right">
-                            <button type="submit" class="btn btn-primary" data-loading-text="Working..." onclick="initializeNewCluster(this); return false;">Initialize</button>
+                            <button type="submit" class="btn btn-primary" data-loading-text="Working..."
+                                onclick="initializeNewCluster(this); return false;">Initialize</button>
                             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                         </div>
                     </div>
@@ -6599,7 +9213,8 @@ MII...
             <div class="modal-dialog" role="document" style="width: 780px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Join Cluster</h4>
                     </div>
                     <div class="modal-body">
@@ -6607,37 +9222,54 @@ MII...
 
                         <div id="divInitializeJoinClusterLoader" style="height: 500px;"></div>
 
-                        <div id="divInitializeJoinClusterView" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                        <div id="divInitializeJoinClusterView"
+                            style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                             <p>
-                                Joining a Cluster will make this DNS server its Secondary node. This process will overwrite configuration on this DNS server for Allowed, Blocked, Apps, Settings and Administration sections. The DNS server will automatically synchronize its configuration with the Primary node in the Cluster.
+                                Joining a Cluster will make this DNS server its Secondary node. This process will
+                                overwrite configuration on this DNS server for Allowed, Blocked, Apps, Settings and
+                                Administration sections. The DNS server will automatically synchronize its configuration
+                                with the Primary node in the Cluster.
                             </p>
 
                             <div class="form-group">
-                                <label for="txtInitializeJoinClusterSecondaryNodeIpAddresses" class="col-sm-4 control-label">Secondary Node IP Addresses</label>
+                                <label for="txtInitializeJoinClusterSecondaryNodeIpAddresses"
+                                    class="col-sm-4 control-label">Secondary Node IP Addresses</label>
                                 <div class="col-sm-7">
-                                    <textarea id="txtInitializeJoinClusterSecondaryNodeIpAddresses" class="form-control" rows="3" spellcheck="false"></textarea>
+                                    <textarea id="txtInitializeJoinClusterSecondaryNodeIpAddresses" class="form-control"
+                                        rows="3" spellcheck="false"></textarea>
 
-                                    <label for="optInitializeJoinClusterQuickIpAddresses" class="control-label">Quick Add</label>
+                                    <label for="optInitializeJoinClusterQuickIpAddresses" class="control-label">Quick
+                                        Add</label>
                                     <select id="optInitializeJoinClusterQuickIpAddresses" class="form-control"></select>
 
-                                    <div style="padding-top: 5px;">The static IP addresses of this DNS server that will be accessible by all other DNS Server nodes in the Cluster.</div>
-                                    <div style="padding-top: 5px;">Enter IP addresses one below another in the above text field or use the Quick Add list to add available IP addresses on the server.</div>
+                                    <div style="padding-top: 5px;">The static IP addresses of this DNS server that will
+                                        be accessible by all other DNS Server nodes in the Cluster.</div>
+                                    <div style="padding-top: 5px;">Enter IP addresses one below another in the above
+                                        text field or use the Quick Add list to add available IP addresses on the
+                                        server.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtInitializeJoinClusterPrimaryNodeUrl" class="col-sm-4 control-label">Primary Node URL</label>
+                                <label for="txtInitializeJoinClusterPrimaryNodeUrl"
+                                    class="col-sm-4 control-label">Primary Node URL</label>
                                 <div class="col-sm-7">
-                                    <input id="txtInitializeJoinClusterPrimaryNodeUrl" type="text" class="form-control" placeholder="URL" maxlength="255">
-                                    <div style="padding-top: 5px;">The web service HTTPS URL of the Primary node in the Cluster.</div>
+                                    <input id="txtInitializeJoinClusterPrimaryNodeUrl" type="text" class="form-control"
+                                        placeholder="URL" maxlength="255">
+                                    <div style="padding-top: 5px;">The web service HTTPS URL of the Primary node in the
+                                        Cluster.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtInitializeJoinClusterPrimaryNodeIpAddress" class="col-sm-4 control-label">Primary Node IP Address (Optional)</label>
+                                <label for="txtInitializeJoinClusterPrimaryNodeIpAddress"
+                                    class="col-sm-4 control-label">Primary Node IP Address (Optional)</label>
                                 <div class="col-sm-7">
-                                    <input id="txtInitializeJoinClusterPrimaryNodeIpAddress" type="text" class="form-control" placeholder="IP address" maxlength="255">
-                                    <div style="padding-top: 5px;">The IP address of the Primary node in the Cluster. When unspecified, domain name in the Primary node URL will be resolved and used.</div>
+                                    <input id="txtInitializeJoinClusterPrimaryNodeIpAddress" type="text"
+                                        class="form-control" placeholder="IP address" maxlength="255">
+                                    <div style="padding-top: 5px;">The IP address of the Primary node in the Cluster.
+                                        When unspecified, domain name in the Primary node URL will be resolved and used.
+                                    </div>
                                 </div>
                             </div>
 
@@ -6646,72 +9278,99 @@ MII...
                                 <div class="col-sm-7">
                                     <div class="radio">
                                         <label>
-                                            <input type="radio" name="rdInitializeJoinClusterCertificateValidation" id="rdInitializeJoinClusterCertificateValidationDefault" value="false">
+                                            <input type="radio" name="rdInitializeJoinClusterCertificateValidation"
+                                                id="rdInitializeJoinClusterCertificateValidationDefault" value="false">
                                             Validate Certificate With PKI and DANE (Recommended)
                                         </label>
                                         <div style="padding-top: 5px; padding-left: 20px;">
-                                            The Primary node web service TLS certificate will be validated using PKI and DANE to ensure that your connection is secure.
+                                            The Primary node web service TLS certificate will be validated using PKI and
+                                            DANE to ensure that your connection is secure.
                                         </div>
                                     </div>
                                     <div class="radio">
                                         <label>
-                                            <input type="radio" name="rdInitializeJoinClusterCertificateValidation" id="rdInitializeJoinClusterCertificateValidationIgnore" value="true">
+                                            <input type="radio" name="rdInitializeJoinClusterCertificateValidation"
+                                                id="rdInitializeJoinClusterCertificateValidationIgnore" value="true">
                                             Ignore Certificate Validation Errors
                                         </label>
                                         <div style="padding-top: 5px; padding-left: 20px;">
-                                            Use this options only when you know that the Primary node web service is using a self-signed TLS certificate and is reachable on a private network.
+                                            Use this options only when you know that the Primary node web service is
+                                            using a self-signed TLS certificate and is reachable on a private network.
                                         </div>
                                     </div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtInitializeJoinClusterPrimaryNodeUsername" class="col-sm-4 control-label">Primary Node Username</label>
+                                <label for="txtInitializeJoinClusterPrimaryNodeUsername"
+                                    class="col-sm-4 control-label">Primary Node Username</label>
                                 <div class="col-sm-7">
-                                    <input id="txtInitializeJoinClusterPrimaryNodeUsername" type="text" class="form-control" placeholder="username" maxlength="255">
-                                    <div style="padding-top: 5px;">The username of an administrator on the Primary node in the Cluster.</div>
+                                    <input id="txtInitializeJoinClusterPrimaryNodeUsername" type="text"
+                                        class="form-control" placeholder="username" maxlength="255">
+                                    <div style="padding-top: 5px;">The username of an administrator on the Primary node
+                                        in the Cluster.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtInitializeJoinClusterPrimaryNodePassword" class="col-sm-4 control-label">Primary Node Password</label>
+                                <label for="txtInitializeJoinClusterPrimaryNodePassword"
+                                    class="col-sm-4 control-label">Primary Node Password</label>
                                 <div class="col-sm-7">
-                                    <input id="txtInitializeJoinClusterPrimaryNodePassword" type="password" class="form-control" maxlength="255">
-                                    <div style="padding-top: 5px;">The password of the administrator user specified above.</div>
+                                    <input id="txtInitializeJoinClusterPrimaryNodePassword" type="password"
+                                        class="form-control" maxlength="255">
+                                    <div style="padding-top: 5px;">The password of the administrator user specified
+                                        above.</div>
                                 </div>
                             </div>
 
                             <div id="divInitializeJoinClusterPrimaryNode2faTotp" class="form-group">
-                                <label for="txtInitializeJoinClusterPrimaryNode2faTotp" class="col-sm-4 control-label">Primary Node OTP</label>
+                                <label for="txtInitializeJoinClusterPrimaryNode2faTotp"
+                                    class="col-sm-4 control-label">Primary Node OTP</label>
                                 <div class="col-sm-7">
-                                    <input id="txtInitializeJoinClusterPrimaryNode2faTotp" type="text" class="form-control" placeholder="OTP" maxlength="6">
-                                    <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator app for the administrator user specified above.</div>
+                                    <input id="txtInitializeJoinClusterPrimaryNode2faTotp" type="text"
+                                        class="form-control" placeholder="OTP" maxlength="6">
+                                    <div style="padding-top: 5px;">Enter the 6-digit code you see in your authenticator
+                                        app for the administrator user specified above.</div>
                                 </div>
                             </div>
 
                             <p>
-                                <b>Note!</b> The process to join the Cluster may take a while to complete depending on the amount of initial config data that needs to be synchronized from the Primary node. Please be patient till the process completes.
+                                <b>Note!</b> The process to join the Cluster may take a while to complete depending on
+                                the amount of initial config data that needs to be synchronized from the Primary node.
+                                Please be patient till the process completes.
                             </p>
 
                             <p>
-                                <b>Note!</b> If the web service does not have HTTPS enabled, then the joining process will enable it automatically with a self-signed certificate. However, its recommended to manually configure HTTPS with a valid certificate before joining the cluster. This certificate should optionally include the new expected DNS Server Domain Name, which will be a subdomain name of the Cluster Domain name, as the Subject Common Name or Subject Alternative Name (SAN).
+                                <b>Note!</b> If the web service does not have HTTPS enabled, then the joining process
+                                will enable it automatically with a self-signed certificate. However, its recommended to
+                                manually configure HTTPS with a valid certificate before joining the cluster. This
+                                certificate should optionally include the new expected DNS Server Domain Name, which
+                                will be a subdomain name of the Cluster Domain name, as the Subject Common Name or
+                                Subject Alternative Name (SAN).
                             </p>
 
                             <p>
-                                <b>Note!</b> The Ignore Certificate Validation Errors option when selected is used only for the initial connection to the Primary node during the joining process. Once the DNS server joins the Cluster, it will always use DANE-EE for authentication using the TLSA records in the Cluster Primary zone that are added for each node in the Cluster.
+                                <b>Note!</b> The Ignore Certificate Validation Errors option when selected is used only
+                                for the initial connection to the Primary node during the joining process. Once the DNS
+                                server joins the Cluster, it will always use DANE-EE for authentication using the TLSA
+                                records in the Cluster Primary zone that are added for each node in the Cluster.
                             </p>
 
                             <p>
-                                <b>Warning!</b> Joining a Cluster will cause configuration on this DNS Server to be overwritten permanently for Allowed, Blocked, Apps, Settings and Administration sections!
+                                <b>Warning!</b> Joining a Cluster will cause configuration on this DNS Server to be
+                                overwritten permanently for Allowed, Blocked, Apps, Settings and Administration
+                                sections!
                             </p>
                         </div>
                     </div>
                     <div class="modal-footer">
                         <div class="pull-left">
-                            <a href="https://blog.technitium.com/2025/11/understanding-clustering-and-how-to.html" target="_blank">Help: Understanding Clustering And How To Configure It</a>
+                            <a href="https://blog.technitium.com/2025/11/understanding-clustering-and-how-to.html"
+                                target="_blank">Help: Understanding Clustering And How To Configure It</a>
                         </div>
                         <div class="pull-right">
-                            <button type="submit" class="btn btn-primary" data-loading-text="Joining..." onclick="initializeJoinCluster(this); return false;">Join</button>
+                            <button type="submit" class="btn btn-primary" data-loading-text="Joining..."
+                                onclick="initializeJoinCluster(this); return false;">Join</button>
                             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                         </div>
                     </div>
@@ -6725,7 +9384,8 @@ MII...
             <div class="modal-dialog" role="document" style="width: 780px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Cluster Options</h4>
                     </div>
                     <div class="modal-body">
@@ -6733,62 +9393,84 @@ MII...
 
                         <div id="divClusterOptionsLoader" style="height: 100px;"></div>
 
-                        <div id="divClusterOptionsView" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                        <div id="divClusterOptionsView"
+                            style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                             <div class="form-group">
-                                <label for="txtClusterOptionsClusterDomain" class="col-sm-4 control-label">Cluster Domain</label>
+                                <label for="txtClusterOptionsClusterDomain" class="col-sm-4 control-label">Cluster
+                                    Domain</label>
                                 <div class="col-sm-7">
-                                    <input id="txtClusterOptionsClusterDomain" type="text" class="form-control" placeholder="domain name" maxlength="255" disabled>
+                                    <input id="txtClusterOptionsClusterDomain" type="text" class="form-control"
+                                        placeholder="domain name" maxlength="255" disabled>
                                     <div style="padding-top: 5px;">The fully qualified domain name of the Cluster.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtClusterOptionsHeartbeatRefreshIntervalSeconds" class="col-sm-4 control-label">Heartbeat Refresh Interval</label>
+                                <label for="txtClusterOptionsHeartbeatRefreshIntervalSeconds"
+                                    class="col-sm-4 control-label">Heartbeat Refresh Interval</label>
                                 <div class="col-sm-7">
                                     <div>
-                                        <input id="txtClusterOptionsHeartbeatRefreshIntervalSeconds" type="number" class="form-control" placeholder="seconds" maxlength="5" style="width: 100px; display: inline;">
+                                        <input id="txtClusterOptionsHeartbeatRefreshIntervalSeconds" type="number"
+                                            class="form-control" placeholder="seconds" maxlength="5"
+                                            style="width: 100px; display: inline;">
                                         <span>seconds (valid range 10-300; default 30)</span>
                                     </div>
-                                    <div style="padding-top: 5px;">The interval in seconds in which the DNS server must refresh the state of all nodes in the Cluster.</div>
+                                    <div style="padding-top: 5px;">The interval in seconds in which the DNS server must
+                                        refresh the state of all nodes in the Cluster.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtClusterOptionsHeartbeatRetryIntervalSeconds" class="col-sm-4 control-label">Heartbeat Retry Interval</label>
+                                <label for="txtClusterOptionsHeartbeatRetryIntervalSeconds"
+                                    class="col-sm-4 control-label">Heartbeat Retry Interval</label>
                                 <div class="col-sm-7">
                                     <div>
-                                        <input id="txtClusterOptionsHeartbeatRetryIntervalSeconds" type="number" class="form-control" placeholder="seconds" maxlength="5" style="width: 100px; display: inline;">
+                                        <input id="txtClusterOptionsHeartbeatRetryIntervalSeconds" type="number"
+                                            class="form-control" placeholder="seconds" maxlength="5"
+                                            style="width: 100px; display: inline;">
                                         <span>seconds (valid range 10-300; default 10)</span>
                                     </div>
-                                    <div style="padding-top: 5px;">The interval in seconds in which the DNS server must retry the state refresh process for all nodes in case of a failure.</div>
+                                    <div style="padding-top: 5px;">The interval in seconds in which the DNS server must
+                                        retry the state refresh process for all nodes in case of a failure.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtClusterOptionsConfigRefreshIntervalSeconds" class="col-sm-4 control-label">Config Refresh Interval</label>
+                                <label for="txtClusterOptionsConfigRefreshIntervalSeconds"
+                                    class="col-sm-4 control-label">Config Refresh Interval</label>
                                 <div class="col-sm-7">
                                     <div>
-                                        <input id="txtClusterOptionsConfigRefreshIntervalSeconds" type="number" class="form-control" placeholder="seconds" maxlength="5" style="width: 100px; display: inline;">
+                                        <input id="txtClusterOptionsConfigRefreshIntervalSeconds" type="number"
+                                            class="form-control" placeholder="seconds" maxlength="5"
+                                            style="width: 100px; display: inline;">
                                         <span>seconds (valid range 30-3600; default 900)</span>
                                     </div>
-                                    <div style="padding-top: 5px;">The interval in seconds in which the DNS server must refresh the configuration from the Primary node.</div>
+                                    <div style="padding-top: 5px;">The interval in seconds in which the DNS server must
+                                        refresh the configuration from the Primary node.</div>
                                 </div>
                             </div>
 
                             <div class="form-group">
-                                <label for="txtClusterOptionsConfigRetryIntervalSeconds" class="col-sm-4 control-label">Config Retry Interval</label>
+                                <label for="txtClusterOptionsConfigRetryIntervalSeconds"
+                                    class="col-sm-4 control-label">Config Retry Interval</label>
                                 <div class="col-sm-7">
                                     <div>
-                                        <input id="txtClusterOptionsConfigRetryIntervalSeconds" type="number" class="form-control" placeholder="seconds" maxlength="5" style="width: 100px; display: inline;">
+                                        <input id="txtClusterOptionsConfigRetryIntervalSeconds" type="number"
+                                            class="form-control" placeholder="seconds" maxlength="5"
+                                            style="width: 100px; display: inline;">
                                         <span>seconds (valid range 30-3600; default 60)</span>
                                     </div>
-                                    <div style="padding-top: 5px;">The interval in seconds in which the DNS server must retry the configuration refresh process for the Primary node in case of a failure.</div>
+                                    <div style="padding-top: 5px;">The interval in seconds in which the DNS server must
+                                        retry the configuration refresh process for the Primary node in case of a
+                                        failure.</div>
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnClusterOptionsSave" type="submit" class="btn btn-primary" data-loading-text="Saving..." onclick="saveClusterOptions(this); return false;">Save</button>
+                        <button id="btnClusterOptionsSave" type="submit" class="btn btn-primary"
+                            data-loading-text="Saving..."
+                            onclick="saveClusterOptions(this); return false;">Save</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6801,52 +9483,70 @@ MII...
             <div class="modal-dialog" role="document" style="width: 780px;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Edit Node - <span id="lblEditClusterNodeName">node1.example.com</span></h4>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title">Edit Node - <span id="lblEditClusterNodeName">node1.example.com</span>
+                        </h4>
                     </div>
                     <div class="modal-body">
                         <div id="divEditClusterNodeAlert"></div>
 
                         <div id="divEditClusterNodeLoader" style="height: 100px;"></div>
 
-                        <div id="divEditClusterNodeView" style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
+                        <div id="divEditClusterNodeView"
+                            style="max-height: 500px; overflow-y: auto; padding: 0 6px; overflow-x: hidden;">
                             <div id="divEditClusterNodeSelfNode">
                                 <div class="form-group">
-                                    <label for="txtEditClusterNodeSelfNodeIpAddresses" class="col-sm-4 control-label">Node IP Addresses</label>
+                                    <label for="txtEditClusterNodeSelfNodeIpAddresses"
+                                        class="col-sm-4 control-label">Node IP Addresses</label>
                                     <div class="col-sm-7">
-                                        <textarea id="txtEditClusterNodeSelfNodeIpAddresses" class="form-control" rows="3" spellcheck="false"></textarea>
+                                        <textarea id="txtEditClusterNodeSelfNodeIpAddresses" class="form-control"
+                                            rows="3" spellcheck="false"></textarea>
 
-                                        <label for="optEditClusterNodeQuickSelfIpAddresses" class="control-label">Quick Add</label>
-                                        <select id="optEditClusterNodeQuickSelfIpAddresses" class="form-control"></select>
+                                        <label for="optEditClusterNodeQuickSelfIpAddresses" class="control-label">Quick
+                                            Add</label>
+                                        <select id="optEditClusterNodeQuickSelfIpAddresses"
+                                            class="form-control"></select>
 
-                                        <div style="padding-top: 5px;">The static IP addresses of this DNS server that will be accessible by all other DNS Server nodes in the Cluster.</div>
-                                        <div style="padding-top: 5px;">Enter IP addresses one below another in the above text field or use the Quick Add list to add available IP addresses on the server.</div>
+                                        <div style="padding-top: 5px;">The static IP addresses of this DNS server that
+                                            will be accessible by all other DNS Server nodes in the Cluster.</div>
+                                        <div style="padding-top: 5px;">Enter IP addresses one below another in the above
+                                            text field or use the Quick Add list to add available IP addresses on the
+                                            server.</div>
                                     </div>
                                 </div>
                             </div>
 
                             <div id="divEditClusterNodePrimaryNode">
                                 <div class="form-group">
-                                    <label for="txtEditClusterNodePrimaryNodeUrl" class="col-sm-4 control-label">Primary Node URL</label>
+                                    <label for="txtEditClusterNodePrimaryNodeUrl" class="col-sm-4 control-label">Primary
+                                        Node URL</label>
                                     <div class="col-sm-7">
-                                        <input id="txtEditClusterNodePrimaryNodeUrl" type="text" class="form-control" placeholder="URL" maxlength="255">
-                                        <div style="padding-top: 5px;">The web service HTTPS URL of the Primary node in the Cluster.</div>
+                                        <input id="txtEditClusterNodePrimaryNodeUrl" type="text" class="form-control"
+                                            placeholder="URL" maxlength="255">
+                                        <div style="padding-top: 5px;">The web service HTTPS URL of the Primary node in
+                                            the Cluster.</div>
                                     </div>
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="txtEditClusterNodePrimaryNodeIpAddresses" class="col-sm-4 control-label">Primary Node IP Addresses (Optional)</label>
+                                    <label for="txtEditClusterNodePrimaryNodeIpAddresses"
+                                        class="col-sm-4 control-label">Primary Node IP Addresses (Optional)</label>
                                     <div class="col-sm-7">
-                                        <textarea id="txtEditClusterNodePrimaryNodeIpAddresses" class="form-control" rows="3" spellcheck="false"></textarea>
+                                        <textarea id="txtEditClusterNodePrimaryNodeIpAddresses" class="form-control"
+                                            rows="3" spellcheck="false"></textarea>
 
-                                        <div style="padding-top: 5px;">The IP addresses of the Primary node in the Cluster. When unspecified, domain name in the Primary node URL will be resolved and used.</div>
+                                        <div style="padding-top: 5px;">The IP addresses of the Primary node in the
+                                            Cluster. When unspecified, domain name in the Primary node URL will be
+                                            resolved and used.</div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnEditClusterNodeSave" type="submit" class="btn btn-primary" data-loading-text="Saving...">Save</button>
+                        <button id="btnEditClusterNodeSave" type="submit" class="btn btn-primary"
+                            data-loading-text="Saving...">Save</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6859,14 +9559,18 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Remove Node - <span id="lblRemoveClusterNodeName">node1.example.com</span></h4>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title">Remove Node - <span
+                                id="lblRemoveClusterNodeName">node1.example.com</span></h4>
                     </div>
                     <div class="modal-body">
                         <div id="divRemoveClusterNodeAlert"></div>
 
                         <p>
-                            The Remove Node process will ask the selected Secondary node to leave the Cluster gracefully. The Secondary will then initiate Leave Cluster process as if the Leave Cluster action was performed on that node itself.
+                            The Remove Node process will ask the selected Secondary node to leave the Cluster
+                            gracefully. The Secondary will then initiate Leave Cluster process as if the Leave Cluster
+                            action was performed on that node itself.
                         </p>
 
                         <div class="form-group">
@@ -6876,7 +9580,9 @@ MII...
                                         <input id="chkRemoveClusterNodeForceRemove" type="checkbox"> Force Remove Node
                                     </label>
                                 </div>
-                                <div style="padding-top: 5px; padding-left: 20px;">Enabling this option will cause the Secondary node to be deleted from the Cluster without asking the node to leave gracefully.</div>
+                                <div style="padding-top: 5px; padding-left: 20px;">Enabling this option will cause the
+                                    Secondary node to be deleted from the Cluster without asking the node to leave
+                                    gracefully.</div>
                             </div>
                         </div>
 
@@ -6885,11 +9591,14 @@ MII...
                         </p>
 
                         <p>
-                            <b>Note!</b> Use the Force Remove Node option only when the Secondary node is unreachable/decommissioned and cannot leave the Cluster gracefully.
+                            <b>Note!</b> Use the Force Remove Node option only when the Secondary node is
+                            unreachable/decommissioned and cannot leave the Cluster gracefully.
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnRemoveClusterNode" type="submit" class="btn btn-warning" data-loading-text="Removing..." onclick="removeSecondaryClusterNode(this); return false;">Remove</button>
+                        <button id="btnRemoveClusterNode" type="submit" class="btn btn-warning"
+                            data-loading-text="Removing..."
+                            onclick="removeSecondaryClusterNode(this); return false;">Remove</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6902,41 +9611,55 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Promote To Primary Node - <span id="lblPromoteToPrimaryClusterNodeName"></span></h4>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title">Promote To Primary Node - <span
+                                id="lblPromoteToPrimaryClusterNodeName"></span></h4>
                     </div>
                     <div class="modal-body">
                         <div id="divPromoteToPrimaryClusterNodeAlert"></div>
 
                         <p>
-                            The promote To Primary node process will resync complete configuration from the Primary node and then proceed to delete it from the Cluster followed by upgrading the selected Secondary node to become the Primary node in the Cluster. The former Primary node when deleted will cause it to delete all its own Cluster configuration leaving the Cluster without causing any other data loss.
+                            The promote To Primary node process will resync complete configuration from the Primary node
+                            and then proceed to delete it from the Cluster followed by upgrading the selected Secondary
+                            node to become the Primary node in the Cluster. The former Primary node when deleted will
+                            cause it to delete all its own Cluster configuration leaving the Cluster without causing any
+                            other data loss.
                         </p>
 
                         <div class="form-group">
                             <div class="col-sm-offset-1 col-sm-10">
                                 <div class="checkbox">
                                     <label>
-                                        <input id="chkPromoteToPrimaryClusterNodeForceDeletePrimary" type="checkbox"> Force Delete Current Primary Node
+                                        <input id="chkPromoteToPrimaryClusterNodeForceDeletePrimary" type="checkbox">
+                                        Force Delete Current Primary Node
                                     </label>
                                 </div>
-                                <div style="padding-top: 5px; padding-left: 20px;">Enabling this option will cause the current Primary node to be deleted from the Cluster without resyncing complete configuration from it and without inform it.</div>
+                                <div style="padding-top: 5px; padding-left: 20px;">Enabling this option will cause the
+                                    current Primary node to be deleted from the Cluster without resyncing complete
+                                    configuration from it and without inform it.</div>
                             </div>
                         </div>
 
                         <p>
-                            Are you sure you want to promote the selected Secondary node to become the Primary node in the Cluster?
+                            Are you sure you want to promote the selected Secondary node to become the Primary node in
+                            the Cluster?
                         </p>
 
                         <p>
-                            <b>Note!</b> Use the Force Delete Current Primary Node option only when the Primary node is unreachable/decommissioned and thus cannot be deleted from the Cluster gracefully.
+                            <b>Note!</b> Use the Force Delete Current Primary Node option only when the Primary node is
+                            unreachable/decommissioned and thus cannot be deleted from the Cluster gracefully.
                         </p>
 
                         <p>
-                            <b>Note!</b> The process to promote to Primary node may take a while to complete depending on the size of the complete configuration being resynced and the number of local zones that need to be converted. Please be patient till the process completes.
+                            <b>Note!</b> The process to promote to Primary node may take a while to complete depending
+                            on the size of the complete configuration being resynced and the number of local zones that
+                            need to be converted. Please be patient till the process completes.
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-warning" data-loading-text="Promoting..." onclick="promoteToPrimaryClusterNode(this); return false;">Promote</button>
+                        <button type="submit" class="btn btn-warning" data-loading-text="Promoting..."
+                            onclick="promoteToPrimaryClusterNode(this); return false;">Promote</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6949,14 +9672,18 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Leave Cluster</h4>
                     </div>
                     <div class="modal-body">
                         <div id="divLeaveClusterAlert"></div>
 
                         <p>
-                            The Leave Cluster process will remove all Cluster configuration from this Secondary node and leave the Cluster gracefully. There will be no data loss except for the Cluster configuration. You will need to re-join the Cluster again to use this DNS server as a Secondary node.
+                            The Leave Cluster process will remove all Cluster configuration from this Secondary node and
+                            leave the Cluster gracefully. There will be no data loss except for the Cluster
+                            configuration. You will need to re-join the Cluster again to use this DNS server as a
+                            Secondary node.
                         </p>
 
                         <div class="form-group">
@@ -6966,7 +9693,8 @@ MII...
                                         <input id="chkLeaveClusterForceLeave" type="checkbox"> Force Leave Cluster
                                     </label>
                                 </div>
-                                <div style="padding-top: 5px; padding-left: 20px;">Enabling this option will cause this Secondary node to leave the Cluster without informing the Primary node.</div>
+                                <div style="padding-top: 5px; padding-left: 20px;">Enabling this option will cause this
+                                    Secondary node to leave the Cluster without informing the Primary node.</div>
                             </div>
                         </div>
 
@@ -6975,11 +9703,13 @@ MII...
                         </p>
 
                         <p>
-                            <b>Note!</b> Use the Force Leave Cluster option only when the Primary node is unreachable/decommissioned and thus cannot leave the Cluster gracefully.
+                            <b>Note!</b> Use the Force Leave Cluster option only when the Primary node is
+                            unreachable/decommissioned and thus cannot leave the Cluster gracefully.
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-warning" data-loading-text="Leaving..." onclick="leaveCluster(this); return false;">Leave</button>
+                        <button type="submit" class="btn btn-warning" data-loading-text="Leaving..."
+                            onclick="leaveCluster(this); return false;">Leave</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -6992,14 +9722,17 @@ MII...
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title">Delete Cluster</h4>
                     </div>
                     <div class="modal-body">
                         <div id="divDeleteClusterAlert"></div>
 
                         <p>
-                            The Delete Cluster process will remove all Cluster configuration from this Primary node. There will be no data loss except for the Cluster configuration. You will need to re-initialize the Cluster again to use clustering features on this DNS server.
+                            The Delete Cluster process will remove all Cluster configuration from this Primary node.
+                            There will be no data loss except for the Cluster configuration. You will need to
+                            re-initialize the Cluster again to use clustering features on this DNS server.
                         </p>
 
                         <div class="form-group">
@@ -7009,7 +9742,9 @@ MII...
                                         <input id="chkDeleteClusterForceDelete" type="checkbox"> Force Delete Cluster
                                     </label>
                                 </div>
-                                <div style="padding-top: 5px; padding-left: 20px;">Enabling this option will cause this Primary node to delete the Cluster for itself even when other Secondary nodes still exist, orphaning them.</div>
+                                <div style="padding-top: 5px; padding-left: 20px;">Enabling this option will cause this
+                                    Primary node to delete the Cluster for itself even when other Secondary nodes still
+                                    exist, orphaning them.</div>
                             </div>
                         </div>
 
@@ -7018,11 +9753,16 @@ MII...
                         </p>
 
                         <p>
-                            <b>Note!</b> You can delete the Cluster only when there are no Secondary nodes in the Cluster. Use the Force Delete Cluster option only when you wish this Primary node to be removed from the Cluster even when there are Secondary nodes in the Cluster. In this case, the Secondary nodes will become orphaned and you will need to promote one of them to be the new Primary node manually.
+                            <b>Note!</b> You can delete the Cluster only when there are no Secondary nodes in the
+                            Cluster. Use the Force Delete Cluster option only when you wish this Primary node to be
+                            removed from the Cluster even when there are Secondary nodes in the Cluster. In this case,
+                            the Secondary nodes will become orphaned and you will need to promote one of them to be the
+                            new Primary node manually.
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-danger" data-loading-text="Deleting..." onclick="deleteCluster(this); return false;">Delete</button>
+                        <button type="submit" class="btn btn-danger" data-loading-text="Deleting..."
+                            onclick="deleteCluster(this); return false;">Delete</button>
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>
                 </div>
@@ -7032,4 +9772,5 @@ MII...
 
     <div id="footer"></div>
 </body>
+
 </html>

--- a/DnsServerCore/www/js/main.js
+++ b/DnsServerCore/www/js/main.js
@@ -2866,6 +2866,7 @@ function restoreSettings() {
     });
 }
 
+// Dae Euhwa <daedaevibin@ik.me>
 function applyTheme() {
     const currentTheme = localStorage.getItem("theme");
 

--- a/DnsServerCore/www/js/main.js
+++ b/DnsServerCore/www/js/main.js
@@ -2869,21 +2869,20 @@ function restoreSettings() {
 function applyTheme() {
     const currentTheme = localStorage.getItem("theme");
 
-    if (currentTheme === "dark")
+    //remove all theme classes
+    document.body.classList.remove("dark-mode");
+    document.body.classList.remove("rust-theme");
+
+    if (currentTheme === "dark") {
         document.body.classList.add("dark-mode");
-    else
-        document.body.classList.remove("dark-mode");
+    } else if (currentTheme === "rust") {
+        document.body.classList.add("rust-theme");
+    }
 }
 
-function toggleTheme() {
-    document.body.classList.toggle("dark-mode");
-
-    let theme = "light";
-
-    if (document.body.classList.contains("dark-mode"))
-        theme = "dark";
-
+function setTheme(theme) {
     localStorage.setItem("theme", theme);
+    applyTheme();
 
     if (window.chartDashboardMain) {
         window.chartDashboardMain.update();


### PR DESCRIPTION
## Summary
This PR introduces a new "Rust" theme for the DNS Server web interface and updates the theme selection mechanism to support multiple themes. 

## Key Changes
* **New Theme:** Added a `.rust-theme` to `main.css` featuring a dark background with rust/orange accents.
* **UI Update:** Replaced the "Toggle Dark Mode" button in the user dropdown menu with a "Theme" submenu. Users can now explicitly select between **Light**, **Dark**, and **Rust** themes.
* **JavaScript Refactoring:** Replaced the `toggleTheme()` toggle logic in `main.js` with a new `setTheme(theme)` and `applyTheme()` function. This safely clears existing theme classes before applying the newly selected theme from `localStorage`.
* **Formatting:** Ran auto-formatting across `index.html`, `main.css`, and `CHANGELOG.md`, which accounts for the large number of lines changed in this diff.