### PR TITLE
Alpine Linux support for Technitium DNS

### DIFF
--- a/DnsServerApp/install.sh
+++ b/DnsServerApp/install.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+cleanup() {
+    # On Alpine Linux get rid of virtual packages installed in support for this script.
+    # If none was installed, just fail silently
+    if $alpineLinux
+    then
+        apk del .deps > /dev/null 2>&1
+    fi
+}
+
+trap cleanup INT TERM EXIT
+
 dotnetDir="/opt/dotnet"
 dotnetVersion="10.0"
 dotnetRuntime="Microsoft.AspNetCore.App 10.0."
@@ -31,7 +42,30 @@ mkdir -p $dnsConfig
 
 echo "" > $installLog
 
-if dotnet --list-runtimes 2> /dev/null | grep -q "$dotnetRuntime"; 
+if command -v apk >/dev/null 2>&1
+then
+    # On Alpine Linux we need bash & curl to install dotnet
+    alpineLinux=true
+    apk update >> $installLog 2>&1
+    deps=""
+    # Check for bash
+    if ! command -v bash >/dev/null 2>&1; then
+        deps="$deps bash"
+    fi
+    # Check for curl
+    if ! command -v curl >/dev/null 2>&1; then
+        deps="$deps curl"
+    fi
+    # Install missing packages, if any
+    if [ -n "$deps" ]; then
+        echo "Installing packages needed for the installation: $deps"
+        apk add --no-cache --virtual .deps $deps
+    fi
+else
+    alpineLinux=false
+fi
+
+if dotnet --list-runtimes 2> /dev/null | grep -q "$dotnetRuntime";
 then
     dotnetFound="yes"
 else
@@ -53,12 +87,18 @@ else
 
     curl -sSL $dotnetUrl | bash /dev/stdin -c $dotnetVersion --runtime aspnetcore --no-path --install-dir $dotnetDir --verbose >> $installLog 2>&1
 
+    # On Alpine Linux dotnet requires libstdc++
+    if $alpineLinux; then
+        echo "Installing ASP.NET Core Runtime dependencies..."
+        apk add --no-cache libstdc++ >> $installLog 2>&1
+    fi
+
     if [ ! -f "/usr/bin/dotnet" ]
     then
         ln -s $dotnetDir/dotnet /usr/bin >> $installLog 2>&1
     fi
 
-    if dotnet --list-runtimes 2> /dev/null | grep -q "$dotnetRuntime"; 
+    if dotnet --list-runtimes 2> /dev/null | grep -q "$dotnetRuntime";
     then
         if [ "$dotnetUpdate" = "yes" ]
         then
@@ -170,49 +210,88 @@ fi
 
 echo ""
 
-if ! [ "$(ps --no-headers -o comm 1 | tr -d '\n')" = "systemd" ] 
+installed=true
+if ! $alpineLinux
 then
-    echo "Failed to install Technitium DNS Server: systemd was not detected."
-    echo "Please read the 'Installing DNS Server Manually' section in this blog post to understand how to manually install the DNS server on your distro: https://blog.technitium.com/2017/11/running-dns-server-on-ubuntu-linux.html"
-    exit 1
-fi
-
-if [ -f "/etc/systemd/system/dns.service" ]
-then
-    echo "Restarting systemd service..."
-    systemctl restart dns.service >> $installLog 2>&1
-else
-    mkdir -p $dnsLog
-    
-    echo "Configuring user and permissions..."
-    useradd --system -M --shell /usr/sbin/nologin $serviceUser >> $installLog 2>&1
-    chown -R $serviceUser:$serviceUser $dnsDir $dnsConfig $dnsLog >> $installLog 2>&1
-
-    echo "Configuring systemd service..."
-    cp $dnsDir/systemd.service /etc/systemd/system/dns.service
-    systemctl enable dns.service >> $installLog 2>&1
-
-    systemctl stop systemd-resolved >> $installLog 2>&1
-    systemctl disable systemd-resolved >> $installLog 2>&1
-
-    systemctl start dns.service >> $installLog 2>&1
-
-    if [ -f "/etc/NetworkManager/NetworkManager.conf" ]
+    if ! [ "$(ps --no-headers -o comm 1 | tr -d '\n')" = "systemd" ]
     then
-        currentVal=$(grep -F "dns=" /etc/NetworkManager/NetworkManager.conf)
+        expected=systemd
+        installed=false
+    else
+        if [ -f "/etc/systemd/system/dns.service" ]
+        then
+            echo "Restarting systemd service..."
+            systemctl restart dns.service >> $installLog 2>&1
+        else
+            mkdir -p $dnsLog
 
