### PR TITLE
BlockPageApp: fix three bugs in Online Certificate Signing

### DIFF
--- a/Apps/BlockPageApp/App.cs
+++ b/Apps/BlockPageApp/App.cs
@@ -337,6 +337,19 @@ namespace BlockPage
                 _webServer.UseResponseCompression();
 
                 _webServer.UseDefaultFiles();
+
+                if (_serveBlockPageFromWebServerRoot)
+                {
+                    _webServer.Use(async (HttpContext context, RequestDelegate next) =>
+                    {
+                        if (HttpMethods.IsGet(context.Request.Method) &&
+                            (context.Request.Path == "/" || context.Request.Path == "/index.html"))
+                            await ServeDefaultPageAsync(context, next);
+                        else
+                            await next(context);
+                    });
+                }
+
                 _webServer.UseStaticFiles(new StaticFileOptions()
                 {
                     OnPrepareResponse = delegate (StaticFileResponseContext ctx)
@@ -474,7 +487,10 @@ namespace BlockPage
 
             private async Task ServeDefaultPageAsync(HttpContext context, RequestDelegate next)
             {
-                string blockPageContent = _blockPageContent!;
+                string indexFilePath = Path.Combine(_webServerRootPath!, "index.html");
+                string blockPageContent = (_serveBlockPageFromWebServerRoot && File.Exists(indexFilePath))
+                    ? await File.ReadAllTextAsync(indexFilePath)
+                    : _blockPageContent!;
 
                 if (_includeBlockingInfo)
                 {

--- a/Apps/BlockPageApp/App.cs
+++ b/Apps/BlockPageApp/App.cs
@@ -271,6 +271,8 @@ namespace BlockPage
                                             {
                                                 if (!_certCache.TryGetValue(sniDomain, out SslServerAuthenticationOptions? sslServerAuthenticationOptions))
                                                 {
+                                                    X509Certificate2 caCert = _sslServerAuthenticationOptions!.ServerCertificateContext!.TargetCertificate;
+
                                                     RSA rsa = RSA.Create(2048);
                                                     CertificateRequest req = new CertificateRequest("cn=" + sniDomain, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 
@@ -286,13 +288,24 @@ namespace BlockPage
                                                     Span<byte> serial = stackalloc byte[16];
                                                     RandomNumberGenerator.Fill(serial);
 
-                                                    X509Certificate2 newCert = req.Create(_sslServerAuthenticationOptions!.ServerCertificateContext!.TargetCertificate, DateTime.UtcNow.AddMinutes(-30), DateTime.UtcNow.AddDays(7), serial);
+                                                    DateTimeOffset certNotBefore = DateTimeOffset.UtcNow.AddMinutes(-30);
+                                                    if (certNotBefore < caCert.NotBefore)
+                                                        certNotBefore = caCert.NotBefore;
+
+                                                    X509SignatureGenerator generator;
+                                                    ECDsa? ecdsa = caCert.GetECDsaPrivateKey();
+                                                    if (ecdsa is not null)
+                                                        generator = X509SignatureGenerator.CreateForECDsa(ecdsa);
+                                                    else
+                                                        generator = X509SignatureGenerator.CreateForRSA(caCert.GetRSAPrivateKey()!, RSASignaturePadding.Pkcs1);
+
+                                                    X509Certificate2 newCert = req.Create(caCert.SubjectName, generator, certNotBefore, DateTimeOffset.UtcNow.AddDays(7), serial.ToArray());
                                                     newCert = newCert.CopyWithPrivateKey(rsa);
                                                     newCert = X509CertificateLoader.LoadPkcs12(newCert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.PersistKeySet);
 
                                                     sslServerAuthenticationOptions = new SslServerAuthenticationOptions()
                                                     {
-                                                        ServerCertificateContext = SslStreamCertificateContext.Create(newCert, null, false)
+                                                        ServerCertificateContext = SslStreamCertificateContext.Create(newCert, new X509Certificate2Collection(caCert), false)
                                                     };
 
                                                     _certCache[sniDomain] = sslServerAuthenticationOptions;

--- a/Apps/BlockPageApp/wwwroot/index.html
+++ b/Apps/BlockPageApp/wwwroot/index.html
@@ -5,5 +5,6 @@
 <body>
     <h1>Website Blocked</h1>
     <p>This website has been blocked by your network administrator.</p>
+{BLOCKING-INFO}
 </body>
 </html>


### PR DESCRIPTION
Fixes the three bugs reported in #1896.

**Missing intermediate certificate in TLS handshake**

When a per-domain cert is generated and cached, the `SslStreamCertificateContext` was created with `null` for the additional certificates, meaning the signing CA was never included in the TLS handshake. Clients that did not already have the CA cached would get a chain validation error. The CA cert is now passed as the additional certs collection so browsers receive the full chain.

**`notBefore` not clamped to CA own `NotBefore`**

The code backdates generated certs by 30 minutes for clock skew tolerance. If the CA cert was created within the last 30 minutes, this fell before the CA own `NotBefore` and .NET threw `ArgumentException: The requested notBefore value is earlier than issuerCertificate.NotBefore`. The exception was caught and logged but the app silently fell back to serving the CA cert directly as the server cert for up to 30 minutes. `certNotBefore` is now clamped to `Max(UtcNow - 30min, caCert.NotBefore)`.

**ECC and ECDSA CA certs not supported**

`CertificateRequest.Create(X509Certificate2, ...)` requires the CA key algorithm to match the CSR algorithm. Since the CSR is always RSA 2048, any ECC CA failed with `ArgumentException: The issuer certificate public key algorithm does not match`. The `X509SignatureGenerator` overload is now used, which supports both RSA and ECC CA certs.

Both the self-signed cert path (`webServerUseSelfSignedTlsCertificate: true`) and the custom CA path are covered by these changes.