### PR TITLE
Fix incorrect endpoint for updateIpAddress in docs

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -7134,7 +7134,7 @@ RESPONSE:
 Allows to update the current Cluster node's IP address. This call can be made at both the Primary and Secondary nodes.
 
 URL:\
-`http://localhost:5380/api/admin/cluster/updateIpAddresses?token=x`
+`http://localhost:5380/api/admin/cluster/updateIpAddress?token=x`
 
 PERMISSIONS:\
 Administration: Modify


### PR DESCRIPTION
I could not find a PR template, so I hope you're happy with this.

APIDOCS currently specifies `/api/admin/cluster/updateIpAddresses` as the endpoint to update a node's IP address(es).

However, after much trial and error I was able to discover the correct endpoint is `/api/admin/cluster/updateIpAddresses` . I've updated the document accordingly.