-        if [ "$currentVal" = "" ]
-        then
-            printf "\n[main]\ndns=none\n" >> /etc/NetworkManager/NetworkManager.conf 2>> $installLog
-        elif [ "$currentVal" != "dns=none" ]
-        then
-            sed -i "s/$currentVal/dns=none/g" /etc/NetworkManager/NetworkManager.conf 2>> $installLog
+            echo "Configuring user and permissions..."
+            useradd --system -M --shell /usr/sbin/nologin $serviceUser >> $installLog 2>&1
+            chown -R $serviceUser:$serviceUser $dnsDir $dnsConfig $dnsLog >> $installLog 2>&1
+
+            echo "Configuring systemd service..."
+            cp $dnsDir/systemd.service /etc/systemd/system/dns.service
+            systemctl enable dns.service >> $installLog 2>&1
+
+            systemctl stop systemd-resolved >> $installLog 2>&1
+            systemctl disable systemd-resolved >> $installLog 2>&1
+
+            systemctl start dns.service >> $installLog 2>&1
+
+            if [ -f "/etc/NetworkManager/NetworkManager.conf" ]
+            then
+                currentVal=$(grep -F "dns=" /etc/NetworkManager/NetworkManager.conf)
+
+                if [ "$currentVal" = "" ]
+                then
+                    printf "\n[main]\ndns=none\n" >> /etc/NetworkManager/NetworkManager.conf 2>> $installLog
+                elif [ "$currentVal" != "dns=none" ]
+                then
+                    sed -i "s/$currentVal/dns=none/g" /etc/NetworkManager/NetworkManager.conf 2>> $installLog
+                fi
+            fi
+
+            cp -a /etc/resolv.conf $dnsDir/resolv.conf.bak >> $installLog 2>&1
+            rm /etc/resolv.conf >> $installLog 2>&1
+            printf "# Generated by Technitium DNS Server Installer\n\nnameserver 127.0.0.1\n" > /etc/resolv.conf 2>> $installLog
         fi
     fi
+else
+    if [ ! -x "/sbin/rc-service" ]
+    then
+        expected=OpenRC
+        installed=false
+    else
+        if [ -f "/etc/init.d/dns" ]
+        then
+            echo "Restarting OpenRC service..."
+            rc-service dns stop >> $installLog 2>&1
+            rc-service dns start >> $installLog 2>&1
+        else
+            mkdir -p $dnsLog
 
-    cp -a /etc/resolv.conf $dnsDir/resolv.conf.bak >> $installLog 2>&1
-    rm /etc/resolv.conf >> $installLog 2>&1
-    printf "# Generated by Technitium DNS Server Installer\n\nnameserver 127.0.0.1\n" > /etc/resolv.conf 2>> $installLog
+            echo "Configuring user and permissions..."
+            adduser -H -S -s /bin/false $serviceUser >> $installLog 2>&1
+            chown -R $serviceUser:$serviceUser $dnsDir $dnsConfig $dnsLog >> $installLog 2>&1
+
+            echo "Configuring OpenRC service..."
+            cat $dnsDir/openrc.service | sed -e "s/serviceUser/$serviceUser/g" > /etc/init.d/dns
+            chmod +x /etc/init.d/dns
+            rc-update add dns >> $installLog 2>&1
+            rc-service dns start >> $installLog 2>&1
+
+            cp -a /etc/resolv.conf $dnsDir/resolv.conf.bak >> $installLog 2>&1
+            rm /etc/resolv.conf >> $installLog 2>&1
+            echo -e "# Generated by Technitium DNS Server Installer\n\nnameserver 127.0.0.1" > /etc/resolv.conf 2>> $installLog
+        fi
+    fi
+fi
+
+if ! $installed
+then
+   echo "Failed to install Technitium DNS Server: $expected was not detected."
+   echo "Please read the 'Installing DNS Server Manually' section in this blog post to understand how to manually install the DNS server on your distro: https://blog.technitium.com/2017/11/running-dns-server-on-ubuntu-linux.html"
+   exit 1
 fi
 
 echo ""

--- a/DnsServerApp/openrc.service
+++ b/DnsServerApp/openrc.service
@@ -1,0 +1,10 @@
+#!/sbin/openrc-run
+
+name=$RC_SVCNAME
+description="Technitium DNS Server"
+supervisor="supervise-daemon"
+command="/usr/bin/dotnet"
+command_args="/opt/technitium/dns/DnsServerApp.dll /etc/dns"
+supervise_daemon_args=" -d /opt/technitium/dns"
+command_user=serviceUser:serviceUser
+capabilities="^cap_net_bind_service"


### PR DESCRIPTION
I have extended the Technitium DNS installation script to properly install on Alpine Linux. The script now takes care of installing the binaries needed just for the installation, as well as the libstdc++ package required by Microsoft .NET (the dotnet installation scripts does not check if it is missing)

I also provide the `openrc.service` file to run Technitium DNS as a service. The installation script now checks not only for systemd, but also for OpenRC.

The code would need some more cleanup, but I tried to avoid bigger code reshuffles so that the PR has a better chance to be adopted.

If this PR is accepted, [this blog post](https://blog.technitium.com/2017/11/running-dns-server-on-ubuntu-linux.html) should be updated stating the now supported Alpine Linux.

I have tested the script on Alpine Linux 3.20-3.23.

PS: This PR replace the previous #1461, as per request from the maintainer.