### PR TITLE
Add LDAP/Active Directory authentication support

### DIFF
--- a/DnsServerCore/Auth/AuthManager.cs
+++ b/DnsServerCore/Auth/AuthManager.cs
@@ -59,6 +59,20 @@ namespace DnsServerCore.Auth
         bool _ssoAllowSignupOnlyForMappedUsers = true;
         IReadOnlyDictionary<string, string> _ssoGroupMap;
 
+        bool _ldapEnabled;
+        string _ldapServer;
+        int _ldapPort = 389;
+        bool _ldapUseSsl;
+        bool _ldapIgnoreSslErrors;
+        string _ldapBindDn;
+        string _ldapBindPassword;
+        string _ldapSearchBase;
+        string _ldapUserFilter;
+        string _ldapGroupAttribute;
+        bool _ldapAllowSignup;
+        bool _ldapAllowSignupOnlyForMappedUsers = true;
+        IReadOnlyDictionary<string, string> _ldapGroupMap;
+
         readonly Lock _saveLock = new Lock();
         bool _pendingSave;
         readonly Timer _saveTimer;
@@ -249,6 +263,70 @@ namespace DnsServerCore.Auth
                     _ssoGroupMap = groupMap;
                 }
 
+                string strLdapEnabled = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_ENABLED");
+                if (!string.IsNullOrEmpty(strLdapEnabled))
+                    _ldapEnabled = bool.Parse(strLdapEnabled);
+
+                string strLdapServer = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_SERVER");
+                if (!string.IsNullOrEmpty(strLdapServer))
+                    _ldapServer = strLdapServer;
+
+                string strLdapPort = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_PORT");
+                if (!string.IsNullOrEmpty(strLdapPort))
+                    _ldapPort = int.Parse(strLdapPort);
+
+                string strLdapUseSsl = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_USE_SSL");
+                if (!string.IsNullOrEmpty(strLdapUseSsl))
+                    _ldapUseSsl = bool.Parse(strLdapUseSsl);
+
+                string strLdapIgnoreSslErrors = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_IGNORE_SSL_ERRORS");
+                if (!string.IsNullOrEmpty(strLdapIgnoreSslErrors))
+                    _ldapIgnoreSslErrors = bool.Parse(strLdapIgnoreSslErrors);
+
+                string strLdapBindDn = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_BIND_DN");
+                if (!string.IsNullOrEmpty(strLdapBindDn))
+                    _ldapBindDn = strLdapBindDn;
+
+                string strLdapBindPassword = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_BIND_PASSWORD");
+                if (!string.IsNullOrEmpty(strLdapBindPassword))
+                    _ldapBindPassword = strLdapBindPassword;
+
+                string strLdapSearchBase = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_SEARCH_BASE");
+                if (!string.IsNullOrEmpty(strLdapSearchBase))
+                    _ldapSearchBase = strLdapSearchBase;
+
+                string strLdapUserFilter = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_USER_FILTER");
+                if (!string.IsNullOrEmpty(strLdapUserFilter))
+                    _ldapUserFilter = strLdapUserFilter;
+
+                string strLdapGroupAttribute = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_GROUP_ATTRIBUTE");
+                if (!string.IsNullOrEmpty(strLdapGroupAttribute))
+                    _ldapGroupAttribute = strLdapGroupAttribute;
+
+                string strLdapAllowSignup = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_ALLOW_SIGNUP");
+                if (!string.IsNullOrEmpty(strLdapAllowSignup))
+                    _ldapAllowSignup = bool.Parse(strLdapAllowSignup);
+
+                string strLdapAllowSignupOnlyForMappedUsers = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_ALLOW_SIGNUP_ONLY_FOR_MAPPED_USERS");
+                if (!string.IsNullOrEmpty(strLdapAllowSignupOnlyForMappedUsers))
+                    _ldapAllowSignupOnlyForMappedUsers = bool.Parse(strLdapAllowSignupOnlyForMappedUsers);
+
+                string strLdapGroupMap = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_GROUP_MAP");
+                if (!string.IsNullOrEmpty(strLdapGroupMap))
+                {
+                    string[] entries = strLdapGroupMap.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    Dictionary<string, string> groupMap = new Dictionary<string, string>(entries.Length);
+
+                    foreach (string entry in entries)
+                    {
+                        string[] parts = entry.Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                        if (parts.Length == 2)
+                            groupMap.TryAdd(parts[0], parts[1]);
+                    }
+
+                    _ldapGroupMap = groupMap;
+                }
+
                 SaveConfigFileInternal();
             }
             catch (Exception ex)
@@ -376,6 +454,7 @@ namespace DnsServerCore.Auth
             {
                 case 1:
                 case 2:
+                case 3:
                     {
                         int count = bR.ReadByte();
 
@@ -506,6 +585,55 @@ namespace DnsServerCore.Auth
                         restartWebService = !ssoIsStillDisabled && restartWebService;
                     }
 
+                    if (version >= 3)
+                    {
+                        _ldapEnabled = bR.ReadBoolean();
+                        _ldapServer = s.ReadShortString();
+                        if (_ldapServer.Length == 0)
+                            _ldapServer = null;
+                        _ldapPort = bR.ReadInt32();
+                        _ldapUseSsl = bR.ReadBoolean();
+                        _ldapIgnoreSslErrors = bR.ReadBoolean();
+                        _ldapBindDn = s.ReadShortString();
+                        if (_ldapBindDn.Length == 0)
+                            _ldapBindDn = null;
+                        _ldapBindPassword = s.ReadShortString();
+                        if (_ldapBindPassword.Length == 0)
+                            _ldapBindPassword = null;
+                        _ldapSearchBase = s.ReadShortString();
+                        if (_ldapSearchBase.Length == 0)
+                            _ldapSearchBase = null;
+                        _ldapUserFilter = s.ReadShortString();
+                        if (_ldapUserFilter.Length == 0)
+                            _ldapUserFilter = null;
+                        _ldapGroupAttribute = s.ReadShortString();
+                        if (_ldapGroupAttribute.Length == 0)
+                            _ldapGroupAttribute = null;
+                        _ldapAllowSignup = bR.ReadBoolean();
+                        _ldapAllowSignupOnlyForMappedUsers = bR.ReadBoolean();
+
+                        {
+                            int count = bR.ReadByte();
+                            if (count > 0)
+                            {
+                                Dictionary<string, string> ldapGroupMap = new Dictionary<string, string>(count);
+
+                                for (int i = 0; i < count; i++)
+                                {
+                                    string key = s.ReadShortString();
+                                    string value = s.ReadShortString();
+                                    ldapGroupMap.TryAdd(key, value);
+                                }
+
+                                _ldapGroupMap = ldapGroupMap;
+                            }
+                            else
+                            {
+                                _ldapGroupMap = null;
+                            }
+                        }
+                    }
+
                     break;
 
                 default:
@@ -576,7 +704,7 @@ namespace DnsServerCore.Auth
             BinaryWriter bW = new BinaryWriter(s);
 
             bW.Write(Encoding.ASCII.GetBytes("AS")); //format
-            bW.Write((byte)2); //version
+            bW.Write((byte)3); //version
 
             bW.Write(Convert.ToByte(_groups.Count));
 
@@ -642,6 +770,35 @@ namespace DnsServerCore.Auth
                 bW.Write(Convert.ToByte(_ssoGroupMap.Count));
 
                 foreach (KeyValuePair<string, string> entry in _ssoGroupMap)
+                {
+                    s.WriteShortString(entry.Key);
+                    s.WriteShortString(entry.Value);
+                }
+            }
+
+            // LDAP config (version 3+)
+            bW.Write(_ldapEnabled);
+            s.WriteShortString(_ldapServer ?? "");
+            bW.Write(_ldapPort);
+            bW.Write(_ldapUseSsl);
+            bW.Write(_ldapIgnoreSslErrors);
+            s.WriteShortString(_ldapBindDn ?? "");
+            s.WriteShortString(_ldapBindPassword ?? "");
+            s.WriteShortString(_ldapSearchBase ?? "");
+            s.WriteShortString(_ldapUserFilter ?? "");
+            s.WriteShortString(_ldapGroupAttribute ?? "");
+            bW.Write(_ldapAllowSignup);
+            bW.Write(_ldapAllowSignupOnlyForMappedUsers);
+
+            if ((_ldapGroupMap is null) || (_ldapGroupMap.Count == 0))
+            {
+                bW.Write((byte)0);
+            }
+            else
+            {
+                bW.Write(Convert.ToByte(_ldapGroupMap.Count));
+
+                foreach (KeyValuePair<string, string> entry in _ldapGroupMap)
                 {
                     s.WriteShortString(entry.Key);
                     s.WriteShortString(entry.Value);
@@ -735,7 +892,137 @@ namespace DnsServerCore.Auth
 
             User user = GetUser(username);
 
-            if ((user is null) || user.IsSsoUser || !user.PasswordHash.Equals(user.GetPasswordHashFor(password), StringComparison.Ordinal))
+            if (user is not null && user.IsSsoUser)
+            {
+                // OIDC SSO users cannot authenticate via password
+                MarkFailedLoginAttempt(network);
+
+                if (HasLoginAttemptExceedLimit(network, MAX_LOGIN_ATTEMPTS))
+                    BlockNetwork(network, BLOCK_NETWORK_INTERVAL);
+
+                await Task.Delay(1000);
+
+                throw new DnsWebServiceException("Invalid username or password for user: " + username);
+            }
+
+            if (user is not null && user.IsLdapUser)
+            {
+                // Existing LDAP user — validate credentials against LDAP directory
+                if (!_ldapEnabled || string.IsNullOrEmpty(_ldapServer))
+                {
+                    await Task.Delay(1000);
+                    throw new DnsWebServiceException("LDAP authentication is not configured.");
+                }
+
+                LdapAuthProvider ldapProvider = new LdapAuthProvider(_ldapServer, _ldapPort, _ldapUseSsl, _ldapIgnoreSslErrors, _ldapBindDn, _ldapBindPassword, _ldapSearchBase, _ldapUserFilter, _ldapGroupAttribute);
+                LdapAuthResult ldapResult = await ldapProvider.AuthenticateAsync(username, password);
+
+                if (!ldapResult.Success)
+                {
+                    MarkFailedLoginAttempt(network);
+
+                    if (HasLoginAttemptExceedLimit(network, MAX_LOGIN_ATTEMPTS))
+                        BlockNetwork(network, BLOCK_NETWORK_INTERVAL);
+
+                    await Task.Delay(1000);
+
+                    throw new DnsWebServiceException("Invalid username or password for user: " + username);
+                }
+
+                ResetFailedLoginAttempts(network);
+
+                if (user.Disabled)
+                    throw new DnsWebServiceException("User account is disabled. Please contact your administrator.");
+
+                // Sync display name and group memberships from LDAP
+                user.DisplayName = ldapResult.DisplayName;
+
+                if (_ldapGroupMap is not null)
+                {
+                    Dictionary<string, Group> mappedGroups = new Dictionary<string, Group>();
+                    Group everyoneGroup = GetGroup(Group.EVERYONE);
+                    if (everyoneGroup is not null)
+                        mappedGroups[everyoneGroup.Name.ToLowerInvariant()] = everyoneGroup;
+
+                    foreach (string remoteGroup in ldapResult.Groups)
+                    {
+                        if (_ldapGroupMap.TryGetValue(remoteGroup, out string localGroupName))
+                        {
+                            Group localGroup = GetGroup(localGroupName);
+                            if (localGroup is not null)
+                                mappedGroups[localGroup.Name.ToLowerInvariant()] = localGroup;
+                        }
+                    }
+
+                    user.SyncGroups(mappedGroups);
+                }
+
+                return user;
+            }
+
+            if (user is null && _ldapEnabled && !string.IsNullOrEmpty(_ldapServer))
+            {
+                // No local account found — try LDAP authentication and auto-provision if allowed
+                LdapAuthProvider ldapProvider = new LdapAuthProvider(_ldapServer, _ldapPort, _ldapUseSsl, _ldapIgnoreSslErrors, _ldapBindDn, _ldapBindPassword, _ldapSearchBase, _ldapUserFilter, _ldapGroupAttribute);
+                LdapAuthResult ldapResult = await ldapProvider.AuthenticateAsync(username, password);
+
+                if (ldapResult.Success)
+                {
+                    if (!_ldapAllowSignup)
+                    {
+                        _log.Write(new System.Net.IPEndPoint(remoteAddress, 0), "LDAP authentication succeeded for '" + username + "' but new user sign up is disabled.");
+                        await Task.Delay(1000);
+                        throw new DnsWebServiceException("LDAP authentication succeeded but new user sign up is disabled. Please contact your administrator.");
+                    }
+
+                    if (_ldapAllowSignupOnlyForMappedUsers && _ldapGroupMap is not null)
+                    {
+                        bool hasMappedGroup = false;
+
+                        foreach (string remoteGroup in ldapResult.Groups)
+                        {
+                            if (_ldapGroupMap.ContainsKey(remoteGroup))
+                            {
+                                hasMappedGroup = true;
+                                break;
+                            }
+                        }
+
+                        if (!hasMappedGroup)
+                        {
+                            _log.Write(new System.Net.IPEndPoint(remoteAddress, 0), "LDAP authentication succeeded for '" + username + "' but new user sign up is restricted to mapped groups only.");
+                            await Task.Delay(1000);
+                            throw new DnsWebServiceException("LDAP authentication succeeded but new user sign up is restricted only to members of mapped groups. Please contact your administrator.");
+                        }
+                    }
+
+                    // Provision new LDAP user
+                    string localUsername = username.ToLowerInvariant();
+                    user = CreateLdapUser(ldapResult.DisplayName, localUsername, ldapResult.LdapIdentifier);
+
+                    if (_ldapGroupMap is not null)
+                    {
+                        foreach (string remoteGroup in ldapResult.Groups)
+                        {
+                            if (_ldapGroupMap.TryGetValue(remoteGroup, out string localGroupName))
+                            {
+                                Group localGroup = GetGroup(localGroupName);
+                                if (localGroup is not null)
+                                    user.AddToGroup(localGroup);
+                            }
+                        }
+                    }
+
+                    _log.Write(new System.Net.IPEndPoint(remoteAddress, 0), "LDAP user account was created successfully with username: " + user.Username);
+                    SaveConfigFile();
+
+                    ResetFailedLoginAttempts(network);
+                    return user;
+                }
+            }
+
+            // Local password authentication (or final failure)
+            if ((user is null) || !user.PasswordHash.Equals(user.GetPasswordHashFor(password), StringComparison.Ordinal))
             {
                 if ((username != "admin") || (password != "admin"))
                 {
@@ -863,6 +1150,41 @@ namespace DnsServerCore.Auth
             }
 
             return null;
+        }
+
+        public User GetLdapUser(string ldapIdentifier)
+        {
+            foreach (KeyValuePair<string, User> user in _users)
+            {
+                if (ldapIdentifier.Equals(user.Value.LdapIdentifier, StringComparison.OrdinalIgnoreCase) && user.Value.IsLdapUser)
+                    return user.Value;
+            }
+
+            return null;
+        }
+
+        public User CreateLdapUser(string displayName, string username, string ldapIdentifier)
+        {
+            if (_users.Count >= byte.MaxValue)
+                throw new DnsWebServiceException("Cannot create more than 255 users.");
+
+            username = username.ToLowerInvariant();
+
+            User user = User.CreateLdapUser(displayName, username, ldapIdentifier);
+
+            if (_users.TryAdd(username, user))
+            {
+                if (_users.Count > byte.MaxValue)
+                {
+                    _users.TryRemove(username, out _); //undo
+                    throw new DnsWebServiceException("Cannot create more than 255 users.");
+                }
+
+                user.AddToGroup(GetGroup(Group.EVERYONE));
+                return user;
+            }
+
+            throw new DnsWebServiceException("User already exists: " + username);
         }
 
         public User CreateUser(string displayName, string username, string password, int iterations = User.DEFAULT_ITERATIONS)
@@ -1371,6 +1693,133 @@ namespace DnsServerCore.Auth
 
         public bool SsoManagedGroups
         { get { return _ssoGroupMap is not null; } }
+
+        public bool LdapEnabled
+        {
+            get { return _ldapEnabled; }
+            set { _ldapEnabled = value; }
+        }
+
+        public string LdapServer
+        {
+            get { return _ldapServer; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapServer = value;
+            }
+        }
+
+        public int LdapPort
+        {
+            get { return _ldapPort; }
+            set
+            {
+                if ((value < 1) || (value > 65535))
+                    throw new ArgumentOutOfRangeException(nameof(LdapPort), "LDAP port must be between 1 and 65535.");
+                _ldapPort = value;
+            }
+        }
+
+        public bool LdapUseSsl
+        {
+            get { return _ldapUseSsl; }
+            set { _ldapUseSsl = value; }
+        }
+
+        public bool LdapIgnoreSslErrors
+        {
+            get { return _ldapIgnoreSslErrors; }
+            set { _ldapIgnoreSslErrors = value; }
+        }
+
+        public string LdapBindDn
+        {
+            get { return _ldapBindDn; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapBindDn = value;
+            }
+        }
+
+        public string LdapBindPassword
+        {
+            get { return _ldapBindPassword; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapBindPassword = value;
+            }
+        }
+
+        public string LdapSearchBase
+        {
+            get { return _ldapSearchBase; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapSearchBase = value;
+            }
+        }
+
+        public string LdapUserFilter
+        {
+            get { return _ldapUserFilter; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapUserFilter = value;
+            }
+        }
+
+        public string LdapGroupAttribute
+        {
+            get { return _ldapGroupAttribute; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapGroupAttribute = value;
+            }
+        }
+
+        public bool LdapAllowSignup
+        {
+            get { return _ldapAllowSignup; }
+            set { _ldapAllowSignup = value; }
+        }
+
+        public bool LdapAllowSignupOnlyForMappedUsers
+        {
+            get { return _ldapAllowSignupOnlyForMappedUsers; }
+            set { _ldapAllowSignupOnlyForMappedUsers = value; }
+        }
+
+        public IReadOnlyDictionary<string, string> LdapGroupMap
+        {
+            get { return _ldapGroupMap; }
+            set
+            {
+                if (value is not null)
+                {
+                    if (value.Count == 0)
+                        value = null;
+                    else if (value.Count > 255)
+                        throw new ArgumentException("The LDAP Group Map cannot have more than 255 entries.", nameof(LdapGroupMap));
+                }
+
+                _ldapGroupMap = value;
+            }
+        }
+
+        public bool LdapManagedGroups
+        { get { return _ldapGroupMap is not null; } }
 
         #endregion
     }

--- a/DnsServerCore/Auth/AuthManager.cs
+++ b/DnsServerCore/Auth/AuthManager.cs
@@ -61,6 +61,20 @@ namespace DnsServerCore.Auth
         bool _ssoAllowSignupOnlyForMappedUsers = true;
         IReadOnlyDictionary<string, string> _ssoGroupMap;
 
+        bool _ldapEnabled;
+        string _ldapServer;
+        int _ldapPort = 389;
+        bool _ldapUseSsl;
+        bool _ldapIgnoreSslErrors;
+        string _ldapBindDn;
+        string _ldapBindPassword;
+        string _ldapSearchBase;
+        string _ldapUserFilter;
+        string _ldapGroupAttribute;
+        bool _ldapAllowSignup;
+        bool _ldapAllowSignupOnlyForMappedUsers = true;
+        IReadOnlyDictionary<string, string> _ldapGroupMap;
+
         readonly Lock _saveLock = new Lock();
         bool _pendingSave;
         readonly Timer _saveTimer;
@@ -261,6 +275,70 @@ namespace DnsServerCore.Auth
                     }
 
                     SsoGroupMap = groupMap;
