### PR TITLE
Add groups and roles to OIDC requested scopes

### DIFF
--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -1624,7 +1624,7 @@ namespace DnsServerCore
                     options.ResponseMode = OpenIdConnectResponseMode.FormPost;
 
                     options.Scope.Clear();
-                    options.Scope.Add("groups");
+                    options.Scope.Add("openid");
                     options.Scope.Add("profile");
                     options.Scope.Add("email");
                     options.Scope.Add("groups");

--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -1624,9 +1624,11 @@ namespace DnsServerCore
                     options.ResponseMode = OpenIdConnectResponseMode.FormPost;
 
                     options.Scope.Clear();
-                    options.Scope.Add("openid");
+                    options.Scope.Add("groups");
                     options.Scope.Add("profile");
                     options.Scope.Add("email");
+                    options.Scope.Add("groups");
+                    options.Scope.Add("roles");
 
                     options.CallbackPath = new PathString("/sso/callback");
 


### PR DESCRIPTION
## Summary
The OIDC client only requests `openid profile email`. Standards-compliant OIDC providers (PocketID, and any OP that follows the RFC convention of gating optional claims on scopes) therefore never return a `groups` (or `roles`) claim, so `SsoLoginFinalizeAsync` sees an empty claim set and `SsoGroupMap` lookups never match. The result is that the SSO group-mapping feature is effectively dead code on RFC-strict providers.

## Fix
Add `groups` and `roles` to the requested scopes in the `AddOpenIdConnect` configuration in `DnsServerCore/DnsWebService.cs`. The claim parser at `DnsServerCore/WebServiceAuthApi.cs` already accepts `"groups"`, `"roles"` and `ClaimTypes.Role` — only the request side needed changing.

Standards-compliant OPs silently ignore unknown scopes, so requesting both is safe across providers using either convention (PocketID/Authentik/Keycloak typically use `groups`; Azure AD / some Okta deployments use `roles`).

## Diff
Two lines in `DnsServerCore/DnsWebService.cs` only:

```diff
                     options.Scope.Add("openid");
                     options.Scope.Add("profile");
                     options.Scope.Add("email");
+                    options.Scope.Add("groups");
+                    options.Scope.Add("roles");
```

Fixes [#1845](https://github.com/TechnitiumSoftware/DnsServer/issues/1845)