### PR TITLE
Fix for config corruption on Linux (Docker) after host crash / reboot

### DIFF
--- a/DnsServerCore/Auth/AuthManager.cs
+++ b/DnsServerCore/Auth/AuthManager.cs
@@ -337,6 +337,7 @@ namespace DnsServerCore.Auth
                 using (FileStream fS = new FileStream(tmpConfigFile, FileMode.Create, FileAccess.Write))
                 {
                     mS.CopyTo(fS);
+                    fS.Flush(flushToDisk: true);
                 }
             }
 

--- a/DnsServerCore/Cluster/ClusterManager.cs
+++ b/DnsServerCore/Cluster/ClusterManager.cs
@@ -296,6 +296,7 @@ namespace DnsServerCore.Cluster
                 using (FileStream fS = new FileStream(tmpConfigFile, FileMode.Create, FileAccess.Write))
                 {
                     mS.CopyTo(fS);
+                    fS.Flush(flushToDisk: true);
                 }
             }
 

--- a/DnsServerCore/Dhcp/DhcpServer.cs
+++ b/DnsServerCore/Dhcp/DhcpServer.cs
@@ -1282,6 +1282,7 @@ namespace DnsServerCore.Dhcp
                     using (FileStream fS = new FileStream(tmpScopeFile, FileMode.Create, FileAccess.Write))
                     {
                         mS.CopyTo(fS);
+                        fS.Flush(flushToDisk: true);
                     }
                 }
 

--- a/DnsServerCore/Dns/Applications/DnsApplication.cs
+++ b/DnsServerCore/Dns/Applications/DnsApplication.cs
@@ -243,7 +243,13 @@ namespace DnsServerCore.Dns.Applications
             {
                 string tmpConfigFile = Path.Combine(_dnsServer.ApplicationFolder, "dnsApp.tmp");
 
-                await File.WriteAllTextAsync(tmpConfigFile, config);
+                await using (FileStream fS = new FileStream(tmpConfigFile, FileMode.Create, FileAccess.Write))
+                {
+                    byte[] configBytes = System.Text.Encoding.UTF8.GetBytes(config);
+                    await fS.WriteAsync(configBytes);
+                    await fS.FlushAsync();
+                    fS.Flush(flushToDisk: true);
+                }
 
                 File.Move(tmpConfigFile, configFile, true);
             }

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -619,6 +619,7 @@ namespace DnsServerCore.Dns
                 using (FileStream fS = new FileStream(tmpConfigFile, FileMode.Create, FileAccess.Write))
                 {
                     mS.CopyTo(fS);
+                    fS.Flush(flushToDisk: true);
                 }
             }
 

--- a/DnsServerCore/Dns/ZoneManagers/AllowedZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/AllowedZoneManager.cs
@@ -168,6 +168,7 @@ namespace DnsServerCore.Dns.ZoneManagers
             using (FileStream fS = new FileStream(tmpAllowedZoneFile, FileMode.Create, FileAccess.Write))
             {
                 WriteConfigTo(fS);
+                fS.Flush(flushToDisk: true);
             }
 
             File.Move(tmpAllowedZoneFile, allowedZoneFile, true);

--- a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
@@ -303,6 +303,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                 using (FileStream fS = new FileStream(tmpZoneFile, FileMode.Create, FileAccess.Write))
                 {
                     mS.CopyTo(fS);
+                    fS.Flush(flushToDisk: true);
                 }
             }
 

--- a/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
@@ -206,6 +206,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                 using (FileStream fS = new FileStream(tmpBlockListConfigFile, FileMode.Create, FileAccess.Write))
                 {
                     mS.CopyTo(fS);
+                    fS.Flush(flushToDisk: true);
                 }
             }
 

--- a/DnsServerCore/Dns/ZoneManagers/BlockedZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/BlockedZoneManager.cs
@@ -184,6 +184,7 @@ namespace DnsServerCore.Dns.ZoneManagers
             using (FileStream fS = new FileStream(tmpBlockedZoneFile, FileMode.Create, FileAccess.Write))
             {
                 WriteConfigTo(fS);
+                fS.Flush(flushToDisk: true);
             }
 
             File.Move(tmpBlockedZoneFile, blockedZoneFile, true);

--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -379,6 +379,7 @@ namespace DnsServerCore
                 using (FileStream fS = new FileStream(tmpConfigFile, FileMode.Create, FileAccess.Write))
                 {
                     mS.CopyTo(fS);
+                    fS.Flush(flushToDisk: true);
                 }
             }
 

--- a/DnsServerCore/LogManager.cs
+++ b/DnsServerCore/LogManager.cs
@@ -330,6 +330,7 @@ namespace DnsServerCore
                 using (FileStream fS = new FileStream(tmpLogConfigFile, FileMode.Create, FileAccess.Write))
                 {
                     mS.CopyTo(fS);
+                    fS.Flush(flushToDisk: true);
                 }
             }
 


### PR DESCRIPTION
I experienced regular corruption of auth.config every time one of my cluster nodes rebooted.

The write-to-temp and then rename is a valid pattern but for crash safety the file should be flushed to disk before renaming.

This is a fix for observed behavior where my docker host was rebooted and then it had corrupted this file. (
My temporary fix, if it helps someone, was to fsync one of the other cluster nodes and copy the auth.config file from it.)

I searched for other instances of this pattern; I think I got them. 

Love this project btw, thanks for making it!