### PR TITLE
SecondaryZone: fall back to AXFR when IXFR fails at transport level

### DIFF
--- a/DnsServerCore/Dns/Zones/SecondaryZone.cs
+++ b/DnsServerCore/Dns/Zones/SecondaryZone.cs
@@ -464,10 +464,14 @@ namespace DnsServerCore.Dns.Zones
                     DnsDatagram xfrRequest = new DnsDatagram(0, false, DnsOpcode.StandardQuery, false, false, false, false, false, false, DnsResponseCode.NoError, [xfrQuestion], null, xfrAuthority, udpPayloadSize: _dnsServer.UdpPayloadSize, options: [new EDnsOption(EDnsOptionCode.EDNS_EXPIRE, new EDnsExpireOptionData())]);
                     DnsDatagram xfrResponse;
 
-                    if (key is null)
-                        xfrResponse = await xfrClient.RawResolveAsync(xfrRequest);
-                    else
-                        xfrResponse = await xfrClient.TsigResolveAsync(xfrRequest, key, REFRESH_TSIG_FUDGE);
+                    try
+                    {
+                        if (key is null)
+                            xfrResponse = await xfrClient.RawResolveAsync(xfrRequest);
+                        else
+                            xfrResponse = await xfrClient.TsigResolveAsync(xfrRequest, key, REFRESH_TSIG_FUDGE);
+                    }
+                    catch when (doIXFR) { doIXFR = false; continue; }
 
                     if (doIXFR && ((xfrResponse.RCODE == DnsResponseCode.NotImplemented) || (xfrResponse.RCODE == DnsResponseCode.Refused)))
                     {


### PR DESCRIPTION
When a secondary zone attempts IXFR, the code already falls back to AXFR if the primary responds with `RCODE=NotImplemented` or `RCODE=Refused`. However, if the request fails at the transport layer (timeout, connection reset, etc.) the exception propagates to the outer catch block and the refresh is abandoned with no AXFR fallback.

**Scenario where this surfaces:**
- Primary zone is DNSSEC-signed and receives frequent record changes (e.g. DHCP-driven DDNS)
- DNSSEC auto-signing causes rapid serial increments, building a large IXFR history
- Secondary falls behind after a transient network event
- Primary must build and stream a large IXFR diff; QUIC stream times out before it completes
- Secondary logs `DNS Server failed to refresh` and keeps retrying IXFR, falling further behind
- Manual resync (which forces AXFR) succeeds immediately

**Fix:**
Wrap the two resolve calls in a `try/catch when (doIXFR)` inside the loop. If the transport throws while attempting IXFR, fall back to AXFR. If AXFR also fails, the exception propagates normally to the outer catch — no change to existing behaviour, no infinite loop risk.