+                }
+
+                string strLdapEnabled = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_ENABLED");
+                if (!string.IsNullOrEmpty(strLdapEnabled))
+                    _ldapEnabled = bool.Parse(strLdapEnabled);
+
+                string strLdapServer = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_SERVER");
+                if (!string.IsNullOrEmpty(strLdapServer))
+                    _ldapServer = strLdapServer;
+
+                string strLdapPort = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_PORT");
+                if (!string.IsNullOrEmpty(strLdapPort))
+                    _ldapPort = int.Parse(strLdapPort);
+
+                string strLdapUseSsl = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_USE_SSL");
+                if (!string.IsNullOrEmpty(strLdapUseSsl))
+                    _ldapUseSsl = bool.Parse(strLdapUseSsl);
+
+                string strLdapIgnoreSslErrors = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_IGNORE_SSL_ERRORS");
+                if (!string.IsNullOrEmpty(strLdapIgnoreSslErrors))
+                    _ldapIgnoreSslErrors = bool.Parse(strLdapIgnoreSslErrors);
+
+                string strLdapBindDn = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_BIND_DN");
+                if (!string.IsNullOrEmpty(strLdapBindDn))
+                    _ldapBindDn = strLdapBindDn;
+
+                string strLdapBindPassword = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_BIND_PASSWORD");
+                if (!string.IsNullOrEmpty(strLdapBindPassword))
+                    _ldapBindPassword = strLdapBindPassword;
+
+                string strLdapSearchBase = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_SEARCH_BASE");
+                if (!string.IsNullOrEmpty(strLdapSearchBase))
+                    _ldapSearchBase = strLdapSearchBase;
+
+                string strLdapUserFilter = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_USER_FILTER");
+                if (!string.IsNullOrEmpty(strLdapUserFilter))
+                    _ldapUserFilter = strLdapUserFilter;
+
+                string strLdapGroupAttribute = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_GROUP_ATTRIBUTE");
+                if (!string.IsNullOrEmpty(strLdapGroupAttribute))
+                    _ldapGroupAttribute = strLdapGroupAttribute;
+
+                string strLdapAllowSignup = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_ALLOW_SIGNUP");
+                if (!string.IsNullOrEmpty(strLdapAllowSignup))
+                    _ldapAllowSignup = bool.Parse(strLdapAllowSignup);
+
+                string strLdapAllowSignupOnlyForMappedUsers = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_ALLOW_SIGNUP_ONLY_FOR_MAPPED_USERS");
+                if (!string.IsNullOrEmpty(strLdapAllowSignupOnlyForMappedUsers))
+                    _ldapAllowSignupOnlyForMappedUsers = bool.Parse(strLdapAllowSignupOnlyForMappedUsers);
+
+                string strLdapGroupMap = Environment.GetEnvironmentVariable("DNS_SERVER_LDAP_GROUP_MAP");
+                if (!string.IsNullOrEmpty(strLdapGroupMap))
+                {
+                    string[] entries = strLdapGroupMap.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    Dictionary<string, string> groupMap = new Dictionary<string, string>(entries.Length);
+
+                    foreach (string entry in entries)
+                    {
+                        string[] parts = entry.Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                        if (parts.Length == 2)
+                            groupMap.TryAdd(parts[0], parts[1]);
+                    }
+
+                    _ldapGroupMap = groupMap;
                 }
 
                 lock (_saveLock)
@@ -546,6 +624,55 @@ namespace DnsServerCore.Auth
                         restartWebService = !ssoIsStillDisabled && restartWebService;
                     }
 
+                    if (version >= 3)
+                    {
+                        _ldapEnabled = bR.ReadBoolean();
+                        _ldapServer = s.ReadShortString();
+                        if (_ldapServer.Length == 0)
+                            _ldapServer = null;
+                        _ldapPort = bR.ReadInt32();
+                        _ldapUseSsl = bR.ReadBoolean();
+                        _ldapIgnoreSslErrors = bR.ReadBoolean();
+                        _ldapBindDn = s.ReadShortString();
+                        if (_ldapBindDn.Length == 0)
+                            _ldapBindDn = null;
+                        _ldapBindPassword = s.ReadShortString();
+                        if (_ldapBindPassword.Length == 0)
+                            _ldapBindPassword = null;
+                        _ldapSearchBase = s.ReadShortString();
+                        if (_ldapSearchBase.Length == 0)
+                            _ldapSearchBase = null;
+                        _ldapUserFilter = s.ReadShortString();
+                        if (_ldapUserFilter.Length == 0)
+                            _ldapUserFilter = null;
+                        _ldapGroupAttribute = s.ReadShortString();
+                        if (_ldapGroupAttribute.Length == 0)
+                            _ldapGroupAttribute = null;
+                        _ldapAllowSignup = bR.ReadBoolean();
+                        _ldapAllowSignupOnlyForMappedUsers = bR.ReadBoolean();
+
+                        {
+                            int count = bR.ReadByte();
+                            if (count > 0)
+                            {
+                                Dictionary<string, string> ldapGroupMap = new Dictionary<string, string>(count);
+
+                                for (int i = 0; i < count; i++)
+                                {
+                                    string key = s.ReadShortString();
+                                    string value = s.ReadShortString();
+                                    ldapGroupMap.TryAdd(key, value);
+                                }
+
+                                _ldapGroupMap = ldapGroupMap;
+                            }
+                            else
+                            {
+                                _ldapGroupMap = null;
+                            }
+                        }
+                    }
+
                     break;
 
                 default:
@@ -699,6 +826,35 @@ namespace DnsServerCore.Auth
                     s.WriteShortString(entry.Value);
                 }
             }
+
+            // LDAP config (version 3+)
+            bW.Write(_ldapEnabled);
+            s.WriteShortString(_ldapServer ?? "");
+            bW.Write(_ldapPort);
+            bW.Write(_ldapUseSsl);
+            bW.Write(_ldapIgnoreSslErrors);
+            s.WriteShortString(_ldapBindDn ?? "");
+            s.WriteShortString(_ldapBindPassword ?? "");
+            s.WriteShortString(_ldapSearchBase ?? "");
+            s.WriteShortString(_ldapUserFilter ?? "");
+            s.WriteShortString(_ldapGroupAttribute ?? "");
+            bW.Write(_ldapAllowSignup);
+            bW.Write(_ldapAllowSignupOnlyForMappedUsers);
+
+            if ((_ldapGroupMap is null) || (_ldapGroupMap.Count == 0))
+            {
+                bW.Write((byte)0);
+            }
+            else
+            {
+                bW.Write(Convert.ToByte(_ldapGroupMap.Count));
+
+                foreach (KeyValuePair<string, string> entry in _ldapGroupMap)
+                {
+                    s.WriteShortString(entry.Key);
+                    s.WriteShortString(entry.Value);
+                }
+            }
         }
 
         #endregion
@@ -787,7 +943,137 @@ namespace DnsServerCore.Auth
 
             User user = GetUser(username);
 
-            if ((user is null) || user.IsSsoUser || !user.PasswordHash.Equals(user.GetPasswordHashFor(password), StringComparison.Ordinal))
+            if (user is not null && user.IsSsoUser)
+            {
+                // OIDC SSO users cannot authenticate via password
+                MarkFailedLoginAttempt(network);
+
+                if (HasLoginAttemptExceedLimit(network, MAX_LOGIN_ATTEMPTS))
+                    BlockNetwork(network, BLOCK_NETWORK_INTERVAL);
+
+                await Task.Delay(1000);
+
+                throw new DnsWebServiceException("Invalid username or password for user: " + username);
+            }
+
+            if (user is not null && user.IsLdapUser)
+            {
+                // Existing LDAP user — validate credentials against LDAP directory
+                if (!_ldapEnabled || string.IsNullOrEmpty(_ldapServer))
+                {
+                    await Task.Delay(1000);
+                    throw new DnsWebServiceException("LDAP authentication is not configured.");
+                }
+
+                LdapAuthProvider ldapProvider = new LdapAuthProvider(_ldapServer, _ldapPort, _ldapUseSsl, _ldapIgnoreSslErrors, _ldapBindDn, _ldapBindPassword, _ldapSearchBase, _ldapUserFilter, _ldapGroupAttribute);
+                LdapAuthResult ldapResult = await ldapProvider.AuthenticateAsync(username, password);
+
+                if (!ldapResult.Success)
+                {
+                    MarkFailedLoginAttempt(network);
+
+                    if (HasLoginAttemptExceedLimit(network, MAX_LOGIN_ATTEMPTS))
+                        BlockNetwork(network, BLOCK_NETWORK_INTERVAL);
+
+                    await Task.Delay(1000);
+
+                    throw new DnsWebServiceException("Invalid username or password for user: " + username);
+                }
+
+                ResetFailedLoginAttempts(network);
+
+                if (user.Disabled)
+                    throw new DnsWebServiceException("User account is disabled. Please contact your administrator.");
+
+                // Sync display name and group memberships from LDAP
+                user.DisplayName = ldapResult.DisplayName;
+
+                if (_ldapGroupMap is not null)
+                {
+                    Dictionary<string, Group> mappedGroups = new Dictionary<string, Group>();
+                    Group everyoneGroup = GetGroup(Group.EVERYONE);
+                    if (everyoneGroup is not null)
+                        mappedGroups[everyoneGroup.Name.ToLowerInvariant()] = everyoneGroup;
+
+                    foreach (string remoteGroup in ldapResult.Groups)
+                    {
+                        if (_ldapGroupMap.TryGetValue(remoteGroup, out string localGroupName))
+                        {
+                            Group localGroup = GetGroup(localGroupName);
+                            if (localGroup is not null)
+                                mappedGroups[localGroup.Name.ToLowerInvariant()] = localGroup;
+                        }
+                    }
+
+                    user.SyncGroups(mappedGroups);
+                }
+
+                return user;
+            }
+
+            if (user is null && _ldapEnabled && !string.IsNullOrEmpty(_ldapServer))
+            {
+                // No local account found — try LDAP authentication and auto-provision if allowed
+                LdapAuthProvider ldapProvider = new LdapAuthProvider(_ldapServer, _ldapPort, _ldapUseSsl, _ldapIgnoreSslErrors, _ldapBindDn, _ldapBindPassword, _ldapSearchBase, _ldapUserFilter, _ldapGroupAttribute);
+                LdapAuthResult ldapResult = await ldapProvider.AuthenticateAsync(username, password);
+
+                if (ldapResult.Success)
+                {
+                    if (!_ldapAllowSignup)
+                    {
+                        _log.Write(new System.Net.IPEndPoint(remoteAddress, 0), "LDAP authentication succeeded for '" + username + "' but new user sign up is disabled.");
+                        await Task.Delay(1000);
+                        throw new DnsWebServiceException("LDAP authentication succeeded but new user sign up is disabled. Please contact your administrator.");
+                    }
+
+                    if (_ldapAllowSignupOnlyForMappedUsers && _ldapGroupMap is not null)
+                    {
+                        bool hasMappedGroup = false;
+
+                        foreach (string remoteGroup in ldapResult.Groups)
+                        {
+                            if (_ldapGroupMap.ContainsKey(remoteGroup))
+                            {
+                                hasMappedGroup = true;
+                                break;
+                            }
+                        }
+
+                        if (!hasMappedGroup)
+                        {
+                            _log.Write(new System.Net.IPEndPoint(remoteAddress, 0), "LDAP authentication succeeded for '" + username + "' but new user sign up is restricted to mapped groups only.");
+                            await Task.Delay(1000);
+                            throw new DnsWebServiceException("LDAP authentication succeeded but new user sign up is restricted only to members of mapped groups. Please contact your administrator.");
+                        }
+                    }
+
+                    // Provision new LDAP user
+                    string localUsername = username.ToLowerInvariant();
+                    user = CreateLdapUser(ldapResult.DisplayName, localUsername, ldapResult.LdapIdentifier);
+
+                    if (_ldapGroupMap is not null)
+                    {
+                        foreach (string remoteGroup in ldapResult.Groups)
+                        {
+                            if (_ldapGroupMap.TryGetValue(remoteGroup, out string localGroupName))
+                            {
+                                Group localGroup = GetGroup(localGroupName);
+                                if (localGroup is not null)
+                                    user.AddToGroup(localGroup);
+                            }
+                        }
+                    }
+
+                    _log.Write(new System.Net.IPEndPoint(remoteAddress, 0), "LDAP user account was created successfully with username: " + user.Username);
+                    SaveConfigFile();
+
+                    ResetFailedLoginAttempts(network);
+                    return user;
+                }
+            }
+
+            // Local password authentication (or final failure)
+            if ((user is null) || !user.PasswordHash.Equals(user.GetPasswordHashFor(password), StringComparison.Ordinal))
             {
                 if ((username != "admin") || (password != "admin"))
                 {
@@ -915,6 +1201,41 @@ namespace DnsServerCore.Auth
             }
 
             return null;
+        }
+
+        public User GetLdapUser(string ldapIdentifier)
+        {
+            foreach (KeyValuePair<string, User> user in _users)
+            {
+                if (ldapIdentifier.Equals(user.Value.LdapIdentifier, StringComparison.OrdinalIgnoreCase) && user.Value.IsLdapUser)
+                    return user.Value;
+            }
+
+            return null;
+        }
+
+        public User CreateLdapUser(string displayName, string username, string ldapIdentifier)
+        {
+            if (_users.Count >= byte.MaxValue)
+                throw new DnsWebServiceException("Cannot create more than 255 users.");
+
+            username = username.ToLowerInvariant();
+
+            User user = User.CreateLdapUser(displayName, username, ldapIdentifier);
+
+            if (_users.TryAdd(username, user))
+            {
+                if (_users.Count > byte.MaxValue)
+                {
+                    _users.TryRemove(username, out _); //undo
+                    throw new DnsWebServiceException("Cannot create more than 255 users.");
+                }
+
+                user.AddToGroup(GetGroup(Group.EVERYONE));
+                return user;
+            }
+
+            throw new DnsWebServiceException("User already exists: " + username);
         }
 
         public User CreateUser(string displayName, string username, string password, int iterations = User.DEFAULT_ITERATIONS)
@@ -1462,6 +1783,133 @@ namespace DnsServerCore.Auth
 
         public bool SsoManagedGroups
         { get { return _ssoGroupMap is not null; } }
