### PR TITLE
fix: fix typo preventing Prometheus scraping

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -707,7 +707,7 @@ Response data is in Prometheus text format with `Content-Type: text/plain; versi
 # TYPE uptime_seconds gauge
 uptime_seconds 264
 # HELP start_time Start time of the DNS Server since epoch (milliseconds)
-# TYPE start_time guage
+# TYPE start_time gauge
 start_time 1776773647619
 # TYPE total_queries counter
 total_queries 0

--- a/DnsServerCore/WebServiceDashboardApi.cs
+++ b/DnsServerCore/WebServiceDashboardApi.cs
@@ -184,7 +184,7 @@ namespace DnsServerCore
                 sb.Append($"uptime_seconds {Convert.ToUInt64((DateTime.UtcNow - _dnsWebService._uptimestamp).TotalSeconds)}\n");
 
                 sb.Append("# HELP start_time Start time of the DNS Server since epoch (milliseconds)\n");
-                sb.Append("# TYPE start_time guage\n");
+                sb.Append("# TYPE start_time gauge\n");
                 sb.Append($"start_time {Convert.ToUInt64((_dnsWebService._uptimestamp - DateTime.UnixEpoch).TotalMilliseconds)}\n");
 
                 sb.Append("# TYPE total_queries counter\n");


### PR DESCRIPTION
Fixes `Error scraping target: invalid metric type "guage"`