### PR TITLE
Added missing technitium library build step

### DIFF
--- a/build.md
+++ b/build.md
@@ -52,6 +52,7 @@ git clone --depth 1 https://github.com/TechnitiumSoftware/DnsServer.git DnsServe
 ```
 dotnet build TechnitiumLibrary/TechnitiumLibrary.ByteTree/TechnitiumLibrary.ByteTree.csproj -c Release
 dotnet build TechnitiumLibrary/TechnitiumLibrary.Net/TechnitiumLibrary.Net.csproj -c Release
+dotnet build TechnitiumLibrary/TechnitiumLibrary.Net.Mail/TechnitiumLibrary.Net.Mail.csproj -c Release
 dotnet build TechnitiumLibrary/TechnitiumLibrary.Security.OTP/TechnitiumLibrary.Security.OTP.csproj -c Release
 ```
 


### PR DESCRIPTION
I wanted to experiment with the DnsServer source code and followed the build instructions. However one app used the TechnitiumLibrary.Net.Mail package required for building.

 This PR just adds this to the instructions.