+
+        public bool LdapEnabled
+        {
+            get { return _ldapEnabled; }
+            set { _ldapEnabled = value; }
+        }
+
+        public string LdapServer
+        {
+            get { return _ldapServer; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapServer = value;
+            }
+        }
+
+        public int LdapPort
+        {
+            get { return _ldapPort; }
+            set
+            {
+                if ((value < 1) || (value > 65535))
+                    throw new ArgumentOutOfRangeException(nameof(LdapPort), "LDAP port must be between 1 and 65535.");
+                _ldapPort = value;
+            }
+        }
+
+        public bool LdapUseSsl
+        {
+            get { return _ldapUseSsl; }
+            set { _ldapUseSsl = value; }
+        }
+
+        public bool LdapIgnoreSslErrors
+        {
+            get { return _ldapIgnoreSslErrors; }
+            set { _ldapIgnoreSslErrors = value; }
+        }
+
+        public string LdapBindDn
+        {
+            get { return _ldapBindDn; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapBindDn = value;
+            }
+        }
+
+        public string LdapBindPassword
+        {
+            get { return _ldapBindPassword; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapBindPassword = value;
+            }
+        }
+
+        public string LdapSearchBase
+        {
+            get { return _ldapSearchBase; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapSearchBase = value;
+            }
+        }
+
+        public string LdapUserFilter
+        {
+            get { return _ldapUserFilter; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapUserFilter = value;
+            }
+        }
+
+        public string LdapGroupAttribute
+        {
+            get { return _ldapGroupAttribute; }
+            set
+            {
+                if (value is not null && value.Length == 0)
+                    value = null;
+                _ldapGroupAttribute = value;
+            }
+        }
+
+        public bool LdapAllowSignup
+        {
+            get { return _ldapAllowSignup; }
+            set { _ldapAllowSignup = value; }
+        }
+
+        public bool LdapAllowSignupOnlyForMappedUsers
+        {
+            get { return _ldapAllowSignupOnlyForMappedUsers; }
+            set { _ldapAllowSignupOnlyForMappedUsers = value; }
+        }
+
+        public IReadOnlyDictionary<string, string> LdapGroupMap
+        {
+            get { return _ldapGroupMap; }
+            set
+            {
+                if (value is not null)
+                {
+                    if (value.Count == 0)
+                        value = null;
+                    else if (value.Count > 255)
+                        throw new ArgumentException("The LDAP Group Map cannot have more than 255 entries.", nameof(LdapGroupMap));
+                }
+
+                _ldapGroupMap = value;
+            }
+        }
+
+        public bool LdapManagedGroups
+        { get { return _ldapGroupMap is not null; } }
 
         #endregion
     }

