### PR TITLE
Fix ClusterApiToken not persisted on secondary after initJoin

### DIFF
--- a/DnsServerCore/Auth/AuthManager.cs
+++ b/DnsServerCore/Auth/AuthManager.cs
@@ -538,6 +538,7 @@ namespace DnsServerCore.Auth
                 {
                     switch (existingSession.Value.Type)
                     {
+                        case UserSessionType.ClusterApiToken:
                         case UserSessionType.ApiToken:
                             if (!sessions.ContainsKey(existingSession.Key))
                                 _sessions.TryRemove(existingSession);
@@ -550,6 +551,7 @@ namespace DnsServerCore.Auth
                 {
                     switch (session.Value.Type)
                     {
+                        case UserSessionType.ClusterApiToken:
                         case UserSessionType.ApiToken:
                             _sessions[session.Key] = session.Value;
                             break;


### PR DESCRIPTION
See: https://github.com/TechnitiumSoftware/DnsServer/issues/1848

- initJoin calls SyncConfigFromAsync → RestoreConfigAsync(isConfigTransfer: true)
- The isConfigTransfer branch filters sessions to only ApiToken, dropping ClusterApiToken
- Token lives in memory after join but is never written to auth.config on the secondary
- On service restart, ClusterManager can't find the token so you get "No API token was found for the Cluster domain"

This is a simple fix to add the ClusterAPI token so it won't get filtered.