### PR TITLE
BlockPageApp/IDnsServer: fix wrong group shown in blocking info

### DIFF
--- a/Apps/BlockPageApp/App.cs
+++ b/Apps/BlockPageApp/App.cs
@@ -473,7 +473,8 @@ namespace BlockPage
                         if (host is not null)
                         {
                             DnsDatagram dnsRequest = new DnsDatagram(0, false, DnsOpcode.StandardQuery, false, false, true, false, false, false, DnsResponseCode.NoError, [new DnsQuestionRecord(host, DnsResourceRecordType.A, DnsClass.IN)], udpPayloadSize: DnsDatagram.EDNS_DEFAULT_UDP_PAYLOAD_SIZE);
-                            DnsDatagram dnsResponse = await _dnsServer.DirectQueryAsync(dnsRequest, 500);
+                            System.Net.IPEndPoint clientEndPoint = context.Connection.RemoteIpAddress is null ? new System.Net.IPEndPoint(System.Net.IPAddress.Any, 0) : new System.Net.IPEndPoint(context.Connection.RemoteIpAddress, context.Connection.RemotePort);
+                            DnsDatagram dnsResponse = await _dnsServer.DirectQueryAsync(dnsRequest, clientEndPoint, 500);
 
                             List<EDnsExtendedDnsErrorOptionData> options = new List<EDnsExtendedDnsErrorOptionData>();
 

--- a/DnsServerCore.ApplicationCommon/IDnsServer.cs
+++ b/DnsServerCore.ApplicationCommon/IDnsServer.cs
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Net;
 using System.Net.Mail;
 using System.Threading;
 using System.Threading.Tasks;
@@ -50,6 +51,17 @@ namespace DnsServerCore.ApplicationCommon
         /// <returns>The DNS response for the DNS query.</returns>
         /// <exception cref="TimeoutException">When request times out.</exception>
         Task<DnsDatagram> DirectQueryAsync(DnsDatagram request, int timeout = 4000, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Allows querying the DNS server core directly on behalf of a specific client endpoint. This overload passes the supplied <paramref name="remoteEndPoint"/> through the full query pipeline, allowing DNS Apps that perform client-based group mapping (such as the Advanced Blocking App) to apply the correct policy for the originating client rather than treating the query as originating from 0.0.0.0. The request wont be routed to any of the installed DNS Apps except for processing APP records. The request and its response are not counted in any stats or logged.
+        /// </summary>
+        /// <param name="request">The DNS request to query.</param>
+        /// <param name="remoteEndPoint">The client endpoint to present to the query pipeline.</param>
+        /// <param name="timeout">The timeout value in milliseconds to wait for response.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>The DNS response for the DNS query.</returns>
+        /// <exception cref="TimeoutException">When request times out.</exception>
+        Task<DnsDatagram> DirectQueryAsync(DnsDatagram request, IPEndPoint remoteEndPoint, int timeout = 4000, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Writes a log entry to the DNS server log file.

--- a/DnsServerCore/Dns/Applications/InternalDnsServer.cs
+++ b/DnsServerCore/Dns/Applications/InternalDnsServer.cs
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using DnsServerCore.ApplicationCommon;
 using System;
+using System.Net;
 using System.Net.Mail;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,6 +61,11 @@ namespace DnsServerCore.Dns.Applications
         public Task<DnsDatagram> DirectQueryAsync(DnsDatagram request, int timeout = 4000, CancellationToken cancellationToken = default)
         {
             return _dnsServer.DirectQueryAsync(request, timeout, true, cancellationToken);
+        }
+
+        public Task<DnsDatagram> DirectQueryAsync(DnsDatagram request, IPEndPoint remoteEndPoint, int timeout = 4000, CancellationToken cancellationToken = default)
+        {
+            return _dnsServer.DirectQueryAsync(request, remoteEndPoint, timeout, true, cancellationToken);
         }
 
         public Task<DnsDatagram> ResolveAsync(DnsQuestionRecord question, CancellationToken cancellationToken = default)

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -6954,6 +6954,14 @@ namespace DnsServerCore.Dns
             }, timeout, cancellationToken);
         }
 
+        public Task<DnsDatagram> DirectQueryAsync(DnsDatagram request, IPEndPoint remoteEndPoint, int timeout = 4000, bool skipDnsAppAuthoritativeRequestHandlers = false, CancellationToken cancellationToken = default)
+        {
+            return TechnitiumLibrary.TaskExtensions.TimeoutAsync(delegate (CancellationToken cancellationToken1)
+            {
+                return ProcessQueryAsync(request, remoteEndPoint, DnsTransportProtocol.Tcp, true, skipDnsAppAuthoritativeRequestHandlers, timeout, null);
+            }, timeout, cancellationToken);
+        }
+
         Task<DnsDatagram> IDnsClient.ResolveAsync(DnsQuestionRecord question, CancellationToken cancellationToken)
         {
             return DirectQueryAsync(question, cancellationToken: cancellationToken);


### PR DESCRIPTION
## Problem

When a client hits the block page, the Block Page App makes a secondary DNS query to retrieve the EDE blocking info to display on the page (group name, blocklist URL, etc.). This re-query goes through `DirectQueryAsync`, which hardcodes `IPENDPOINT_ANY_0` (0.0.0.0) as the remote endpoint.

The Advanced Blocking App's `networkGroupMap` matches 0.0.0.0 against the catch-all entry, so the blocking info re-query always returns the catch-all group's response. The group name shown on the block page is therefore always the catch-all group, even when the client belongs to a more specific group and was correctly blocked by that group's rules.

The blocking itself is unaffected — the original DNS query from the client carries the real IP and is routed correctly. Only the secondary re-query used to populate the block page display was wrong.

## Fix

Added a new `IDnsServer.DirectQueryAsync(DnsDatagram, IPEndPoint, int, CancellationToken)` overload that threads a caller-supplied endpoint through to `ProcessQueryAsync`, with matching implementations in `DnsServer` and `InternalDnsServer`.

Updated `BlockPageApp` to pass the real client `IPEndPoint` from the HTTP connection when making the blocking info re-query, so the Advanced Blocking App (and any similar app using client-based group mapping) returns the response for the correct group.

## Changes

- `DnsServerCore.ApplicationCommon/IDnsServer.cs` — new `DirectQueryAsync` overload accepting `IPEndPoint`
- `DnsServerCore/Dns/DnsServer.cs` — implementation of the new overload
- `DnsServerCore/Dns/Applications/InternalDnsServer.cs` — forwards the new overload to `DnsServer`
- `Apps/BlockPageApp/App.cs` — passes real client endpoint for the blocking info re-query