--- a/DnsServerCore/Auth/LdapAuthProvider.cs
+++ b/DnsServerCore/Auth/LdapAuthProvider.cs
@@ -1,0 +1,251 @@
+/*
+Technitium DNS Server
+Copyright (C) 2026  Shreyas Zare (shreyas@technitium.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+using Novell.Directory.Ldap;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DnsServerCore.Auth
+{
+    sealed class LdapAuthResult
+    {
+        public bool Success { get; init; }
+        public string LdapIdentifier { get; init; }
+        public string DisplayName { get; init; }
+        public IReadOnlyList<string> Groups { get; init; }
+        public string ErrorMessage { get; init; }
+
+        public static LdapAuthResult Failed(string message) =>
+            new LdapAuthResult { Success = false, ErrorMessage = message };
+    }
+
+    sealed class LdapAuthProvider
+    {
+        #region variables
+
+        readonly string _server;
+        readonly int _port;
+        readonly bool _useSsl;
+        readonly bool _ignoreSslErrors;
+        readonly string _bindDn;
+        readonly string _bindPassword;
+        readonly string _searchBase;
+        readonly string _userFilter;
+        readonly string _groupAttribute;
+
+        #endregion
+
+        #region constructor
+
+        public LdapAuthProvider(string server, int port, bool useSsl, bool ignoreSslErrors, string bindDn, string bindPassword, string searchBase, string userFilter, string groupAttribute)
+        {
+            _server = server;
+            _port = port;
+            _useSsl = useSsl;
+            _ignoreSslErrors = ignoreSslErrors;
+            _bindDn = bindDn;
+            _bindPassword = bindPassword;
+            _searchBase = searchBase;
+            _userFilter = string.IsNullOrWhiteSpace(userFilter) ? "(sAMAccountName={0})" : userFilter;
+            _groupAttribute = string.IsNullOrWhiteSpace(groupAttribute) ? "memberOf" : groupAttribute;
+        }
+
+        #endregion
+
+        #region private
+
+        private LdapConnection CreateConnection()
+        {
+            var options = new LdapConnectionOptions();
+
+            if (_ignoreSslErrors)
+                options = options.ConfigureRemoteCertificateValidationCallback((sender, cert, chain, errors) => true);
+
+            // Port 636 = LDAPS (SSL-wrapped from the start); all other ports use StartTLS
+            bool useLdaps = _useSsl && _port == 636;
+            if (useLdaps)
+                options = options.UseSsl();
+
+            var conn = new LdapConnection(options);
+            conn.Connect(_server, _port);
+
+            if (_useSsl && !useLdaps)
+                conn.StartTls();
+
+            return conn;
+        }
+
+        private static string LdapFilterEscape(string value)
+        {
+            // RFC 4515 escape special filter characters
+            return new StringBuilder(value)
+                .Replace("\\", "\\5c")
+                .Replace("*", "\\2a")
+                .Replace("(", "\\28")
+                .Replace(")", "\\29")
+                .Replace("\0", "\\00")
+                .ToString();
+        }
+
+        private static string GetCnFromDn(string dn)
+        {
+            if (string.IsNullOrEmpty(dn))
+                return dn;
+
+            int eq = dn.IndexOf('=');
+            int comma = dn.IndexOf(',');
+
+            if (eq < 0)
+                return dn;
+
+            int end = comma > eq ? comma : dn.Length;
+            return dn.Substring(eq + 1, end - eq - 1).Trim();
+        }
+
+        #endregion
+
+        #region public
+
+        public Task<LdapAuthResult> AuthenticateAsync(string username, string password)
+        {
+            return Task.Run(() =>
+            {
+                // Step 1: bind service account and search for the user
+                string userDn;
+                string displayName;
+                string userPrincipalName;
+                List<string> groups;
+
+                try
+                {
+                    using LdapConnection searchConn = CreateConnection();
+                    searchConn.Bind(LdapConnection.LdapV3, _bindDn, _bindPassword);
+
+                    string filter = string.Format(_userFilter, LdapFilterEscape(username));
+                    string[] attrs = new[] { "distinguishedName", "cn", "displayName", "userPrincipalName", _groupAttribute };
+
+                    var searchConstraints = new LdapSearchConstraints { ReferralFollowing = false, TimeLimit = 15000, ServerTimeLimit = 15 };
+                    ILdapSearchResults results = searchConn.Search(
+                        _searchBase,
+                        LdapConnection.ScopeSub,
+                        filter,
+                        attrs,
+                        false,
+                        searchConstraints);
+
+                    LdapEntry entry = null;
+                    while (results.HasMore())
+                    {
+                        LdapEntry candidate;
+                        try { candidate = results.Next(); }
+                        catch (LdapReferralException) { continue; }
+                        entry = candidate;
+                        break;
+                    }
+
+                    if (entry is null)
+                        return LdapAuthResult.Failed("User not found in directory.");
+                    LdapAttributeSet attrSet = entry.GetAttributeSet();
+
+                    userDn = entry.Dn;
+
+                    displayName = null;
+                    if (attrSet.ContainsKey("displayName"))
+                        displayName = attrSet["displayName"].StringValue;
+                    if (string.IsNullOrEmpty(displayName) && attrSet.ContainsKey("cn"))
+                        displayName = attrSet["cn"].StringValue;
+                    if (string.IsNullOrEmpty(displayName))
+                        displayName = username;
+
+                    userPrincipalName = null;
+                    if (attrSet.ContainsKey("userPrincipalName"))
+                        userPrincipalName = attrSet["userPrincipalName"].StringValue;
+
+                    groups = new List<string>();
+                    if (attrSet.ContainsKey(_groupAttribute))
+                    {
+                        foreach (string groupDn in attrSet[_groupAttribute].StringValueArray)
+                        {
+                            string cn = GetCnFromDn(groupDn);
+                            if (!string.IsNullOrEmpty(cn))
+                                groups.Add(cn);
+                        }
+                    }
+                }
+                catch (LdapException ex) when (ex.ResultCode == LdapException.InvalidCredentials)
+                {
+                    return LdapAuthResult.Failed("Service account credentials are invalid.");
+                }
+                catch (Exception ex)
+                {
+                    return LdapAuthResult.Failed($"Service account bind/search failed: {ex.Message}");
+                }
+
+                // Step 2: re-bind as the user to validate their password
+                // Prefer UPN (user@domain) over full DN — more reliable with AD
+                string bindUsername = !string.IsNullOrEmpty(userPrincipalName) ? userPrincipalName : userDn;
+
+                try
+                {
+                    using LdapConnection userConn = CreateConnection();
+                    userConn.Bind(LdapConnection.LdapV3, bindUsername, password);
+                }
+                catch (LdapException ex) when (ex.ResultCode == LdapException.InvalidCredentials)
+                {
+                    return LdapAuthResult.Failed("Invalid credentials.");
+                }
+                catch (Exception ex)
+                {
+                    return LdapAuthResult.Failed($"User bind failed: {ex.Message}");
+                }
+
+                return new LdapAuthResult
+                {
+                    Success = true,
+                    LdapIdentifier = userDn,
+                    DisplayName = displayName,
+                    Groups = groups
+                };
+            });
+        }
+
+        public Task<string> TestConnectionAsync()
+        {
+            return Task.Run(() =>
+            {
+                try
+                {
+                    using LdapConnection conn = CreateConnection();
+                    conn.Bind(LdapConnection.LdapV3, _bindDn, _bindPassword);
+                    return (string)null; // null = success
+                }
+                catch (Exception ex)
+                {
+                    Exception inner = ex;
+                    while (inner.InnerException != null) inner = inner.InnerException;
+                    return inner == ex ? ex.Message : $"{ex.Message} → {inner.GetType().Name}: {inner.Message}";
+                }
+            });
+        }
+
+        #endregion
+    }
+}

--- a/DnsServerCore/Auth/LdapAuthProvider.cs
+++ b/DnsServerCore/Auth/LdapAuthProvider.cs
@@ -1,0 +1,245 @@
+/*
+Technitium DNS Server
+Copyright (C) 2026  Shreyas Zare (shreyas@technitium.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+using System;
+using System.Collections.Generic;
+using System.DirectoryServices.Protocols;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DnsServerCore.Auth
+{
+    sealed class LdapAuthResult
+    {
+        public bool Success { get; init; }
+        public string LdapIdentifier { get; init; }
+        public string DisplayName { get; init; }
+        public IReadOnlyList<string> Groups { get; init; }
+        public string ErrorMessage { get; init; }
+
+        public static LdapAuthResult Failed(string message) =>
+            new LdapAuthResult { Success = false, ErrorMessage = message };
+    }
+
+    sealed class LdapAuthProvider
+    {
+        #region variables
+
+        readonly string _server;
+        readonly int _port;
+        readonly bool _useSsl;
+        readonly bool _ignoreSslErrors;
+        readonly string _bindDn;
+        readonly string _bindPassword;
+        readonly string _searchBase;
+        readonly string _userFilter;
+        readonly string _groupAttribute;
+
+        #endregion
+
+        #region constructor
+
+        public LdapAuthProvider(string server, int port, bool useSsl, bool ignoreSslErrors, string bindDn, string bindPassword, string searchBase, string userFilter, string groupAttribute)
+        {
+            _server = server;
+            _port = port;
+            _useSsl = useSsl;
+            _ignoreSslErrors = ignoreSslErrors;
+            _bindDn = bindDn;
+            _bindPassword = bindPassword;
+            _searchBase = searchBase;
+            _userFilter = string.IsNullOrWhiteSpace(userFilter) ? "(sAMAccountName={0})" : userFilter;
+            _groupAttribute = string.IsNullOrWhiteSpace(groupAttribute) ? "memberOf" : groupAttribute;
+        }
+
+        #endregion
+
+        #region private
+
+        private LdapConnection CreateBoundConnection(string bindDn, string bindPassword)
+        {
+            var identifier = new LdapDirectoryIdentifier(_server, _port);
+            var conn = new LdapConnection(identifier);
+            conn.SessionOptions.ProtocolVersion = 3;
+            conn.SessionOptions.ReferralChasing = ReferralChasingOptions.None;
+            conn.Timeout = TimeSpan.FromSeconds(15);
+            conn.AuthType = AuthType.Basic;
+
+            if (_ignoreSslErrors)
+                conn.SessionOptions.VerifyServerCertificate = (connection, certificate) => true;
+
+            // Port 636 = LDAPS (SSL-wrapped from the start); all other ports use StartTLS
+            bool useLdaps = _useSsl && _port == 636;
+            if (useLdaps)
+                conn.SessionOptions.SecureSocketLayer = true;
+
+            if (_useSsl && !useLdaps)
+                conn.SessionOptions.StartTransportLayerSecurity(null);
+
+            conn.Credential = new NetworkCredential(bindDn, bindPassword);
+            conn.Bind();
+            return conn;
+        }
+
+        private static string LdapFilterEscape(string value)
+        {
+            // RFC 4515 escape special filter characters
+            return new StringBuilder(value)
+                .Replace("\\", "\\5c")
+                .Replace("*", "\\2a")
+                .Replace("(", "\\28")
+                .Replace(")", "\\29")
+                .Replace("\0", "\\00")
+                .ToString();
+        }
+
+        private static string GetCnFromDn(string dn)
+        {
+            if (string.IsNullOrEmpty(dn))
+                return dn;
+
+            int eq = dn.IndexOf('=');
+            int comma = dn.IndexOf(',');
+
+            if (eq < 0)
+                return dn;
+
+            int end = comma > eq ? comma : dn.Length;
+            return dn.Substring(eq + 1, end - eq - 1).Trim();
+        }
+
+        private static string GetAttributeValue(SearchResultEntry entry, string attributeName)
+        {
+            DirectoryAttribute attr = entry.Attributes[attributeName];
+            if (attr == null || attr.Count == 0)
+                return null;
+            return attr[0] as string;
+        }
+
+        #endregion
+
+        #region public
+
+        public Task<LdapAuthResult> AuthenticateAsync(string username, string password)
+        {
+            return Task.Run(() =>
+            {
+                // Step 1: bind service account and search for the user
+                string userDn;
+                string displayName;
+                string userPrincipalName;
+                List<string> groups;
+
+                try
+                {
+                    using LdapConnection searchConn = CreateBoundConnection(_bindDn, _bindPassword);
+
+                    string filter = string.Format(_userFilter, LdapFilterEscape(username));
+                    string[] attrs = new[] { "distinguishedName", "cn", "displayName", "userPrincipalName", _groupAttribute };
+
+                    var request = new SearchRequest(_searchBase, filter, SearchScope.Subtree, attrs);
+                    request.TimeLimit = TimeSpan.FromSeconds(15);
+
+                    var response = (SearchResponse)searchConn.SendRequest(request);
+
+                    SearchResultEntry entry = response.Entries.Count > 0 ? response.Entries[0] : null;
+
+                    if (entry is null)
+                        return LdapAuthResult.Failed("User not found in directory.");
+
+                    userDn = entry.DistinguishedName;
+
+                    displayName = GetAttributeValue(entry, "displayName");
+                    if (string.IsNullOrEmpty(displayName))
+                        displayName = GetAttributeValue(entry, "cn");
+                    if (string.IsNullOrEmpty(displayName))
+                        displayName = username;
+
+                    userPrincipalName = GetAttributeValue(entry, "userPrincipalName");
+
+                    groups = new List<string>();
+                    DirectoryAttribute groupAttr = entry.Attributes[_groupAttribute];
+                    if (groupAttr != null)
+                    {
+                        foreach (string groupDn in (string[])groupAttr.GetValues(typeof(string)))
+                        {
+                            string cn = GetCnFromDn(groupDn);
+                            if (!string.IsNullOrEmpty(cn))
+                                groups.Add(cn);
+                        }
+                    }
+                }
+                catch (LdapException ex) when (ex.ErrorCode == 49)
+                {
+                    return LdapAuthResult.Failed("Service account credentials are invalid.");
+                }
+                catch (Exception ex)
+                {
+                    return LdapAuthResult.Failed($"Service account bind/search failed: {ex.Message}");
+                }
+
+                // Step 2: re-bind as the user to validate their password
+                // Prefer UPN (user@domain) over full DN — more reliable with AD
+                string bindUsername = !string.IsNullOrEmpty(userPrincipalName) ? userPrincipalName : userDn;
+
+                try
+                {
+                    using LdapConnection userConn = CreateBoundConnection(bindUsername, password);
+                }
+                catch (LdapException ex) when (ex.ErrorCode == 49)
+                {
+                    return LdapAuthResult.Failed("Invalid credentials.");
+                }
+                catch (Exception ex)
+                {
+                    return LdapAuthResult.Failed($"User bind failed: {ex.Message}");
+                }
+
+                return new LdapAuthResult
+                {
+                    Success = true,
+                    LdapIdentifier = userDn,
+                    DisplayName = displayName,
+                    Groups = groups
+                };
+            });
+        }
+
+        public Task<string> TestConnectionAsync()
+        {
+            return Task.Run(() =>
+            {
+                try
+                {
+                    using LdapConnection conn = CreateBoundConnection(_bindDn, _bindPassword);
+                    return (string)null; // null = success
+                }
+                catch (Exception ex)
+                {
+                    Exception inner = ex;
+                    while (inner.InnerException != null) inner = inner.InnerException;
+                    return inner == ex ? ex.Message : $"{ex.Message} → {inner.GetType().Name}: {inner.Message}";
+                }
+            });
+        }
+
+        #endregion
+    }
+}

--- a/DnsServerCore/Auth/LdapAuthProvider.cs
+++ b/DnsServerCore/Auth/LdapAuthProvider.cs
@@ -185,6 +185,34 @@ namespace DnsServerCore.Auth
                                 groups.Add(cn);
                         }
                     }
+
+                    if (groups.Count == 0)
+                    {
+                        // Fallback for directories that don't maintain a reverse group-membership
+                        // attribute on the user entry (e.g. stock OpenLDAP without the memberof
+                        // overlay loaded). Search for groups that list this user as a member
+                        // instead of relying on the user entry carrying _groupAttribute.
+                        // Best-effort: some directories (e.g. AD without RFC2307/Unix attributes)
+                        // don't define uniqueMember/memberUid at all, which errors instead of just
+                        // not matching - swallow that so it degrades to "no groups", same as before.
+                        try
+                        {
+                            string reverseFilter = "(|(member=" + LdapFilterEscape(userDn) + ")(uniqueMember=" + LdapFilterEscape(userDn) + ")(memberUid=" + LdapFilterEscape(username) + "))";
+                            var groupRequest = new SearchRequest(_searchBase, reverseFilter, SearchScope.Subtree, new[] { "cn" });
+                            groupRequest.TimeLimit = TimeSpan.FromSeconds(15);
+
+                            var groupResponse = (SearchResponse)searchConn.SendRequest(groupRequest);
+
+                            foreach (SearchResultEntry groupEntry in groupResponse.Entries)
+                            {
+                                string cn = GetAttributeValue(groupEntry, "cn");
+                                if (!string.IsNullOrEmpty(cn))
+                                    groups.Add(cn);
+                            }
+                        }
+                        catch
+                        { }
+                    }
                 }
                 catch (LdapException ex) when (ex.ErrorCode == 49)
                 {

--- a/DnsServerCore/Auth/User.cs
+++ b/DnsServerCore/Auth/User.cs
@@ -47,6 +47,8 @@ namespace DnsServerCore.Auth
         string _username;
         bool _isSsoUser;
         string _ssoIdentifier;
+        bool _isLdapUser;
+        string _ldapIdentifier;
         UserPasswordHashType _passwordHashType;
         int _iterations;
         byte[] _salt;
@@ -83,6 +85,7 @@ namespace DnsServerCore.Auth
                 case 1:
                 case 2:
                 case 3:
+                case 4:
                     _displayName = bR.BaseStream.ReadShortString();
                     _username = bR.BaseStream.ReadShortString();
 
@@ -95,18 +98,28 @@ namespace DnsServerCore.Auth
                     }
                     else
                     {
-                        _passwordHashType = (UserPasswordHashType)bR.ReadByte();
-                        _iterations = bR.ReadInt32();
-                        _salt = bR.ReadBuffer();
-                        _passwordHash = bR.BaseStream.ReadShortString();
+                        if (version >= 4)
+                            _isLdapUser = bR.ReadBoolean();
 
-                        if (version >= 2)
+                        if (_isLdapUser)
                         {
-                            string otpKeyUri = bR.ReadString();
-                            if (!string.IsNullOrEmpty(otpKeyUri))
-                                _totpKeyUri = AuthenticatorKeyUri.Parse(otpKeyUri);
+                            _ldapIdentifier = bR.BaseStream.ReadShortString();
+                        }
+                        else
+                        {
+                            _passwordHashType = (UserPasswordHashType)bR.ReadByte();
+                            _iterations = bR.ReadInt32();
+                            _salt = bR.ReadBuffer();
+                            _passwordHash = bR.BaseStream.ReadShortString();
 
-                            _totpEnabled = bR.ReadBoolean();
+                            if (version >= 2)
+                            {
+                                string otpKeyUri = bR.ReadString();
+                                if (!string.IsNullOrEmpty(otpKeyUri))
+                                    _totpKeyUri = AuthenticatorKeyUri.Parse(otpKeyUri);
+
+                                _totpEnabled = bR.ReadBoolean();
+                            }
                         }
                     }
 
@@ -159,6 +172,18 @@ namespace DnsServerCore.Auth
             user.DisplayName = displayName;
             user._isSsoUser = true;
             user._ssoIdentifier = ssoIdentifier;
+
+            return user;
+        }
+
+        public static User CreateLdapUser(string displayName, string username, string ldapIdentifier)
+        {
+            User user = new User();
+
+            user.SetUsername(username);
+            user.DisplayName = displayName;
+            user._isLdapUser = true;
+            user._ldapIdentifier = ldapIdentifier;
 
             return user;
         }
@@ -260,6 +285,9 @@ namespace DnsServerCore.Auth
             if (_isSsoUser)
                 throw new InvalidOperationException("Cannot change password for SSO users.");
 
+            if (_isLdapUser)
+                throw new InvalidOperationException("Cannot change password for LDAP users.");
+
             _passwordHashType = UserPasswordHashType.PBKDF2_SHA256;
             _iterations = iterations;
 
@@ -274,6 +302,9 @@ namespace DnsServerCore.Auth
             if (_isSsoUser)
                 throw new InvalidOperationException();
 
+            if (_isLdapUser)
+                throw new InvalidOperationException();
+
             _passwordHashType = UserPasswordHashType.OldScheme;
             _passwordHash = passwordHash;
         }
@@ -282,6 +313,9 @@ namespace DnsServerCore.Auth
         {
             if (_isSsoUser)
                 throw new InvalidOperationException("Time-based one-time password (TOTP) feature is not available for SSO users.");
+
+            if (_isLdapUser)
+                throw new InvalidOperationException("Time-based one-time password (TOTP) feature is not available for LDAP users.");
 
             if (_totpEnabled)
                 throw new InvalidOperationException("Time-based one-time password (TOTP) is already enabled for user: " + _username);
@@ -295,6 +329,9 @@ namespace DnsServerCore.Auth
         {
             if (_isSsoUser)
                 throw new InvalidOperationException("Time-based one-time password (TOTP) feature is not available for SSO users.");
+
+            if (_isLdapUser)
+                throw new InvalidOperationException("Time-based one-time password (TOTP) feature is not available for LDAP users.");
 
             if (_totpKeyUri is null)
                 throw new InvalidOperationException("Time-based one-time password (TOTP) was not initialized for user: " + _username);
@@ -314,6 +351,9 @@ namespace DnsServerCore.Auth
         {
             if (_isSsoUser)
                 throw new InvalidOperationException("Time-based one-time password (TOTP) feature is not available for SSO users.");
+
+            if (_isLdapUser)
+                throw new InvalidOperationException("Time-based one-time password (TOTP) feature is not available for LDAP users.");
 
             if (!_totpEnabled)
                 throw new InvalidOperationException("Time-based one-time password (TOTP) is already disabled for user: " + _username);
@@ -371,7 +411,7 @@ namespace DnsServerCore.Auth
 
         public void WriteTo(BinaryWriter bW)
         {
-            bW.Write((byte)3);
+            bW.Write((byte)4);
 
             bW.BaseStream.WriteShortString(_displayName);
             bW.BaseStream.WriteShortString(_username);
@@ -383,17 +423,26 @@ namespace DnsServerCore.Auth
             }
             else
             {
-                bW.Write((byte)_passwordHashType);
-                bW.Write(_iterations);
-                bW.WriteBuffer(_salt);
-                bW.BaseStream.WriteShortString(_passwordHash);
+                bW.Write(_isLdapUser);
 
-                if (_totpKeyUri is null)
-                    bW.Write("");
+                if (_isLdapUser)
+                {
+                    bW.BaseStream.WriteShortString(_ldapIdentifier);
+                }
                 else
-                    bW.Write(_totpKeyUri.ToString());
+                {
+                    bW.Write((byte)_passwordHashType);
+                    bW.Write(_iterations);
+                    bW.WriteBuffer(_salt);
+                    bW.BaseStream.WriteShortString(_passwordHash);
 
-                bW.Write(_totpEnabled);
+                    if (_totpKeyUri is null)
+                        bW.Write("");
+                    else
+                        bW.Write(_totpKeyUri.ToString());
+
+                    bW.Write(_totpEnabled);
+                }
             }
 
             bW.Write(_disabled);
@@ -459,6 +508,12 @@ namespace DnsServerCore.Auth
 
         public string SsoIdentifier
         { get { return _ssoIdentifier; } }
+
+        public bool IsLdapUser
+        { get { return _isLdapUser; } }
+
+        public string LdapIdentifier
+        { get { return _ldapIdentifier; } }
 
         public UserPasswordHashType PasswordHashType
         { get { return _passwordHashType; } }

--- a/DnsServerCore/DnsServerCore.csproj
+++ b/DnsServerCore/DnsServerCore.csproj
@@ -47,6 +47,7 @@
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.7" />
 		<PackageReference Include="QRCoder" Version="1.8.0" />
+		<PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DnsServerCore/DnsServerCore.csproj
+++ b/DnsServerCore/DnsServerCore.csproj
@@ -47,6 +47,7 @@
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.7" />
 		<PackageReference Include="QRCoder" Version="1.8.0" />
+		<PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -1993,6 +1993,9 @@ namespace DnsServerCore
             _webService.MapGetAndPost("/api/admin/sso/set", _authApi.SetSsoConfig);
             _webService.MapGetAndPost("/api/admin/sso/users/create", _authApi.CreateSsoUser);
             _webService.MapGetAndPost("/api/admin/sso/users/set", _authApi.SetSsoUser);
+            _webService.MapGetAndPost("/api/admin/ldap/get", _authApi.GetLdapConfig);
+            _webService.MapGetAndPost("/api/admin/ldap/set", _authApi.SetLdapConfig);
+            _webService.MapGetAndPost("/api/admin/ldap/test", _authApi.TestLdapConnectionAsync);
             _webService.MapGetAndPost("/api/admin/cluster/state", _clusterApi.GetClusterState);
             _webService.MapGetAndPost("/api/admin/cluster/init", _clusterApi.InitializeCluster);
             _webService.MapGetAndPost("/api/admin/cluster/primary/delete", _clusterApi.DeleteCluster);
@@ -2064,6 +2067,7 @@ namespace DnsServerCore
                 case "/api/admin/sso/set":
                 case "/api/admin/sso/users/create":
                 case "/api/admin/sso/users/set":
+                case "/api/admin/ldap/set":
                     return ClusterNodeType.Primary; //this api can be called only on primary node
 
                 case "/sso/login":

--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -2161,6 +2161,9 @@ namespace DnsServerCore
             _webService.MapGetAndPost("/api/admin/sso/set", _authApi.SetSsoConfig);
             _webService.MapGetAndPost("/api/admin/sso/users/create", _authApi.CreateSsoUser);
             _webService.MapGetAndPost("/api/admin/sso/users/set", _authApi.SetSsoUser);
+            _webService.MapGetAndPost("/api/admin/ldap/get", _authApi.GetLdapConfig);
+            _webService.MapGetAndPost("/api/admin/ldap/set", _authApi.SetLdapConfig);
+            _webService.MapGetAndPost("/api/admin/ldap/test", _authApi.TestLdapConnectionAsync);
             _webService.MapGetAndPost("/api/admin/cluster/state", _clusterApi.GetClusterState);
             _webService.MapGetAndPost("/api/admin/cluster/init", _clusterApi.InitializeCluster);
             _webService.MapGetAndPost("/api/admin/cluster/primary/delete", _clusterApi.DeleteCluster);
@@ -2232,6 +2235,7 @@ namespace DnsServerCore
                 case "/api/admin/sso/set":
                 case "/api/admin/sso/users/create":
                 case "/api/admin/sso/users/set":
+                case "/api/admin/ldap/set":
                     return ClusterNodeType.Primary; //this api can be called only on primary node
 
                 case "/sso/login":

--- a/DnsServerCore/Extensions.cs
+++ b/DnsServerCore/Extensions.cs
@@ -363,6 +363,10 @@ namespace DnsServerCore
                 separator = COMMA_SEPARATOR;
 
             string[] cells = value.Split(separator);
+
+            if ((cells.Length % colspan) != 0)
+                throw new DnsWebServiceException("Invalid value for parameter '" + parameter + "': expected each entry to have " + colspan + " values separated by '" + new string(separator) + "'.");
+
             array = new T[cells.Length / colspan];
 
             for (int i = 0, j = 0; i < cells.Length; i += colspan)
@@ -403,6 +407,10 @@ namespace DnsServerCore
                 separator = COMMA_SEPARATOR;
 
             string[] cells = value.Split(separator);
+
+            if ((cells.Length % colspan) != 0)
+                throw new DnsWebServiceException("Invalid value for parameter '" + parameter + "': expected each entry to have " + colspan + " values separated by '" + new string(separator) + "'.");
+
             array = new T[cells.Length / colspan];
 
             for (int i = 0, j = 0; i < cells.Length; i += colspan)

--- a/DnsServerCore/WebServiceAuthApi.cs
+++ b/DnsServerCore/WebServiceAuthApi.cs
@@ -72,8 +72,9 @@ namespace DnsServerCore
                         jsonWriter.WriteString("displayName", currentSession.User.DisplayName);
                         jsonWriter.WriteString("username", currentSession.User.Username);
                         jsonWriter.WriteBoolean("isSsoUser", currentSession.User.IsSsoUser);
+                        jsonWriter.WriteBoolean("isLdapUser", currentSession.User.IsLdapUser);
 
-                        if (!currentSession.User.IsSsoUser)
+                        if (!currentSession.User.IsSsoUser && !currentSession.User.IsLdapUser)
                             jsonWriter.WriteBoolean("totpEnabled", currentSession.User.TOTPEnabled);
 
                         jsonWriter.WriteString("token", currentSession.Token);
@@ -129,8 +130,9 @@ namespace DnsServerCore
                 jsonWriter.WriteString("displayName", user.DisplayName);
                 jsonWriter.WriteString("username", user.Username);
                 jsonWriter.WriteBoolean("isSsoUser", user.IsSsoUser);
+                jsonWriter.WriteBoolean("isLdapUser", user.IsLdapUser);
 
-                if (!user.IsSsoUser)
+                if (!user.IsSsoUser && !user.IsLdapUser)
                     jsonWriter.WriteBoolean("totpEnabled", user.TOTPEnabled);
 
                 jsonWriter.WriteBoolean("disabled", user.Disabled);
@@ -143,6 +145,7 @@ namespace DnsServerCore
                 {
                     jsonWriter.WriteNumber("sessionTimeoutSeconds", user.SessionTimeoutSeconds);
                     jsonWriter.WriteBoolean("ssoManagedGroups", _dnsWebService._authManager.SsoManagedGroups);
+                    jsonWriter.WriteBoolean("ldapManagedGroups", _dnsWebService._authManager.LdapManagedGroups);
 
                     jsonWriter.WritePropertyName("memberOfGroups");
                     jsonWriter.WriteStartArray();
@@ -1392,6 +1395,9 @@ namespace DnsServerCore
                             if (ssoManagedGroups && user.IsSsoUser && !user.IsMemberOfGroup(group))
                                 throw new DnsWebServiceException("Cannot add user '" + user.Username + "' since group memberships for SSO users are managed by the SSO provider.");
 
+                            if (_dnsWebService._authManager.LdapManagedGroups && user.IsLdapUser && !user.IsMemberOfGroup(group))
+                                throw new DnsWebServiceException("Cannot add user '" + user.Username + "' since group memberships for LDAP users are managed by the LDAP directory.");
+
                             users.Add(user.Username, user);
                         }
 
@@ -1901,6 +1907,172 @@ namespace DnsServerCore
 
                 Utf8JsonWriter jsonWriter = context.GetCurrentJsonWriter();
                 WriteUserDetails(jsonWriter, user, null, false, false);
+            }
+
+            private void WriteLdapConfig(Utf8JsonWriter jsonWriter, bool includeGroups)
+            {
+                jsonWriter.WriteBoolean("ldapEnabled", _dnsWebService._authManager.LdapEnabled);
+                jsonWriter.WriteString("ldapServer", _dnsWebService._authManager.LdapServer);
+                jsonWriter.WriteNumber("ldapPort", _dnsWebService._authManager.LdapPort);
+                jsonWriter.WriteBoolean("ldapUseSsl", _dnsWebService._authManager.LdapUseSsl);
+                jsonWriter.WriteBoolean("ldapIgnoreSslErrors", _dnsWebService._authManager.LdapIgnoreSslErrors);
+                jsonWriter.WriteString("ldapBindDn", _dnsWebService._authManager.LdapBindDn);
+
+                if (string.IsNullOrEmpty(_dnsWebService._authManager.LdapBindPassword))
+                    jsonWriter.WriteString("ldapBindPassword", null as string);
+                else
+                    jsonWriter.WriteString("ldapBindPassword", "************");
+
+                jsonWriter.WriteString("ldapSearchBase", _dnsWebService._authManager.LdapSearchBase);
+                jsonWriter.WriteString("ldapUserFilter", _dnsWebService._authManager.LdapUserFilter);
+                jsonWriter.WriteString("ldapGroupAttribute", _dnsWebService._authManager.LdapGroupAttribute);
+                jsonWriter.WriteBoolean("ldapAllowSignup", _dnsWebService._authManager.LdapAllowSignup);
+                jsonWriter.WriteBoolean("ldapAllowSignupOnlyForMappedUsers", _dnsWebService._authManager.LdapAllowSignupOnlyForMappedUsers);
+
+                jsonWriter.WriteStartArray("ldapGroupMap");
+
+                IReadOnlyDictionary<string, string> ldapGroupMap = _dnsWebService._authManager.LdapGroupMap;
+                if (ldapGroupMap is not null)
+                {
+                    foreach (KeyValuePair<string, string> entry in ldapGroupMap)
+                    {
+                        jsonWriter.WriteStartObject();
+                        jsonWriter.WriteString("remoteGroup", entry.Key);
+                        jsonWriter.WriteString("localGroup", entry.Value);
+                        jsonWriter.WriteEndObject();
+                    }
+                }
+
+                jsonWriter.WriteEndArray();
+
+                if (includeGroups)
+                {
+                    List<Group> groups = new List<Group>(_dnsWebService._authManager.Groups);
+                    groups.Sort();
+
+                    jsonWriter.WriteStartArray("localGroups");
+
+                    foreach (Group group in groups)
+                    {
+                        if (group.Name.Equals("Everyone", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        jsonWriter.WriteStringValue(group.Name);
+                    }
+
+                    jsonWriter.WriteEndArray();
+                }
+            }
+
+            public void GetLdapConfig(HttpContext context)
+            {
+                User sessionUser = _dnsWebService.GetSessionUser(context);
+
+                if (!_dnsWebService._authManager.IsPermitted(PermissionSection.Administration, sessionUser, PermissionFlag.View))
+                    throw new DnsWebServiceException("Access was denied.");
+
+                bool includeGroups = context.Request.GetQueryOrForm("includeGroups", bool.Parse, false);
+
+                Utf8JsonWriter jsonWriter = context.GetCurrentJsonWriter();
+                WriteLdapConfig(jsonWriter, includeGroups);
+            }
+
+            public void SetLdapConfig(HttpContext context)
+            {
+                User sessionUser = _dnsWebService.GetSessionUser(context);
+
+                if (!_dnsWebService._authManager.IsPermitted(PermissionSection.Administration, sessionUser, PermissionFlag.Delete))
+                    throw new DnsWebServiceException("Access was denied.");
+
+                HttpRequest request = context.Request;
+
+                if (request.TryGetQueryOrForm("ldapEnabled", bool.Parse, out bool ldapEnabled))
+                    _dnsWebService._authManager.LdapEnabled = ldapEnabled;
+
+                if (request.TryQueryOrForm("ldapServer", out string ldapServer))
+                    _dnsWebService._authManager.LdapServer = ldapServer;
+
+                if (request.TryGetQueryOrForm("ldapPort", int.Parse, out int ldapPort))
+                    _dnsWebService._authManager.LdapPort = ldapPort;
+
+                if (request.TryGetQueryOrForm("ldapUseSsl", bool.Parse, out bool ldapUseSsl))
+                    _dnsWebService._authManager.LdapUseSsl = ldapUseSsl;
+
+                if (request.TryGetQueryOrForm("ldapIgnoreSslErrors", bool.Parse, out bool ldapIgnoreSslErrors))
+                    _dnsWebService._authManager.LdapIgnoreSslErrors = ldapIgnoreSslErrors;
+
+                if (request.TryQueryOrForm("ldapBindDn", out string ldapBindDn))
+                    _dnsWebService._authManager.LdapBindDn = ldapBindDn;
+
+                if (request.TryQueryOrForm("ldapBindPassword", out string ldapBindPassword))
+                {
+                    if (ldapBindPassword != "************")
+                        _dnsWebService._authManager.LdapBindPassword = ldapBindPassword;
+                }
+
+                if (request.TryQueryOrForm("ldapSearchBase", out string ldapSearchBase))
+                    _dnsWebService._authManager.LdapSearchBase = ldapSearchBase;
+
+                if (request.TryQueryOrForm("ldapUserFilter", out string ldapUserFilter))
+                    _dnsWebService._authManager.LdapUserFilter = ldapUserFilter;
+
+                if (request.TryQueryOrForm("ldapGroupAttribute", out string ldapGroupAttribute))
+                    _dnsWebService._authManager.LdapGroupAttribute = ldapGroupAttribute;
+
+                if (request.TryGetQueryOrForm("ldapAllowSignup", bool.Parse, out bool ldapAllowSignup))
+                    _dnsWebService._authManager.LdapAllowSignup = ldapAllowSignup;
+
+                if (request.TryGetQueryOrForm("ldapAllowSignupOnlyForMappedUsers", bool.Parse, out bool ldapAllowSignupOnlyForMappedUsers))
+                    _dnsWebService._authManager.LdapAllowSignupOnlyForMappedUsers = ldapAllowSignupOnlyForMappedUsers;
+
+                if (request.TryQueryOrFormArray("ldapGroupMap", delegate (ArraySegment<string> tableRow)
+                    {
+                        return new KeyValuePair<string, string>(tableRow[0], tableRow[1]);
+                    }, 2, out KeyValuePair<string, string>[] ldapGroupMapEntries, '|'))
+                {
+                    _dnsWebService._authManager.LdapGroupMap = new Dictionary<string, string>(ldapGroupMapEntries);
+                }
+
+                _dnsWebService._log.Write(context.GetRemoteEndPoint(_dnsWebService._webServiceRealIpHeader), "[" + sessionUser.Username + "] LDAP config was updated successfully.");
+
+                _dnsWebService._authManager.SaveConfigFile();
+
+                if (_dnsWebService._clusterManager.ClusterInitialized)
+                    _dnsWebService._clusterManager.TriggerNotifyAllSecondaryNodesIfPrimarySelfNode();
+
+                Utf8JsonWriter jsonWriter = context.GetCurrentJsonWriter();
+                WriteLdapConfig(jsonWriter, false);
+            }
+
+            public async Task TestLdapConnectionAsync(HttpContext context)
+            {
+                User sessionUser = _dnsWebService.GetSessionUser(context);
+
+                if (!_dnsWebService._authManager.IsPermitted(PermissionSection.Administration, sessionUser, PermissionFlag.View))
+                    throw new DnsWebServiceException("Access was denied.");
+
+                string server = context.Request.GetQueryOrForm("ldapServer", _dnsWebService._authManager.LdapServer);
+                int port = context.Request.GetQueryOrForm("ldapPort", int.Parse, _dnsWebService._authManager.LdapPort);
+                bool useSsl = context.Request.GetQueryOrForm("ldapUseSsl", bool.Parse, _dnsWebService._authManager.LdapUseSsl);
+                bool ignoreSslErrors = context.Request.GetQueryOrForm("ldapIgnoreSslErrors", bool.Parse, _dnsWebService._authManager.LdapIgnoreSslErrors);
+                string bindDn = context.Request.GetQueryOrForm("ldapBindDn", _dnsWebService._authManager.LdapBindDn);
+                string bindPassword = context.Request.GetQueryOrForm("ldapBindPassword", _dnsWebService._authManager.LdapBindPassword);
+                string searchBase = context.Request.GetQueryOrForm("ldapSearchBase", _dnsWebService._authManager.LdapSearchBase);
+                string userFilter = context.Request.GetQueryOrForm("ldapUserFilter", _dnsWebService._authManager.LdapUserFilter);
+                string groupAttribute = context.Request.GetQueryOrForm("ldapGroupAttribute", _dnsWebService._authManager.LdapGroupAttribute);
+
+                if (string.IsNullOrEmpty(server))
+                    throw new DnsWebServiceException("LDAP Server is required for connection test.");
+
+                if (bindPassword == "************")
+                    bindPassword = _dnsWebService._authManager.LdapBindPassword;
+
+                LdapAuthProvider provider = new LdapAuthProvider(server, port, useSsl, ignoreSslErrors, bindDn, bindPassword, searchBase, userFilter, groupAttribute);
+                string error = await provider.TestConnectionAsync();
+
+                Utf8JsonWriter jsonWriter = context.GetCurrentJsonWriter();
+                jsonWriter.WriteBoolean("success", error is null);
+                jsonWriter.WriteString("message", error is null ? "Connection successful." : error);
             }
 
             #endregion

--- a/DnsServerCore/WebServiceAuthApi.cs
+++ b/DnsServerCore/WebServiceAuthApi.cs
@@ -72,8 +72,9 @@ namespace DnsServerCore
                         jsonWriter.WriteString("displayName", currentSession.User.DisplayName);
                         jsonWriter.WriteString("username", currentSession.User.Username);
                         jsonWriter.WriteBoolean("isSsoUser", currentSession.User.IsSsoUser);
+                        jsonWriter.WriteBoolean("isLdapUser", currentSession.User.IsLdapUser);
 
-                        if (!currentSession.User.IsSsoUser)
+                        if (!currentSession.User.IsSsoUser && !currentSession.User.IsLdapUser)
                             jsonWriter.WriteBoolean("totpEnabled", currentSession.User.TOTPEnabled);
 
                         jsonWriter.WriteString("token", currentSession.Token);
@@ -129,8 +130,9 @@ namespace DnsServerCore
                 jsonWriter.WriteString("displayName", user.DisplayName);
                 jsonWriter.WriteString("username", user.Username);
                 jsonWriter.WriteBoolean("isSsoUser", user.IsSsoUser);
+                jsonWriter.WriteBoolean("isLdapUser", user.IsLdapUser);
 
-                if (!user.IsSsoUser)
+                if (!user.IsSsoUser && !user.IsLdapUser)
                     jsonWriter.WriteBoolean("totpEnabled", user.TOTPEnabled);
 
                 jsonWriter.WriteBoolean("disabled", user.Disabled);
@@ -143,6 +145,7 @@ namespace DnsServerCore
                 {
                     jsonWriter.WriteNumber("sessionTimeoutSeconds", user.SessionTimeoutSeconds);
                     jsonWriter.WriteBoolean("ssoManagedGroups", _dnsWebService._authManager.SsoManagedGroups);
+                    jsonWriter.WriteBoolean("ldapManagedGroups", _dnsWebService._authManager.LdapManagedGroups);
 
                     jsonWriter.WritePropertyName("memberOfGroups");
                     jsonWriter.WriteStartArray();
@@ -1401,6 +1404,9 @@ namespace DnsServerCore
                             if (ssoManagedGroups && user.IsSsoUser && !user.IsMemberOfGroup(group))
                                 throw new DnsWebServiceException("Cannot add user '" + user.Username + "' since group memberships for SSO users are managed by the SSO provider.");
 
+                            if (_dnsWebService._authManager.LdapManagedGroups && user.IsLdapUser && !user.IsMemberOfGroup(group))
+                                throw new DnsWebServiceException("Cannot add user '" + user.Username + "' since group memberships for LDAP users are managed by the LDAP directory.");
+
                             users.Add(user.Username, user);
                         }
 
@@ -1921,6 +1927,172 @@ namespace DnsServerCore
 
                 Utf8JsonWriter jsonWriter = context.GetCurrentJsonWriter();
                 WriteUserDetails(jsonWriter, user, null, false, false);
+            }
+
+            private void WriteLdapConfig(Utf8JsonWriter jsonWriter, bool includeGroups)
+            {
+                jsonWriter.WriteBoolean("ldapEnabled", _dnsWebService._authManager.LdapEnabled);
+                jsonWriter.WriteString("ldapServer", _dnsWebService._authManager.LdapServer);
+                jsonWriter.WriteNumber("ldapPort", _dnsWebService._authManager.LdapPort);
+                jsonWriter.WriteBoolean("ldapUseSsl", _dnsWebService._authManager.LdapUseSsl);
+                jsonWriter.WriteBoolean("ldapIgnoreSslErrors", _dnsWebService._authManager.LdapIgnoreSslErrors);
+                jsonWriter.WriteString("ldapBindDn", _dnsWebService._authManager.LdapBindDn);
+
+                if (string.IsNullOrEmpty(_dnsWebService._authManager.LdapBindPassword))
+                    jsonWriter.WriteString("ldapBindPassword", null as string);
+                else
+                    jsonWriter.WriteString("ldapBindPassword", "************");
+
+                jsonWriter.WriteString("ldapSearchBase", _dnsWebService._authManager.LdapSearchBase);
+                jsonWriter.WriteString("ldapUserFilter", _dnsWebService._authManager.LdapUserFilter);
+                jsonWriter.WriteString("ldapGroupAttribute", _dnsWebService._authManager.LdapGroupAttribute);
+                jsonWriter.WriteBoolean("ldapAllowSignup", _dnsWebService._authManager.LdapAllowSignup);
+                jsonWriter.WriteBoolean("ldapAllowSignupOnlyForMappedUsers", _dnsWebService._authManager.LdapAllowSignupOnlyForMappedUsers);
+
+                jsonWriter.WriteStartArray("ldapGroupMap");
+
+                IReadOnlyDictionary<string, string> ldapGroupMap = _dnsWebService._authManager.LdapGroupMap;
+                if (ldapGroupMap is not null)
+                {
+                    foreach (KeyValuePair<string, string> entry in ldapGroupMap)
+                    {
+                        jsonWriter.WriteStartObject();
+                        jsonWriter.WriteString("remoteGroup", entry.Key);
+                        jsonWriter.WriteString("localGroup", entry.Value);
+                        jsonWriter.WriteEndObject();
+                    }
+                }
+
+                jsonWriter.WriteEndArray();
+
+                if (includeGroups)
+                {
+                    List<Group> groups = new List<Group>(_dnsWebService._authManager.Groups);
+                    groups.Sort();
+
+                    jsonWriter.WriteStartArray("localGroups");
+
+                    foreach (Group group in groups)
+                    {
+                        if (group.Name.Equals("Everyone", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        jsonWriter.WriteStringValue(group.Name);
+                    }
+
+                    jsonWriter.WriteEndArray();
+                }
+            }
+
+            public void GetLdapConfig(HttpContext context)
+            {
+                User sessionUser = _dnsWebService.GetSessionUser(context);
+
+                if (!_dnsWebService._authManager.IsPermitted(PermissionSection.Administration, sessionUser, PermissionFlag.View))
+                    throw new DnsWebServiceException("Access was denied.");
+
+                bool includeGroups = context.Request.GetQueryOrForm("includeGroups", bool.Parse, false);
+
+                Utf8JsonWriter jsonWriter = context.GetCurrentJsonWriter();
+                WriteLdapConfig(jsonWriter, includeGroups);
+            }
+
+            public void SetLdapConfig(HttpContext context)
+            {
+                User sessionUser = _dnsWebService.GetSessionUser(context);
+
+                if (!_dnsWebService._authManager.IsPermitted(PermissionSection.Administration, sessionUser, PermissionFlag.Delete))
+                    throw new DnsWebServiceException("Access was denied.");
+
+                HttpRequest request = context.Request;
+
+                if (request.TryGetQueryOrForm("ldapEnabled", bool.Parse, out bool ldapEnabled))
+                    _dnsWebService._authManager.LdapEnabled = ldapEnabled;
+
+                if (request.TryQueryOrForm("ldapServer", out string ldapServer))
+                    _dnsWebService._authManager.LdapServer = ldapServer;
+
+                if (request.TryGetQueryOrForm("ldapPort", int.Parse, out int ldapPort))
+                    _dnsWebService._authManager.LdapPort = ldapPort;
+
+                if (request.TryGetQueryOrForm("ldapUseSsl", bool.Parse, out bool ldapUseSsl))
+                    _dnsWebService._authManager.LdapUseSsl = ldapUseSsl;
+
+                if (request.TryGetQueryOrForm("ldapIgnoreSslErrors", bool.Parse, out bool ldapIgnoreSslErrors))
+                    _dnsWebService._authManager.LdapIgnoreSslErrors = ldapIgnoreSslErrors;
+
+                if (request.TryQueryOrForm("ldapBindDn", out string ldapBindDn))
+                    _dnsWebService._authManager.LdapBindDn = ldapBindDn;
+
+                if (request.TryQueryOrForm("ldapBindPassword", out string ldapBindPassword))
+                {
+                    if (ldapBindPassword != "************")
+                        _dnsWebService._authManager.LdapBindPassword = ldapBindPassword;
+                }
+
+                if (request.TryQueryOrForm("ldapSearchBase", out string ldapSearchBase))
+                    _dnsWebService._authManager.LdapSearchBase = ldapSearchBase;
+
+                if (request.TryQueryOrForm("ldapUserFilter", out string ldapUserFilter))
+                    _dnsWebService._authManager.LdapUserFilter = ldapUserFilter;
+
+                if (request.TryQueryOrForm("ldapGroupAttribute", out string ldapGroupAttribute))
+                    _dnsWebService._authManager.LdapGroupAttribute = ldapGroupAttribute;
+
+                if (request.TryGetQueryOrForm("ldapAllowSignup", bool.Parse, out bool ldapAllowSignup))
+                    _dnsWebService._authManager.LdapAllowSignup = ldapAllowSignup;
+
+                if (request.TryGetQueryOrForm("ldapAllowSignupOnlyForMappedUsers", bool.Parse, out bool ldapAllowSignupOnlyForMappedUsers))
+                    _dnsWebService._authManager.LdapAllowSignupOnlyForMappedUsers = ldapAllowSignupOnlyForMappedUsers;
+
+                if (request.TryQueryOrFormArray("ldapGroupMap", delegate (ArraySegment<string> tableRow)
+                    {
+                        return new KeyValuePair<string, string>(tableRow[0], tableRow[1]);
+                    }, 2, out KeyValuePair<string, string>[] ldapGroupMapEntries, '|'))
+                {
+                    _dnsWebService._authManager.LdapGroupMap = new Dictionary<string, string>(ldapGroupMapEntries);
+                }
+
+                _dnsWebService._log.Write(_dnsWebService.GetRemoteEndPoint(context), "[" + sessionUser.Username + "] LDAP config was updated successfully.");
+
+                _dnsWebService._authManager.SaveConfigFile();
+
+                if (_dnsWebService._clusterManager.ClusterInitialized)
+                    _dnsWebService._clusterManager.TriggerNotifyAllSecondaryNodesIfPrimarySelfNode();
+
+                Utf8JsonWriter jsonWriter = context.GetCurrentJsonWriter();
+                WriteLdapConfig(jsonWriter, false);
+            }
+
+            public async Task TestLdapConnectionAsync(HttpContext context)
+            {
+                User sessionUser = _dnsWebService.GetSessionUser(context);
+
+                if (!_dnsWebService._authManager.IsPermitted(PermissionSection.Administration, sessionUser, PermissionFlag.View))
+                    throw new DnsWebServiceException("Access was denied.");
+
+                string server = context.Request.GetQueryOrForm("ldapServer", _dnsWebService._authManager.LdapServer);
+                int port = context.Request.GetQueryOrForm("ldapPort", int.Parse, _dnsWebService._authManager.LdapPort);
+                bool useSsl = context.Request.GetQueryOrForm("ldapUseSsl", bool.Parse, _dnsWebService._authManager.LdapUseSsl);
+                bool ignoreSslErrors = context.Request.GetQueryOrForm("ldapIgnoreSslErrors", bool.Parse, _dnsWebService._authManager.LdapIgnoreSslErrors);
+                string bindDn = context.Request.GetQueryOrForm("ldapBindDn", _dnsWebService._authManager.LdapBindDn);
+                string bindPassword = context.Request.GetQueryOrForm("ldapBindPassword", _dnsWebService._authManager.LdapBindPassword);
+                string searchBase = context.Request.GetQueryOrForm("ldapSearchBase", _dnsWebService._authManager.LdapSearchBase);
+                string userFilter = context.Request.GetQueryOrForm("ldapUserFilter", _dnsWebService._authManager.LdapUserFilter);
+                string groupAttribute = context.Request.GetQueryOrForm("ldapGroupAttribute", _dnsWebService._authManager.LdapGroupAttribute);
+
+                if (string.IsNullOrEmpty(server))
+                    throw new DnsWebServiceException("LDAP Server is required for connection test.");
+
+                if (bindPassword == "************")
+                    bindPassword = _dnsWebService._authManager.LdapBindPassword;
+
+                LdapAuthProvider provider = new LdapAuthProvider(server, port, useSsl, ignoreSslErrors, bindDn, bindPassword, searchBase, userFilter, groupAttribute);
+                string error = await provider.TestConnectionAsync();
+
+                Utf8JsonWriter jsonWriter = context.GetCurrentJsonWriter();
+                jsonWriter.WriteBoolean("success", error is null);
+                jsonWriter.WriteString("message", error is null ? "Connection successful." : error);
             }
 
             #endregion

--- a/DnsServerCore/www/index.html
+++ b/DnsServerCore/www/index.html
@@ -2807,6 +2807,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                             <li id="adminTabListGroups" role="presentation"><a href="#adminTabPaneGroups" aria-controls="adminTabPaneGroups" role="tab" data-toggle="tab" onclick="refreshAdminGroups();">Groups</a></li>
                                             <li id="adminTabListPermissions" role="presentation"><a href="#adminTabPanePermissions" aria-controls="adminTabPanePermissions" role="tab" data-toggle="tab" onclick="refreshAdminPermissions();">Permissions</a></li>
                                             <li id="adminTabListSso" role="presentation"><a href="#adminTabPaneSso" aria-controls="adminTabPaneSso" role="tab" data-toggle="tab" onclick="refreshAdminSsoConfig();">Single Sign-On (SSO)</a></li>
+                                            <li id="adminTabListLdap" role="presentation"><a href="#adminTabPaneLdap" aria-controls="adminTabPaneLdap" role="tab" data-toggle="tab" onclick="refreshAdminLdapConfig();">LDAP</a></li>
                                             <li id="adminTabListCluster" role="presentation"><a href="#adminTabPaneCluster" aria-controls="adminTabPaneCluster" role="tab" data-toggle="tab" onclick="refreshAdminCluster();">Cluster</a></li>
                                         </ul>
 
@@ -3029,6 +3030,149 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                                 <div class="form-group" style="margin-bottom: 0px;">
                                                     <button type="button" class="btn btn-primary" data-loading-text="Saving..." onclick="saveAdminSsoConfig(this);">Save Config</button>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div id="adminTabPaneLdap" class="tab-pane">
+                                            <div id="divAdminLdapLoader" style="margin-top: 10px; height: 350px;"></div>
+
+                                            <div id="divAdminLdapView" style="margin-top: 10px">
+                                                <div class="well well-sm form-horizontal">
+                                                    <div class="form-group">
+                                                        <label class="col-sm-3 control-label">LDAP Authentication</label>
+                                                        <div class="col-sm-7">
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapEnabled" type="checkbox"> Enable LDAP Authentication
+                                                                </label>
+                                                            </div>
+                                                            <div style="padding-top: 5px; padding-left: 20px;">Enable to allow users from an LDAP directory (Active Directory, OpenLDAP, etc.) to log in using their directory credentials.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapServer" class="col-sm-3 control-label">LDAP Server</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapServer" maxlength="255" placeholder="ldap.example.com">
+                                                            <div style="padding-top: 5px;">Hostname or IP address of the LDAP server.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapPort" class="col-sm-3 control-label">Port</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="number" class="form-control" id="txtAdminLdapPort" min="1" max="65535" placeholder="389">
+                                                            <div style="padding-top: 5px;">Use 389 for plain LDAP or StartTLS, 636 for LDAPS.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label class="col-sm-3 control-label">SSL / TLS</label>
+                                                        <div class="col-sm-7">
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapUseSsl" type="checkbox"> Use SSL/TLS (StartTLS on port 389, LDAPS on port 636)
+                                                                </label>
+                                                            </div>
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapIgnoreSslErrors" type="checkbox"> Ignore SSL Certificate Errors
+                                                                </label>
+                                                            </div>
+                                                            <div style="padding-top: 5px; padding-left: 20px;"><b>Warning!</b> Ignoring SSL errors is insecure and should only be used for testing.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapBindDn" class="col-sm-3 control-label">Bind DN</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapBindDn" maxlength="512" placeholder="CN=svcDNS,OU=ServiceAccounts,DC=example,DC=com">
+                                                            <div style="padding-top: 5px;">Distinguished Name of a service account used to search the directory. Leave empty for anonymous bind.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapBindPassword" class="col-sm-3 control-label">Bind Password</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="password" class="form-control" id="txtAdminLdapBindPassword" maxlength="255" placeholder="service account password">
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapSearchBase" class="col-sm-3 control-label">Search Base</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapSearchBase" maxlength="512" placeholder="DC=example,DC=com">
+                                                            <div style="padding-top: 5px;">The base Distinguished Name used to search for user entries.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapUserFilter" class="col-sm-3 control-label">User Search Filter</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapUserFilter" maxlength="512" placeholder="(sAMAccountName={0})">
+                                                            <div style="padding-top: 5px;">LDAP search filter used to find the user. Use <code>{0}</code> as a placeholder for the username. Default: <code>(sAMAccountName={0})</code> for Active Directory, <code>(uid={0})</code> for OpenLDAP.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapGroupAttribute" class="col-sm-3 control-label">Group Attribute</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapGroupAttribute" maxlength="255" placeholder="memberOf">
+                                                            <div style="padding-top: 5px;">The user attribute listing group memberships. Default: <code>memberOf</code> for Active Directory.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label class="col-sm-3 control-label">LDAP User Sign Up</label>
+                                                        <div class="col-sm-7">
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapAllowSignup" type="checkbox"> Allow New User Sign Up
+                                                                </label>
+                                                            </div>
+                                                            <div style="padding-top: 5px; padding-left: 20px;">Enable to automatically create a local account for LDAP users on first login.</div>
+
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapAllowSignupOnlyForMappedUsers" type="checkbox"> Allow Sign Up Only For Mapped Users
+                                                                </label>
+                                                            </div>
+                                                            <div style="padding-top: 5px; padding-left: 20px;">Restrict auto-provisioning to users who are members of at least one mapped group.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label class="col-sm-3 control-label">Group Map (Optional)</label>
+                                                        <div class="col-sm-7">
+                                                            <table class="table" style="margin-bottom: 0px;">
+                                                                <thead>
+                                                                    <tr>
+                                                                        <th>Remote Group (LDAP CN)</th>
+                                                                        <th>Local Group</th>
+                                                                        <th style="width: 84px;">
+                                                                            <button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addAdminLdapGroupMapRow('', '');">Add</button>
+                                                                        </th>
+                                                                    </tr>
+                                                                </thead>
+                                                                <tbody id="tableAdminLdapGroupMap"></tbody>
+                                                            </table>
+                                                            <div style="padding-top: 5px;">Map LDAP groups (by CN name) to local Technitium groups. Group memberships are synced on each login.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div>
+                                                        <p><b>Note!</b> LDAP authentication works by binding to the directory with a service account to locate the user, then re-binding as that user to validate credentials.</p>
+                                                        <p><b>Note!</b> If a user exists locally with a password, local authentication takes priority. LDAP is used when no local account is found, or when the account was previously provisioned via LDAP.</p>
+                                                        <p><b>Note!</b> LDAP users cannot use Two-Factor Authentication (TOTP). Credentials are validated by the LDAP directory on each login.</p>
+                                                        <p><b>Note!</b> It is recommended to always keep a local administrator account as a fallback in case the LDAP server becomes unreachable.</p>
+                                                        <p><b>Note!</b> The following environment variables can be used to configure LDAP: <code>DNS_SERVER_LDAP_ENABLED</code>, <code>DNS_SERVER_LDAP_SERVER</code>, <code>DNS_SERVER_LDAP_PORT</code>, <code>DNS_SERVER_LDAP_USE_SSL</code>, <code>DNS_SERVER_LDAP_BIND_DN</code>, <code>DNS_SERVER_LDAP_BIND_PASSWORD</code>, <code>DNS_SERVER_LDAP_SEARCH_BASE</code>, <code>DNS_SERVER_LDAP_USER_FILTER</code>, <code>DNS_SERVER_LDAP_GROUP_ATTRIBUTE</code>, <code>DNS_SERVER_LDAP_ALLOW_SIGNUP</code>, <code>DNS_SERVER_LDAP_ALLOW_SIGNUP_ONLY_FOR_MAPPED_USERS</code>, <code>DNS_SERVER_LDAP_GROUP_MAP</code>.</p>
+                                                    </div>
+                                                </div>
+
+                                                <div class="form-group">
+                                                    <button type="button" class="btn btn-primary" data-loading-text="Saving..." onclick="saveAdminLdapConfig(this);">Save Config</button>
+                                                    <button type="button" class="btn btn-default" style="margin-left: 10px;" data-loading-text="Testing..." onclick="testAdminLdapConnection(this);">Test Connection</button>
                                                 </div>
                                             </div>
                                         </div>

--- a/DnsServerCore/www/index.html
+++ b/DnsServerCore/www/index.html
@@ -2912,6 +2912,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                             <li id="adminTabListGroups" role="presentation"><a href="#adminTabPaneGroups" aria-controls="adminTabPaneGroups" role="tab" data-toggle="tab" onclick="refreshAdminGroups();">Groups</a></li>
                                             <li id="adminTabListPermissions" role="presentation"><a href="#adminTabPanePermissions" aria-controls="adminTabPanePermissions" role="tab" data-toggle="tab" onclick="refreshAdminPermissions();">Permissions</a></li>
                                             <li id="adminTabListSso" role="presentation"><a href="#adminTabPaneSso" aria-controls="adminTabPaneSso" role="tab" data-toggle="tab" onclick="refreshAdminSsoConfig();">Single Sign-On (SSO)</a></li>
+                                            <li id="adminTabListLdap" role="presentation"><a href="#adminTabPaneLdap" aria-controls="adminTabPaneLdap" role="tab" data-toggle="tab" onclick="refreshAdminLdapConfig();">LDAP</a></li>
                                             <li id="adminTabListCluster" role="presentation"><a href="#adminTabPaneCluster" aria-controls="adminTabPaneCluster" role="tab" data-toggle="tab" onclick="refreshAdminCluster();">Cluster</a></li>
                                         </ul>
 
@@ -3153,6 +3154,149 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                                                 <div class="form-group" style="margin-bottom: 0px;">
                                                     <button type="button" class="btn btn-primary" data-loading-text="Saving..." onclick="saveAdminSsoConfig(this);">Save Config</button>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div id="adminTabPaneLdap" class="tab-pane">
+                                            <div id="divAdminLdapLoader" style="margin-top: 10px; height: 350px;"></div>
+
+                                            <div id="divAdminLdapView" style="margin-top: 10px">
+                                                <div class="well well-sm form-horizontal">
+                                                    <div class="form-group">
+                                                        <label class="col-sm-3 control-label">LDAP Authentication</label>
+                                                        <div class="col-sm-7">
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapEnabled" type="checkbox"> Enable LDAP Authentication
+                                                                </label>
+                                                            </div>
+                                                            <div style="padding-top: 5px; padding-left: 20px;">Enable to allow users from an LDAP directory (Active Directory, OpenLDAP, etc.) to log in using their directory credentials.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapServer" class="col-sm-3 control-label">LDAP Server</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapServer" maxlength="255" placeholder="ldap.example.com">
+                                                            <div style="padding-top: 5px;">Hostname or IP address of the LDAP server.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapPort" class="col-sm-3 control-label">Port</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="number" class="form-control" id="txtAdminLdapPort" min="1" max="65535" placeholder="389">
+                                                            <div style="padding-top: 5px;">Use 389 for plain LDAP or StartTLS, 636 for LDAPS.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label class="col-sm-3 control-label">SSL / TLS</label>
+                                                        <div class="col-sm-7">
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapUseSsl" type="checkbox"> Use SSL/TLS (StartTLS on port 389, LDAPS on port 636)
+                                                                </label>
+                                                            </div>
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapIgnoreSslErrors" type="checkbox"> Ignore SSL Certificate Errors
+                                                                </label>
+                                                            </div>
+                                                            <div style="padding-top: 5px; padding-left: 20px;"><b>Warning!</b> Ignoring SSL errors is insecure and should only be used for testing.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapBindDn" class="col-sm-3 control-label">Bind DN</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapBindDn" maxlength="512" placeholder="CN=svcDNS,OU=ServiceAccounts,DC=example,DC=com">
+                                                            <div style="padding-top: 5px;">Distinguished Name of a service account used to search the directory. Leave empty for anonymous bind.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapBindPassword" class="col-sm-3 control-label">Bind Password</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="password" class="form-control" id="txtAdminLdapBindPassword" maxlength="255" placeholder="service account password">
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapSearchBase" class="col-sm-3 control-label">Search Base</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapSearchBase" maxlength="512" placeholder="DC=example,DC=com">
+                                                            <div style="padding-top: 5px;">The base Distinguished Name used to search for user entries.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapUserFilter" class="col-sm-3 control-label">User Search Filter</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapUserFilter" maxlength="512" placeholder="(sAMAccountName={0})">
+                                                            <div style="padding-top: 5px;">LDAP search filter used to find the user. Use <code>{0}</code> as a placeholder for the username. Default: <code>(sAMAccountName={0})</code> for Active Directory, <code>(uid={0})</code> for OpenLDAP.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label for="txtAdminLdapGroupAttribute" class="col-sm-3 control-label">Group Attribute</label>
+                                                        <div class="col-sm-7">
+                                                            <input type="text" class="form-control" id="txtAdminLdapGroupAttribute" maxlength="255" placeholder="memberOf">
+                                                            <div style="padding-top: 5px;">The user attribute listing group memberships. Default: <code>memberOf</code> for Active Directory.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label class="col-sm-3 control-label">LDAP User Sign Up</label>
+                                                        <div class="col-sm-7">
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapAllowSignup" type="checkbox"> Allow New User Sign Up
+                                                                </label>
+                                                            </div>
+                                                            <div style="padding-top: 5px; padding-left: 20px;">Enable to automatically create a local account for LDAP users on first login.</div>
+
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input id="chkAdminLdapAllowSignupOnlyForMappedUsers" type="checkbox"> Allow Sign Up Only For Mapped Users
+                                                                </label>
+                                                            </div>
+                                                            <div style="padding-top: 5px; padding-left: 20px;">Restrict auto-provisioning to users who are members of at least one mapped group.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="form-group">
+                                                        <label class="col-sm-3 control-label">Group Map (Optional)</label>
+                                                        <div class="col-sm-7">
+                                                            <table class="table" style="margin-bottom: 0px;">
+                                                                <thead>
+                                                                    <tr>
+                                                                        <th>Remote Group (LDAP CN)</th>
+                                                                        <th>Local Group</th>
+                                                                        <th style="width: 84px;">
+                                                                            <button type="button" class="btn btn-default" style="padding: 0px 20px;" onclick="addAdminLdapGroupMapRow('', '');">Add</button>
+                                                                        </th>
+                                                                    </tr>
+                                                                </thead>
+                                                                <tbody id="tableAdminLdapGroupMap"></tbody>
+                                                            </table>
+                                                            <div style="padding-top: 5px;">Map LDAP groups (by CN name) to local Technitium groups. Group memberships are synced on each login.</div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div>
+                                                        <p><b>Note!</b> LDAP authentication works by binding to the directory with a service account to locate the user, then re-binding as that user to validate credentials.</p>
+                                                        <p><b>Note!</b> If a user exists locally with a password, local authentication takes priority. LDAP is used when no local account is found, or when the account was previously provisioned via LDAP.</p>
+                                                        <p><b>Note!</b> LDAP users cannot use Two-Factor Authentication (TOTP). Credentials are validated by the LDAP directory on each login.</p>
+                                                        <p><b>Note!</b> It is recommended to always keep a local administrator account as a fallback in case the LDAP server becomes unreachable.</p>
+                                                        <p><b>Note!</b> The following environment variables can be used to configure LDAP: <code>DNS_SERVER_LDAP_ENABLED</code>, <code>DNS_SERVER_LDAP_SERVER</code>, <code>DNS_SERVER_LDAP_PORT</code>, <code>DNS_SERVER_LDAP_USE_SSL</code>, <code>DNS_SERVER_LDAP_BIND_DN</code>, <code>DNS_SERVER_LDAP_BIND_PASSWORD</code>, <code>DNS_SERVER_LDAP_SEARCH_BASE</code>, <code>DNS_SERVER_LDAP_USER_FILTER</code>, <code>DNS_SERVER_LDAP_GROUP_ATTRIBUTE</code>, <code>DNS_SERVER_LDAP_ALLOW_SIGNUP</code>, <code>DNS_SERVER_LDAP_ALLOW_SIGNUP_ONLY_FOR_MAPPED_USERS</code>, <code>DNS_SERVER_LDAP_GROUP_MAP</code>.</p>
+                                                    </div>
+                                                </div>
+
+                                                <div class="form-group">
+                                                    <button type="button" class="btn btn-primary" data-loading-text="Saving..." onclick="saveAdminLdapConfig(this);">Save Config</button>
+                                                    <button type="button" class="btn btn-default" style="margin-left: 10px;" data-loading-text="Testing..." onclick="testAdminLdapConnection(this);">Test Connection</button>
                                                 </div>
                                             </div>
                                         </div>

--- a/DnsServerCore/www/js/auth.js
+++ b/DnsServerCore/www/js/auth.js
@@ -655,13 +655,18 @@ function showMyProfileModal() {
 
             $("#mnuUserDisplayName").text(sessionData.displayName);
 
-            $("#txtMyProfileDisplayName").prop("disabled", responseJSON.response.isSsoUser);
+            var isRemoteUser = responseJSON.response.isSsoUser || responseJSON.response.isLdapUser;
+            $("#txtMyProfileDisplayName").prop("disabled", isRemoteUser);
             $("#txtMyProfileDisplayName").val(responseJSON.response.displayName);
             $("#txtMyProfileUsername").val(responseJSON.response.username);
 
             if (responseJSON.response.isSsoUser) {
                 $("#lblMyProfileUserType").text("Remote/SSO");
                 $("#lblMyProfile2FAStatus").text("SSO Managed");
+            }
+            else if (responseJSON.response.isLdapUser) {
+                $("#lblMyProfileUserType").text("Remote/LDAP");
+                $("#lblMyProfile2FAStatus").text("LDAP Managed");
             }
             else {
                 $("#lblMyProfileUserType").text("Local");
@@ -842,6 +847,8 @@ function refreshAdminTab() {
         refreshAdminPermissions();
     else if ($("#adminTabListSso").hasClass("active"))
         refreshAdminSsoConfig();
+    else if ($("#adminTabListLdap").hasClass("active"))
+        refreshAdminLdapConfig();
     else if ($("#adminTabListCluster").hasClass("active"))
         refreshAdminCluster();
     else
@@ -1113,6 +1120,10 @@ function getAdminUsersRowHtml(id, user) {
         userType = "Remote/SSO";
         totpStatus = "<span class=\"label label-info\">SSO Managed</span>"
     }
+    else if (user.isLdapUser) {
+        userType = "Remote/LDAP";
+        totpStatus = "<span class=\"label label-info\">LDAP Managed</span>"
+    }
     else {
         userType = "Local";
 
@@ -1256,15 +1267,21 @@ function showUserDetailsModal(objMenuItem) {
         url: "api/admin/users/get?user=" + encodeURIComponent(username) + "&includeGroups=true",
         token: sessionData.token,
         success: function (responseJSON) {
-            $("#txtUserDetailsDisplayName").prop("disabled", responseJSON.response.isSsoUser);
+            var isRemoteUser = responseJSON.response.isSsoUser || responseJSON.response.isLdapUser;
+
+            $("#txtUserDetailsDisplayName").prop("disabled", isRemoteUser);
             $("#txtUserDetailsDisplayName").val(responseJSON.response.displayName);
 
-            $("#txtUserDetailsUsername").prop("disabled", responseJSON.response.isSsoUser);
+            $("#txtUserDetailsUsername").prop("disabled", isRemoteUser);
             $("#txtUserDetailsUsername").val(responseJSON.response.username);
 
             if (responseJSON.response.isSsoUser) {
                 $("#lblUserDetailsUserType").text("Remote/SSO");
                 $("#lblUserDetails2FAStatus").text("SSO Managed");
+            }
+            else if (responseJSON.response.isLdapUser) {
+                $("#lblUserDetailsUserType").text("Remote/LDAP");
+                $("#lblUserDetails2FAStatus").text("LDAP Managed");
             }
             else {
                 $("#lblUserDetailsUserType").text("Local");
@@ -1280,8 +1297,10 @@ function showUserDetailsModal(objMenuItem) {
                 memberOf += htmlEncode(responseJSON.response.memberOfGroups[i]) + "\n";
             }
 
-            $("#txtUserDetailsMemberOf").prop("disabled", responseJSON.response.isSsoUser && responseJSON.response.ssoManagedGroups)
-            $("#optUserDetailsGroupList").prop("disabled", responseJSON.response.isSsoUser && responseJSON.response.ssoManagedGroups)
+            var groupsDisabled = (responseJSON.response.isSsoUser && responseJSON.response.ssoManagedGroups) ||
+                                 (responseJSON.response.isLdapUser && responseJSON.response.ldapManagedGroups);
+            $("#txtUserDetailsMemberOf").prop("disabled", groupsDisabled)
+            $("#optUserDetailsGroupList").prop("disabled", groupsDisabled)
 
             $("#txtUserDetailsMemberOf").val(memberOf);
 
@@ -2272,6 +2291,171 @@ function saveAdminSsoConfig(objBtn) {
             btn.button("reset");
 
             showAlert("success", "SSO Config Saved!", "Single Sign-On (SSO) config was saved successfully.");
+        },
+        error: function () {
+            btn.button("reset");
+        },
+        invalidToken: function () {
+            btn.button("reset");
+            showPageLogin();
+        }
+    });
+}
+
+function refreshAdminLdapConfig() {
+    var divAdminLdapLoader = $("#divAdminLdapLoader");
+    var divAdminLdapView = $("#divAdminLdapView");
+
+    divAdminLdapLoader.show();
+    divAdminLdapView.hide();
+
+    HTTPRequest({
+        url: "api/admin/ldap/get?includeGroups=true",
+        token: sessionData.token,
+        success: function (responseJSON) {
+            localGroups = responseJSON.response.localGroups;
+
+            loadAdminLdapConfig(responseJSON);
+
+            divAdminLdapLoader.hide();
+            divAdminLdapView.show();
+        },
+        invalidToken: function () {
+            showPageLogin();
+        },
+        objLoaderPlaceholder: divAdminLdapLoader
+    });
+}
+
+function loadAdminLdapConfig(responseJSON) {
+    $("#chkAdminLdapEnabled").prop("checked", responseJSON.response.ldapEnabled);
+    $("#txtAdminLdapServer").val(responseJSON.response.ldapServer || "");
+    $("#txtAdminLdapPort").val(responseJSON.response.ldapPort || 389);
+    $("#chkAdminLdapUseSsl").prop("checked", responseJSON.response.ldapUseSsl);
+    $("#chkAdminLdapIgnoreSslErrors").prop("checked", responseJSON.response.ldapIgnoreSslErrors);
+    $("#txtAdminLdapBindDn").val(responseJSON.response.ldapBindDn || "");
+    $("#txtAdminLdapBindPassword").val(responseJSON.response.ldapBindPassword || "");
+    $("#txtAdminLdapSearchBase").val(responseJSON.response.ldapSearchBase || "");
+    $("#txtAdminLdapUserFilter").val(responseJSON.response.ldapUserFilter || "");
+    $("#txtAdminLdapGroupAttribute").val(responseJSON.response.ldapGroupAttribute || "");
+    $("#chkAdminLdapAllowSignup").prop("checked", responseJSON.response.ldapAllowSignup);
+    $("#chkAdminLdapAllowSignupOnlyForMappedUsers").prop("checked", responseJSON.response.ldapAllowSignupOnlyForMappedUsers);
+
+    $("#tableAdminLdapGroupMap").html("");
+
+    for (var i = 0; i < responseJSON.response.ldapGroupMap.length; i++)
+        addAdminLdapGroupMapRow(responseJSON.response.ldapGroupMap[i].remoteGroup, responseJSON.response.ldapGroupMap[i].localGroup);
+}
+
+function addAdminLdapGroupMapRow(remoteGroup, localGroup) {
+    var id = Math.floor(Math.random() * 10000);
+
+    var tableHtmlRows = "<tr id=\"tableAdminLdapGroupMapRow" + id + "\"><td><input type=\"text\" class=\"form-control\" value=\"" + htmlEncode(remoteGroup) + "\"></td>";
+
+    tableHtmlRows += "<td><select class=\"form-control\">";
+
+    for (var i = 0; i < localGroups.length; i++)
+        tableHtmlRows += "<option" + (localGroups[i] == localGroup ? " selected" : "") + ">" + htmlEncode(localGroups[i]) + "</option>";
+
+    tableHtmlRows += "</select></td>";
+
+    tableHtmlRows += "<td><button type=\"button\" class=\"btn btn-danger\" onclick=\"$('#tableAdminLdapGroupMapRow" + id + "').remove();\">Delete</button></td></tr>";
+
+    $("#tableAdminLdapGroupMap").append(tableHtmlRows);
+}
+
+function saveAdminLdapConfig(objBtn) {
+    var btn = $(objBtn);
+
+    var ldapEnabled = $("#chkAdminLdapEnabled").prop("checked");
+
+    var ldapServer = $("#txtAdminLdapServer").val();
+    if (ldapEnabled && (ldapServer === "")) {
+        showAlert("warning", "Missing!", "Please enter the LDAP Server address.");
+        $("#txtAdminLdapServer").trigger("focus");
+        return;
+    }
+
+    var ldapPort = $("#txtAdminLdapPort").val();
+    if (ldapEnabled && (ldapPort === "")) {
+        showAlert("warning", "Missing!", "Please enter the LDAP Port.");
+        $("#txtAdminLdapPort").trigger("focus");
+        return;
+    }
+
+    var ldapUseSsl = $("#chkAdminLdapUseSsl").prop("checked");
+    var ldapIgnoreSslErrors = $("#chkAdminLdapIgnoreSslErrors").prop("checked");
+    var ldapBindDn = $("#txtAdminLdapBindDn").val();
+    var ldapBindPassword = $("#txtAdminLdapBindPassword").val();
+    var ldapSearchBase = $("#txtAdminLdapSearchBase").val();
+    var ldapUserFilter = $("#txtAdminLdapUserFilter").val();
+    var ldapGroupAttribute = $("#txtAdminLdapGroupAttribute").val();
+    var ldapAllowSignup = $("#chkAdminLdapAllowSignup").prop("checked");
+    var ldapAllowSignupOnlyForMappedUsers = $("#chkAdminLdapAllowSignupOnlyForMappedUsers").prop("checked");
+
+    var ldapGroupMap = serializeTableData($("#tableAdminLdapGroupMap"), 2);
+    if (ldapGroupMap === false)
+        return;
+
+    if (ldapGroupMap.length == 0)
+        ldapGroupMap = false;
+
+    btn.button("loading");
+
+    HTTPRequest({
+        url: "api/admin/ldap/set",
+        token: sessionData.token,
+        method: "POST",
+        data: "ldapEnabled=" + ldapEnabled + "&ldapServer=" + encodeURIComponent(ldapServer) + "&ldapPort=" + ldapPort + "&ldapUseSsl=" + ldapUseSsl + "&ldapIgnoreSslErrors=" + ldapIgnoreSslErrors + "&ldapBindDn=" + encodeURIComponent(ldapBindDn) + "&ldapBindPassword=" + encodeURIComponent(ldapBindPassword) + "&ldapSearchBase=" + encodeURIComponent(ldapSearchBase) + "&ldapUserFilter=" + encodeURIComponent(ldapUserFilter) + "&ldapGroupAttribute=" + encodeURIComponent(ldapGroupAttribute) + "&ldapAllowSignup=" + ldapAllowSignup + "&ldapAllowSignupOnlyForMappedUsers=" + ldapAllowSignupOnlyForMappedUsers + "&ldapGroupMap=" + encodeURIComponent(ldapGroupMap),
+        success: function (responseJSON) {
+            loadAdminLdapConfig(responseJSON);
+            btn.button("reset");
+
+            showAlert("success", "LDAP Config Saved!", "LDAP authentication config was saved successfully.");
+        },
+        error: function () {
+            btn.button("reset");
+        },
+        invalidToken: function () {
+            btn.button("reset");
+            showPageLogin();
+        }
+    });
+}
+
+function testAdminLdapConnection(objBtn) {
+    var btn = $(objBtn);
+
+    var ldapServer = $("#txtAdminLdapServer").val();
+    if (ldapServer === "") {
+        showAlert("warning", "Missing!", "Please enter the LDAP Server address.");
+        $("#txtAdminLdapServer").trigger("focus");
+        return;
+    }
+
+    var ldapPort = $("#txtAdminLdapPort").val() || 389;
+    var ldapUseSsl = $("#chkAdminLdapUseSsl").prop("checked");
+    var ldapIgnoreSslErrors = $("#chkAdminLdapIgnoreSslErrors").prop("checked");
+    var ldapBindDn = $("#txtAdminLdapBindDn").val();
+    var ldapBindPassword = $("#txtAdminLdapBindPassword").val();
+    var ldapSearchBase = $("#txtAdminLdapSearchBase").val();
+    var ldapUserFilter = $("#txtAdminLdapUserFilter").val();
+    var ldapGroupAttribute = $("#txtAdminLdapGroupAttribute").val();
+
+    btn.button("loading");
+
+    HTTPRequest({
+        url: "api/admin/ldap/test",
+        token: sessionData.token,
+        method: "POST",
+        data: "ldapServer=" + encodeURIComponent(ldapServer) + "&ldapPort=" + ldapPort + "&ldapUseSsl=" + ldapUseSsl + "&ldapIgnoreSslErrors=" + ldapIgnoreSslErrors + "&ldapBindDn=" + encodeURIComponent(ldapBindDn) + "&ldapBindPassword=" + encodeURIComponent(ldapBindPassword) + "&ldapSearchBase=" + encodeURIComponent(ldapSearchBase) + "&ldapUserFilter=" + encodeURIComponent(ldapUserFilter) + "&ldapGroupAttribute=" + encodeURIComponent(ldapGroupAttribute),
+        success: function (responseJSON) {
+            btn.button("reset");
+
+            if (responseJSON.response.success)
+                showAlert("success", "Connection Successful!", responseJSON.response.message);
+            else
+                showAlert("danger", "Connection Failed!", responseJSON.response.message);
         },
         error: function () {
             btn.button("reset");

--- a/DnsServerCore/www/js/auth.js
+++ b/DnsServerCore/www/js/auth.js
@@ -660,13 +660,18 @@ function showMyProfileModal() {
 
             $("#mnuUserDisplayName").text(sessionData.displayName);
 
-            $("#txtMyProfileDisplayName").prop("disabled", responseJSON.response.isSsoUser);
+            var isRemoteUser = responseJSON.response.isSsoUser || responseJSON.response.isLdapUser;
+            $("#txtMyProfileDisplayName").prop("disabled", isRemoteUser);
             $("#txtMyProfileDisplayName").val(responseJSON.response.displayName);
             $("#txtMyProfileUsername").val(responseJSON.response.username);
 
             if (responseJSON.response.isSsoUser) {
                 $("#lblMyProfileUserType").text("Remote/SSO");
                 $("#lblMyProfile2FAStatus").text("SSO Managed");
+            }
+            else if (responseJSON.response.isLdapUser) {
+                $("#lblMyProfileUserType").text("Remote/LDAP");
+                $("#lblMyProfile2FAStatus").text("LDAP Managed");
             }
             else {
                 $("#lblMyProfileUserType").text("Local");
@@ -847,6 +852,8 @@ function refreshAdminTab() {
         refreshAdminPermissions();
     else if ($("#adminTabListSso").hasClass("active"))
         refreshAdminSsoConfig();
+    else if ($("#adminTabListLdap").hasClass("active"))
+        refreshAdminLdapConfig();
     else if ($("#adminTabListCluster").hasClass("active"))
         refreshAdminCluster();
     else
@@ -1118,6 +1125,10 @@ function getAdminUsersRowHtml(id, user) {
         userType = "Remote/SSO";
         totpStatus = "<span class=\"label label-info\">SSO Managed</span>"
     }
+    else if (user.isLdapUser) {
+        userType = "Remote/LDAP";
+        totpStatus = "<span class=\"label label-info\">LDAP Managed</span>"
+    }
     else {
         userType = "Local";
 
@@ -1261,15 +1272,21 @@ function showUserDetailsModal(objMenuItem) {
         url: "api/admin/users/get?user=" + encodeURIComponent(username) + "&includeGroups=true",
         token: sessionData.token,
         success: function (responseJSON) {
-            $("#txtUserDetailsDisplayName").prop("disabled", responseJSON.response.isSsoUser);
+            var isRemoteUser = responseJSON.response.isSsoUser || responseJSON.response.isLdapUser;
+
+            $("#txtUserDetailsDisplayName").prop("disabled", isRemoteUser);
             $("#txtUserDetailsDisplayName").val(responseJSON.response.displayName);
 
-            $("#txtUserDetailsUsername").prop("disabled", responseJSON.response.isSsoUser);
+            $("#txtUserDetailsUsername").prop("disabled", isRemoteUser);
             $("#txtUserDetailsUsername").val(responseJSON.response.username);
 
             if (responseJSON.response.isSsoUser) {
                 $("#lblUserDetailsUserType").text("Remote/SSO");
                 $("#lblUserDetails2FAStatus").text("SSO Managed");
+            }
+            else if (responseJSON.response.isLdapUser) {
+                $("#lblUserDetailsUserType").text("Remote/LDAP");
+                $("#lblUserDetails2FAStatus").text("LDAP Managed");
             }
             else {
                 $("#lblUserDetailsUserType").text("Local");
@@ -1285,8 +1302,10 @@ function showUserDetailsModal(objMenuItem) {
                 memberOf += htmlEncode(responseJSON.response.memberOfGroups[i]) + "\n";
             }
 
-            $("#txtUserDetailsMemberOf").prop("disabled", responseJSON.response.isSsoUser && responseJSON.response.ssoManagedGroups)
-            $("#optUserDetailsGroupList").prop("disabled", responseJSON.response.isSsoUser && responseJSON.response.ssoManagedGroups)
+            var groupsDisabled = (responseJSON.response.isSsoUser && responseJSON.response.ssoManagedGroups) ||
+                                 (responseJSON.response.isLdapUser && responseJSON.response.ldapManagedGroups);
+            $("#txtUserDetailsMemberOf").prop("disabled", groupsDisabled)
+            $("#optUserDetailsGroupList").prop("disabled", groupsDisabled)
 
             $("#txtUserDetailsMemberOf").val(memberOf);
 
@@ -2301,6 +2320,171 @@ function saveAdminSsoConfig(objBtn) {
             btn.button("reset");
 
             showAlert("success", "SSO Config Saved!", "Single Sign-On (SSO) config was saved successfully.");
+        },
+        error: function () {
+            btn.button("reset");
+        },
+        invalidToken: function () {
+            btn.button("reset");
+            showPageLogin();
+        }
+    });
+}
+
+function refreshAdminLdapConfig() {
+    var divAdminLdapLoader = $("#divAdminLdapLoader");
+    var divAdminLdapView = $("#divAdminLdapView");
+
+    divAdminLdapLoader.show();
+    divAdminLdapView.hide();
+
+    HTTPRequest({
+        url: "api/admin/ldap/get?includeGroups=true",
+        token: sessionData.token,
+        success: function (responseJSON) {
+            localGroups = responseJSON.response.localGroups;
+
+            loadAdminLdapConfig(responseJSON);
+
+            divAdminLdapLoader.hide();
+            divAdminLdapView.show();
+        },
+        invalidToken: function () {
+            showPageLogin();
+        },
+        objLoaderPlaceholder: divAdminLdapLoader
+    });
+}
+
+function loadAdminLdapConfig(responseJSON) {
+    $("#chkAdminLdapEnabled").prop("checked", responseJSON.response.ldapEnabled);
+    $("#txtAdminLdapServer").val(responseJSON.response.ldapServer || "");
+    $("#txtAdminLdapPort").val(responseJSON.response.ldapPort || 389);
+    $("#chkAdminLdapUseSsl").prop("checked", responseJSON.response.ldapUseSsl);
+    $("#chkAdminLdapIgnoreSslErrors").prop("checked", responseJSON.response.ldapIgnoreSslErrors);
+    $("#txtAdminLdapBindDn").val(responseJSON.response.ldapBindDn || "");
+    $("#txtAdminLdapBindPassword").val(responseJSON.response.ldapBindPassword || "");
+    $("#txtAdminLdapSearchBase").val(responseJSON.response.ldapSearchBase || "");
+    $("#txtAdminLdapUserFilter").val(responseJSON.response.ldapUserFilter || "");
+    $("#txtAdminLdapGroupAttribute").val(responseJSON.response.ldapGroupAttribute || "");
+    $("#chkAdminLdapAllowSignup").prop("checked", responseJSON.response.ldapAllowSignup);
+    $("#chkAdminLdapAllowSignupOnlyForMappedUsers").prop("checked", responseJSON.response.ldapAllowSignupOnlyForMappedUsers);
+
+    $("#tableAdminLdapGroupMap").html("");
+
+    for (var i = 0; i < responseJSON.response.ldapGroupMap.length; i++)
+        addAdminLdapGroupMapRow(responseJSON.response.ldapGroupMap[i].remoteGroup, responseJSON.response.ldapGroupMap[i].localGroup);
+}
+
+function addAdminLdapGroupMapRow(remoteGroup, localGroup) {
+    var id = Math.floor(Math.random() * 10000);
+
+    var tableHtmlRows = "<tr id=\"tableAdminLdapGroupMapRow" + id + "\"><td><input type=\"text\" class=\"form-control\" value=\"" + htmlEncode(remoteGroup) + "\"></td>";
+
+    tableHtmlRows += "<td><select class=\"form-control\">";
+
+    for (var i = 0; i < localGroups.length; i++)
+        tableHtmlRows += "<option" + (localGroups[i] == localGroup ? " selected" : "") + ">" + htmlEncode(localGroups[i]) + "</option>";
+
+    tableHtmlRows += "</select></td>";
+
+    tableHtmlRows += "<td><button type=\"button\" class=\"btn btn-danger\" onclick=\"$('#tableAdminLdapGroupMapRow" + id + "').remove();\">Delete</button></td></tr>";
+
+    $("#tableAdminLdapGroupMap").append(tableHtmlRows);
+}
+
+function saveAdminLdapConfig(objBtn) {
+    var btn = $(objBtn);
+
+    var ldapEnabled = $("#chkAdminLdapEnabled").prop("checked");
+
+    var ldapServer = $("#txtAdminLdapServer").val();
+    if (ldapEnabled && (ldapServer === "")) {
+        showAlert("warning", "Missing!", "Please enter the LDAP Server address.");
+        $("#txtAdminLdapServer").trigger("focus");
+        return;
+    }
+
+    var ldapPort = $("#txtAdminLdapPort").val();
+    if (ldapEnabled && (ldapPort === "")) {
+        showAlert("warning", "Missing!", "Please enter the LDAP Port.");
+        $("#txtAdminLdapPort").trigger("focus");
+        return;
+    }
+
+    var ldapUseSsl = $("#chkAdminLdapUseSsl").prop("checked");
+    var ldapIgnoreSslErrors = $("#chkAdminLdapIgnoreSslErrors").prop("checked");
+    var ldapBindDn = $("#txtAdminLdapBindDn").val();
+    var ldapBindPassword = $("#txtAdminLdapBindPassword").val();
+    var ldapSearchBase = $("#txtAdminLdapSearchBase").val();
+    var ldapUserFilter = $("#txtAdminLdapUserFilter").val();
+    var ldapGroupAttribute = $("#txtAdminLdapGroupAttribute").val();
+    var ldapAllowSignup = $("#chkAdminLdapAllowSignup").prop("checked");
+    var ldapAllowSignupOnlyForMappedUsers = $("#chkAdminLdapAllowSignupOnlyForMappedUsers").prop("checked");
+
+    var ldapGroupMap = serializeTableData($("#tableAdminLdapGroupMap"), 2);
+    if (ldapGroupMap === false)
+        return;
+
+    if (ldapGroupMap.length == 0)
+        ldapGroupMap = false;
+
+    btn.button("loading");
+
+    HTTPRequest({
+        url: "api/admin/ldap/set",
+        token: sessionData.token,
+        method: "POST",
+        data: "ldapEnabled=" + ldapEnabled + "&ldapServer=" + encodeURIComponent(ldapServer) + "&ldapPort=" + ldapPort + "&ldapUseSsl=" + ldapUseSsl + "&ldapIgnoreSslErrors=" + ldapIgnoreSslErrors + "&ldapBindDn=" + encodeURIComponent(ldapBindDn) + "&ldapBindPassword=" + encodeURIComponent(ldapBindPassword) + "&ldapSearchBase=" + encodeURIComponent(ldapSearchBase) + "&ldapUserFilter=" + encodeURIComponent(ldapUserFilter) + "&ldapGroupAttribute=" + encodeURIComponent(ldapGroupAttribute) + "&ldapAllowSignup=" + ldapAllowSignup + "&ldapAllowSignupOnlyForMappedUsers=" + ldapAllowSignupOnlyForMappedUsers + "&ldapGroupMap=" + encodeURIComponent(ldapGroupMap),
+        success: function (responseJSON) {
+            loadAdminLdapConfig(responseJSON);
+            btn.button("reset");
+
+            showAlert("success", "LDAP Config Saved!", "LDAP authentication config was saved successfully.");
+        },
+        error: function () {
+            btn.button("reset");
+        },
+        invalidToken: function () {
+            btn.button("reset");
+            showPageLogin();
+        }
+    });
+}
+
+function testAdminLdapConnection(objBtn) {
+    var btn = $(objBtn);
+
+    var ldapServer = $("#txtAdminLdapServer").val();
+    if (ldapServer === "") {
+        showAlert("warning", "Missing!", "Please enter the LDAP Server address.");
+        $("#txtAdminLdapServer").trigger("focus");
+        return;
+    }
+
+    var ldapPort = $("#txtAdminLdapPort").val() || 389;
+    var ldapUseSsl = $("#chkAdminLdapUseSsl").prop("checked");
+    var ldapIgnoreSslErrors = $("#chkAdminLdapIgnoreSslErrors").prop("checked");
+    var ldapBindDn = $("#txtAdminLdapBindDn").val();
+    var ldapBindPassword = $("#txtAdminLdapBindPassword").val();
+    var ldapSearchBase = $("#txtAdminLdapSearchBase").val();
+    var ldapUserFilter = $("#txtAdminLdapUserFilter").val();
+    var ldapGroupAttribute = $("#txtAdminLdapGroupAttribute").val();
+
+    btn.button("loading");
+
+    HTTPRequest({
+        url: "api/admin/ldap/test",
+        token: sessionData.token,
+        method: "POST",
+        data: "ldapServer=" + encodeURIComponent(ldapServer) + "&ldapPort=" + ldapPort + "&ldapUseSsl=" + ldapUseSsl + "&ldapIgnoreSslErrors=" + ldapIgnoreSslErrors + "&ldapBindDn=" + encodeURIComponent(ldapBindDn) + "&ldapBindPassword=" + encodeURIComponent(ldapBindPassword) + "&ldapSearchBase=" + encodeURIComponent(ldapSearchBase) + "&ldapUserFilter=" + encodeURIComponent(ldapUserFilter) + "&ldapGroupAttribute=" + encodeURIComponent(ldapGroupAttribute),
+        success: function (responseJSON) {
+            btn.button("reset");
+
+            if (responseJSON.response.success)
+                showAlert("success", "Connection Successful!", responseJSON.response.message);
+            else
+                showAlert("danger", "Connection Failed!", responseJSON.response.message);
         },
         error: function () {
             btn.button("reset");


### PR DESCRIPTION
## Summary

Adds native LDAP authentication to the DNS Server web console, enabling users to sign in with their Active Directory or LDAP directory credentials.

### Features

- **Three connection modes** — plain LDAP, StartTLS (port 389 + SSL), and LDAPS (port 636 + SSL). Mode is selected automatically based on port: `Use SSL` + port 636 = LDAPS, `Use SSL` + any other port = StartTLS.
- **Service account search** — a bind DN/password locates the user in the directory before validating their credentials. Supports UPN (`user@domain`) and full DN formats.
- **Configurable user filter** — defaults to `(sAMAccountName={0})` for Active Directory; any RFC 4515 filter is supported.
- **Group mapping** — maps LDAP groups (by CN) to local Technitium groups, e.g. `Domain Admins` → `Administrators`.
- **Auto-provisioning** — optionally creates a local account on first LDAP login, with optional restriction to mapped groups only.
- **Ignore SSL errors** — for self-signed or internal CA certificates.
- **Test connection button** — verifies the service account bind without saving config.
- **Docker/environment variable support** — full headless configuration via `DNS_SERVER_LDAP_*` variables.

### Environment Variables

| Variable | Description |
|---|---|
| `DNS_SERVER_LDAP_ENABLED` | `true`/`false` |
| `DNS_SERVER_LDAP_SERVER` | Hostname or IP |
| `DNS_SERVER_LDAP_PORT` | Default: `389` |
| `DNS_SERVER_LDAP_USE_SSL` | `true` enables StartTLS (port 389) or LDAPS (port 636) |
| `DNS_SERVER_LDAP_IGNORE_SSL_ERRORS` | `true`/`false` |
| `DNS_SERVER_LDAP_BIND_DN` | Service account DN or UPN |
| `DNS_SERVER_LDAP_BIND_PASSWORD` | Service account password |
| `DNS_SERVER_LDAP_SEARCH_BASE` | e.g. `DC=example,DC=com` |
| `DNS_SERVER_LDAP_USER_FILTER` | Default: `(sAMAccountName={0})` |
| `DNS_SERVER_LDAP_GROUP_ATTRIBUTE` | Default: `memberOf` |
| `DNS_SERVER_LDAP_ALLOW_SIGNUP` | `true`/`false` |
| `DNS_SERVER_LDAP_ALLOW_SIGNUP_ONLY_FOR_MAPPED_USERS` | `true`/`false` |
| `DNS_SERVER_LDAP_GROUP_MAP` | JSON array, e.g. `[{"remoteGroup":"Domain Admins","localGroup":"Administrators"}]` |

### Implementation Notes

Uses `System.DirectoryServices.Protocols` (Microsoft built-in library) for LDAP connectivity. On Linux, this requires `libldap2` to be installed (`apt install libldap2` on Debian/Ubuntu, `dnf install openldap` on RHEL/Rocky). This package is not included by the Technitium install script but is available on all major Linux distributions.