### PR TITLE
fix: update cluster options API for heartbeat retry,

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -7521,6 +7521,7 @@ WHERE:
 - `heartbeatRetryIntervalSeconds` (optional): The interval in seconds in which the DNS server must retry the state refresh process for all nodes in case of a failure. The valid range is `10`-`300` and default value is `10`.
 - `configRefreshIntervalSeconds` (optional): The interval in seconds in which the DNS server must refresh the configuration from the Primary node. The valid range is `30`-`3600` and default value is `900`.
 - `configRetryIntervalSeconds` (optional): The interval in seconds in which the DNS server must retry the configuration refresh process for the Primary node in case of a failure. The valid range is `30`-`3600` and default value is `60`.
+- `ignoreCertificateErrors` (optional): Set to `true` to skip TLS certificate validation on heartbeat and config-refresh calls between Cluster nodes. This is intended for deployments where nodes use self-signed TLS certificates on a private network. The flag defaults to whatever was set during `initJoin` and persists across restarts. Set to `false` after migrating all nodes to PKI-trusted certificates.
 
 RESPONSE:
 ```
@@ -7534,6 +7535,7 @@ RESPONSE:
 		"heartbeatRetryIntervalSeconds": 10,
 		"configRefreshIntervalSeconds": 900,
 		"configRetryIntervalSeconds": 60,
+		"ignoreCertificateErrors": false,
 		"configLastSynced": "2025-09-26T12:30:16Z",
 		"nodes": [
 			{
@@ -7588,7 +7590,7 @@ WHERE:
 - `secondaryNodeIpAddresses`: A comma separated list of IP addresses of this DNS server that will be accessible by all other DNS Server nodes in the Cluster.
 - `primaryNodeUrl`: The web service HTTPS URL of the Primary node in the Cluster.
 - `primaryNodeIpAddress` (optional): The IP address of the Primary node in the Cluster. When unspecified, domain name in the Primary node URL will be resolved and used.
-- `ignoreCertificateErrors` (optional): Set to `true` only when you know that the Primary node web service is using a self-signed TLS certificate and is reachable on a private network. 
+- `ignoreCertificateErrors` (optional): Set to `true` only when you know that the Primary node web service is using a self-signed TLS certificate and is reachable on a private network. The value is persisted as the Cluster-wide default and continues to apply to subsequent heartbeat and config-refresh calls between nodes. It can be toggled later via the `Set Cluster Options` API once all nodes use PKI-trusted certificates. 
 - `primaryNodeUsername`: The username of an administrator on the Primary node in the Cluster.
 - `primaryNodePassword`: The password of the administrator user specified above.
 - `primaryNodeTotp` (optional): The the 6-digit code you see in your authenticator app for the administrator user specified above. Only to be used if the user has 2FA enabled.

--- a/DnsServerCore/Cluster/ClusterManager.cs
+++ b/DnsServerCore/Cluster/ClusterManager.cs
@@ -58,6 +58,7 @@ namespace DnsServerCore.Cluster
         ushort _heartbeatRetryIntervalSeconds;
         ushort _configRefreshIntervalSeconds;
         ushort _configRetryIntervalSeconds;
+        bool _ignoreCertificateErrors;
         DateTime _configLastSynced;
 
         IReadOnlyDictionary<int, ClusterNode> _clusterNodes;
@@ -368,11 +369,16 @@ namespace DnsServerCore.Cluster
             switch (version)
             {
                 case 1:
+                case 2:
                     _clusterDomain = bR.ReadString();
                     _heartbeatRefreshIntervalSeconds = bR.ReadUInt16();
                     _heartbeatRetryIntervalSeconds = bR.ReadUInt16();
                     _configRefreshIntervalSeconds = bR.ReadUInt16();
                     _configRetryIntervalSeconds = bR.ReadUInt16();
+
+                    if (version >= 2)
+                        _ignoreCertificateErrors = bR.ReadBoolean();
+
                     _configLastSynced = s.ReadDateTime();
 
                     Dictionary<int, ClusterNode> clusterNodes = null;
@@ -402,13 +408,14 @@ namespace DnsServerCore.Cluster
             BinaryWriter bW = new BinaryWriter(s);
 
             bW.Write(Encoding.ASCII.GetBytes("CL")); //format
-            bW.Write((byte)1); //version
+            bW.Write((byte)2); //version
 
             bW.Write(_clusterDomain);
             bW.Write(_heartbeatRefreshIntervalSeconds);
             bW.Write(_heartbeatRetryIntervalSeconds);
             bW.Write(_configRefreshIntervalSeconds);
             bW.Write(_configRetryIntervalSeconds);
+            bW.Write(_ignoreCertificateErrors);
             s.WriteDateTime(_configLastSynced);
 
             IReadOnlyDictionary<int, ClusterNode> clusterNodes = _clusterNodes;
@@ -462,6 +469,21 @@ namespace DnsServerCore.Cluster
                         continue;
 
                     clusterNode.Value.UpdateHeartbeatTimer();
+                }
+            }
+        }
+
+        private void ResetApiClientForAllClusterNodes()
+        {
+            IReadOnlyDictionary<int, ClusterNode> clusterNodes = _clusterNodes;
+            if (clusterNodes is not null)
+            {
+                foreach (KeyValuePair<int, ClusterNode> clusterNode in clusterNodes)
+                {
+                    if (clusterNode.Value.State == ClusterNodeState.Self)
+                        continue;
+
+                    clusterNode.Value.ResetApiClient();
                 }
             }
         }
@@ -896,7 +918,7 @@ namespace DnsServerCore.Cluster
                                                     includeZones: includeZones);
         }
 
-        public void UpdateClusterOptions(ushort heartbeatRefreshIntervalSeconds, ushort heartbeatRetryIntervalSeconds, ushort configRefreshIntervalSeconds, ushort configRetryIntervalSeconds)
+        public void UpdateClusterOptions(ushort heartbeatRefreshIntervalSeconds, ushort heartbeatRetryIntervalSeconds, ushort configRefreshIntervalSeconds, ushort configRetryIntervalSeconds, bool ignoreCertificateErrors)
         {
             if (!ClusterInitialized)
                 throw new DnsServerException("Failed to update Cluster options: the Cluster is not initialized.");
@@ -920,6 +942,7 @@ namespace DnsServerCore.Cluster
                 throw new ArgumentException("Failed to update Cluster options: The config refresh interval must be greater than the heartbeat refresh interval.");
 
             bool changed = false;
+            bool ignoreCertificateErrorsChanged = false;
 
             if (_heartbeatRefreshIntervalSeconds != heartbeatRefreshIntervalSeconds)
             {
@@ -945,10 +968,21 @@ namespace DnsServerCore.Cluster
                 changed = true;
             }
 
+            if (_ignoreCertificateErrors != ignoreCertificateErrors)
+            {
+                _ignoreCertificateErrors = ignoreCertificateErrors;
+                changed = true;
+                ignoreCertificateErrorsChanged = true;
+            }
+
             if (changed)
             {
                 //apply new interval to all cluster nodes immediately
                 UpdateHeartbeatTimerForAllClusterNodes();
+
+                //rebuild cached HttpApiClient on all nodes so the new TLS validation policy takes effect
+                if (ignoreCertificateErrorsChanged)
+                    ResetApiClientForAllClusterNodes();
 
                 //save changes
                 SaveConfigFile();
@@ -1413,6 +1447,7 @@ namespace DnsServerCore.Cluster
                 _heartbeatRetryIntervalSeconds = primaryNodeClusterInfo.HeartbeatRetryIntervalSeconds;
                 _configRefreshIntervalSeconds = primaryNodeClusterInfo.ConfigRefreshIntervalSeconds;
                 _configRetryIntervalSeconds = primaryNodeClusterInfo.ConfigRetryIntervalSeconds;
+                _ignoreCertificateErrors = ignoreCertificateErrors;
 
                 try
                 {
@@ -2213,6 +2248,9 @@ namespace DnsServerCore.Cluster
 
         public ushort ConfigRetryIntervalSeconds
         { get { return _configRetryIntervalSeconds; } }
+
+        public bool IgnoreCertificateErrors
+        { get { return _ignoreCertificateErrors; } }
 
         public DateTime ConfigLastSynced
         { get { return _configLastSynced; } }

--- a/DnsServerCore/Cluster/ClusterNode.cs
+++ b/DnsServerCore/Cluster/ClusterNode.cs
@@ -193,7 +193,7 @@ namespace DnsServerCore.Cluster
 
             if (_apiClient is null)
             {
-                _apiClient = new HttpApiClient(_url, _clusterManager.DnsWebService.DnsServer.Proxy, _clusterManager.DnsWebService.DnsServer.IPv6Mode, false, new InternalDnsClient(_clusterManager.DnsWebService.DnsServer, this));
+                _apiClient = new HttpApiClient(_url, _clusterManager.DnsWebService.DnsServer.Proxy, _clusterManager.DnsWebService.DnsServer.IPv6Mode, _clusterManager.IgnoreCertificateErrors, new InternalDnsClient(_clusterManager.DnsWebService.DnsServer, this));
 
                 UserSession clusterApiToken = null;
 
@@ -318,6 +318,15 @@ namespace DnsServerCore.Cluster
             }
 
             if (changed && (_apiClient is not null))
+            {
+                _apiClient.Dispose();
+                _apiClient = null;
+            }
+        }
+
+        public void ResetApiClient()
+        {
+            if (_apiClient is not null)
             {
                 _apiClient.Dispose();
                 _apiClient = null;

--- a/DnsServerCore/WebServiceClusterApi.cs
+++ b/DnsServerCore/WebServiceClusterApi.cs
@@ -70,6 +70,7 @@ namespace DnsServerCore
                     jsonWriter.WriteNumber("heartbeatRetryIntervalSeconds", _dnsWebService._clusterManager.HeartBeatRetryIntervalSeconds);
                     jsonWriter.WriteNumber("configRefreshIntervalSeconds", _dnsWebService._clusterManager.ConfigRefreshIntervalSeconds);
                     jsonWriter.WriteNumber("configRetryIntervalSeconds", _dnsWebService._clusterManager.ConfigRetryIntervalSeconds);
+                    jsonWriter.WriteBoolean("ignoreCertificateErrors", _dnsWebService._clusterManager.IgnoreCertificateErrors);
 
                     WriteClusterNodes(jsonWriter);
                 }
@@ -437,8 +438,9 @@ namespace DnsServerCore
                 ushort heartbeatRetryIntervalSeconds = request.GetQueryOrForm("heartbeatRetryIntervalSeconds", ushort.Parse, _dnsWebService._clusterManager.HeartBeatRetryIntervalSeconds);
                 ushort configRefreshIntervalSeconds = request.GetQueryOrForm("configRefreshIntervalSeconds", ushort.Parse, _dnsWebService._clusterManager.ConfigRefreshIntervalSeconds);
                 ushort configRetryIntervalSeconds = request.GetQueryOrForm("configRetryIntervalSeconds", ushort.Parse, _dnsWebService._clusterManager.ConfigRetryIntervalSeconds);
+                bool ignoreCertificateErrors = request.GetQueryOrForm("ignoreCertificateErrors", bool.Parse, _dnsWebService._clusterManager.IgnoreCertificateErrors);
 
-                _dnsWebService._clusterManager.UpdateClusterOptions(heartbeatRefreshIntervalSeconds, heartbeatRetryIntervalSeconds, configRefreshIntervalSeconds, configRetryIntervalSeconds);
+                _dnsWebService._clusterManager.UpdateClusterOptions(heartbeatRefreshIntervalSeconds, heartbeatRetryIntervalSeconds, configRefreshIntervalSeconds, configRetryIntervalSeconds, ignoreCertificateErrors);
 
                 _dnsWebService._log.Write(_dnsWebService.GetRemoteEndPoint(context), "[" + sessionUser.Username + "] Cluster (" + _dnsWebService._clusterManager.ClusterDomain + ") options were updated successfully.");
 

--- a/DnsServerCore/www/index.html
+++ b/DnsServerCore/www/index.html
@@ -7048,6 +7048,14 @@ MII...
                                     <div style="padding-top: 5px;">The interval in seconds in which the DNS Server must retry the configuration refresh process for the Primary node in case of a failure.</div>
                                 </div>
                             </div>
+
+                            <div class="form-group">
+                                <label class="col-sm-4 control-label">Ignore Certificate Errors</label>
+                                <div class="col-sm-7">
+                                    <div class="checkbox" style="margin: 0px;"><label><input id="chkClusterOptionsIgnoreCertificateErrors" type="checkbox"> Skip TLS certificate validation for Cluster heartbeat and config-refresh calls between nodes.</label></div>
+                                    <div style="padding-top: 5px;">Enable this only when nodes use self-signed TLS certificates on a private network. Disable after migrating all nodes to PKI-trusted certificates.</div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/DnsServerCore/www/js/cluster.js
+++ b/DnsServerCore/www/js/cluster.js
@@ -827,6 +827,7 @@ function showClusterOptionsModal() {
             $("#txtClusterOptionsHeartbeatRetryIntervalSeconds").attr("disabled", !isPrimaryNode);
             $("#txtClusterOptionsConfigRefreshIntervalSeconds").attr("disabled", !isPrimaryNode);
             $("#txtClusterOptionsConfigRetryIntervalSeconds").attr("disabled", !isPrimaryNode);
+            $("#chkClusterOptionsIgnoreCertificateErrors").attr("disabled", !isPrimaryNode);
 
             if (isPrimaryNode)
                 $("#btnClusterOptionsSave").show();
@@ -838,6 +839,7 @@ function showClusterOptionsModal() {
             $("#txtClusterOptionsHeartbeatRetryIntervalSeconds").val(responseJSON.response.heartbeatRetryIntervalSeconds);
             $("#txtClusterOptionsConfigRefreshIntervalSeconds").val(responseJSON.response.configRefreshIntervalSeconds);
             $("#txtClusterOptionsConfigRetryIntervalSeconds").val(responseJSON.response.configRetryIntervalSeconds);
+            $("#chkClusterOptionsIgnoreCertificateErrors").prop("checked", responseJSON.response.ignoreCertificateErrors === true);
 
             divClusterOptionsLoader.hide();
             divClusterOptionsView.show();
@@ -886,6 +888,8 @@ function saveClusterOptions(objBtn) {
         return;
     }
 
+    var ignoreCertificateErrors = $("#chkClusterOptionsIgnoreCertificateErrors").prop("checked");
+
     var node = $("#optAdminClusterNode").val();
 
     var btn = $(objBtn);
@@ -894,6 +898,7 @@ function saveClusterOptions(objBtn) {
     HTTPRequest({
         url: "api/admin/cluster/primary/setOptions?heartbeatRefreshIntervalSeconds=" + heartbeatRefreshIntervalSeconds + "&heartbeatRetryIntervalSeconds=" + heartbeatRetryIntervalSeconds
             + "&configRefreshIntervalSeconds=" + configRefreshIntervalSeconds + "&configRetryIntervalSeconds=" + configRetryIntervalSeconds
+            + "&ignoreCertificateErrors=" + ignoreCertificateErrors
             + "&node=" + encodeURIComponent(node),
         token: sessionData.token,
         success: function (responseJSON) {


### PR DESCRIPTION
## Summary

`POST /api/admin/cluster/initJoin` accepts `ignoreCertificateErrors=true`,
which lets a Secondary node bootstrap-join a Primary that is using the
auto-generated self-signed HTTPS certificate (the default for users who
follow the "Initialize New Cluster" wizard without manually configuring a
PKI-trusted cert first).

After the join completes, however, the value of `ignoreCertificateErrors`
is discarded. Every subsequent heartbeat constructs a fresh `HttpApiClient`
with `ignoreCertificateErrors: false` hard-coded, so the heartbeats
immediately fail and the Secondary node reports the Primary as
`Unreachable`. From the Secondary's `/var/log/technitium/dns/*.log`:

```
[2026-05-11 04:59:47 UTC] Heartbeat failed for Primary node 'tech-a.ns.example.local (10.102.8.71)'.
System.Net.Http.HttpRequestException: The remote certificate is invalid because of errors
  in the certificate chain: UntrustedRoot (tech-a.ns.example.local:53443)
 ---> System.Security.Authentication.AuthenticationException: The remote certificate is
       invalid because of errors in the certificate chain: UntrustedRoot
   at System.Net.Security.SslStream.SendAuthResetSignal(...)
   ...
   at DnsServerCore.HttpApi.HttpApiClient.GetClusterStateAsync(...) in HttpApiClient.cs:line 389
   at DnsServerCore.Cluster.ClusterNode.GetClusterStateAsync(...) in ClusterNode.cs:line 517
   at DnsServerCore.Cluster.ClusterNode.HeartbeatTimerCallbackAsync(...) in ClusterNode.cs:line 224
```

The
[clustering blog post](https://blog.technitium.com/2025/11/understanding-clustering-and-how-to.html)
states that "Once a node joins the Cluster, it uses DANE-EE for server
authentication," but in practice the heartbeat path goes through plain
`SslStream` PKIX validation against the system trust store; the
self-signed cert (or, more generally, any non-publicly-trusted cert)
fails. Users who want clustering "just to work" with the default
auto-generated self-signed cert currently have to manually provision a
PKI-trusted certificate before initialization, which is unfortunate for
private / homelab / Kubernetes deployments where there is no chain back
to a public CA.

## Reproduction

1. Deploy two Technitium 15.1.0 instances on a private network (any two
   Linux hosts, two containers, two pods — anywhere they can reach each
   other on TCP 53443).
2. On node-A: log into the web console, **Administration → Cluster →
   Initialize New Cluster**, accept the auto-generated self-signed cert.
   Note that `clusterInitialized=true` afterwards.
3. On node-B: **Administration → Cluster → Join Cluster** (or call
   `POST /api/admin/cluster/initJoin?...&ignoreCertificateErrors=true`).
   The join completes with `status:ok`. `clusterInitialized=true` on B.
4. From node-A's `/api/admin/cluster/state` you see node-B as
   `state: Connected`.
5. From node-B's `/api/admin/cluster/state` you see node-A as
   `state: Unreachable`, and node-B's DNS server log fills with the
   stack trace above on every heartbeat retry interval.

## Root cause

`DnsServerCore/Cluster/ClusterNode.cs` at the start of every heartbeat /
config-refresh cycle calls `GetApiClient()`. That method builds a fresh
`HttpApiClient` with `ignoreCertificateErrors` hard-coded to `false`:

```csharp
// DnsServerCore/Cluster/ClusterNode.cs
//
// line 189
private HttpApiClient GetApiClient()
{
    if (_state == ClusterNodeState.Self)
        throw new InvalidOperationException();

    if (_apiClient is null)
    {
        _apiClient = new HttpApiClient(
            _url,
            _clusterManager.DnsWebService.DnsServer.Proxy,
            _clusterManager.DnsWebService.DnsServer.IPv6Mode,
            false,                                                // <-- hard-coded ignoreCertificateErrors
            new InternalDnsClient(_clusterManager.DnsWebService.DnsServer, this));
        ...
    }
}
```

For comparison, the bootstrap join *does* honor the flag
(`DnsServerCore/Cluster/ClusterManager.cs:1347`):

```csharp
using HttpApiClient primaryNodeApiClient = new HttpApiClient(
    primaryNodeUrl,
    _dnsWebService.DnsServer.Proxy,
    _dnsWebService.DnsServer.IPv6Mode,
    ignoreCertificateErrors,                                    // <-- threaded through from API param
    new InternalDnsClient(_dnsWebService.DnsServer, primaryNodeIpAddresses),
    TimeSpan.FromSeconds(300));
```

So the user expresses consent to trust self-signed certs at join time,
but that consent is not persisted into cluster state.

## Proposed fix

Persist the flag as a cluster-wide option and use it in
`ClusterNode.GetApiClient()`. Expose it via the existing
`setOptions` endpoint so an operator can toggle it later (e.g., turn it
off after migrating to a PKI-trusted cert).

This is a small, additive change: a new boolean settings field, a new
optional `setOptions` parameter, and one line changed in
`GetApiClient()`. Default value preserves existing strict behavior;
users who explicitly opted into `ignoreCertificateErrors=true` at join
time get the flag propagated automatically.

### Suggested diff (illustrative)

`DnsServerCore/Cluster/ClusterManager.cs`

```diff
 sealed class ClusterManager : IDisposable
 {
     ...
     int _heartbeatRefreshIntervalSeconds = 30;
     int _heartbeatRetryIntervalSeconds = 10;
     int _configRefreshIntervalSeconds = 900;
     int _configRetryIntervalSeconds = 60;
+    bool _ignoreCertificateErrors;
     ...

     public int HeartbeatRefreshIntervalSeconds { ... }
     public int HeartbeatRetryIntervalSeconds  { ... }
     public int ConfigRefreshIntervalSeconds   { ... }
     public int ConfigRetryIntervalSeconds     { ... }
+    public bool IgnoreCertificateErrors
+    {
+        get => _ignoreCertificateErrors;
+        set => _ignoreCertificateErrors = value;
+    }

     // InitializeAndJoinClusterAsync — persist the user's intent:
     public async Task InitializeAndJoinClusterAsync(..., bool ignoreCertificateErrors = false, ...)
     {
         ...
         using HttpApiClient primaryNodeApiClient = new HttpApiClient(
             primaryNodeUrl, ..., ignoreCertificateErrors, ...);
         ...
+        _ignoreCertificateErrors = ignoreCertificateErrors;
         // (persist alongside the other settings during the save call that
         // already happens at the end of this method)
     }
 }
```

`DnsServerCore/Cluster/ClusterNode.cs`

```diff
 private HttpApiClient GetApiClient()
 {
     if (_state == ClusterNodeState.Self)
         throw new InvalidOperationException();

     if (_apiClient is null)
     {
         _apiClient = new HttpApiClient(
             _url,
             _clusterManager.DnsWebService.DnsServer.Proxy,
             _clusterManager.DnsWebService.DnsServer.IPv6Mode,
-            false,
+            _clusterManager.IgnoreCertificateErrors,
             new InternalDnsClient(_clusterManager.DnsWebService.DnsServer, this));
         ...
     }
 }
```

`/api/admin/cluster/primary/setOptions` (web-service handler — wherever
`heartbeatRefreshIntervalSeconds` etc. are read from the query string):

```diff
 if (request.Query.TryGetValue("configRetryIntervalSeconds", out StringValues v))
     ClusterManager.ConfigRetryIntervalSeconds = int.Parse(v);

+if (request.Query.TryGetValue("ignoreCertificateErrors", out StringValues v2))
+    ClusterManager.IgnoreCertificateErrors = bool.Parse(v2);
```

Plus the persistence path that already writes the other cluster options
needs to read/write the new field. (I haven't included those edits here
because the surrounding boilerplate varies by `ClusterManager`'s on-disk
format version.)

### Documentation

Two small doc tweaks:

- `APIDOCS.md` → `Set Cluster Options`: list the new
  `ignoreCertificateErrors` parameter.
- `APIDOCS.md` → `Initialize And Join Cluster`: note that the flag passed
  here is also persisted as the cluster-wide default and will continue
  to apply to heartbeats; it can be flipped off later via `setOptions`
  once a trusted cert is in place.

## Why not implement DANE-EE properly instead?

The blog post implies DANE-EE is in use, and the `clusterCatalog` zone
already holds `TLSA` records keyed off each node. So an alternative,
larger fix is to have the heartbeat client genuinely use DANE-EE
(consult the cluster zone's TLSA record and validate the peer cert
hash against it). That would be the more architecturally correct fix
and would not require any operator opt-in.

The `ignoreCertificateErrors` propagation above is meant to be the
smaller stop-gap that closes the practical gap today while preserving
the option to add DANE-EE later. Happy to revise this PR — or split into
"stop-gap" and "DANE-EE" PRs — based on your preference.

## Testing notes

- Tested by hand on a single-node k0s cluster with two Technitium 15.1.0
  releases deployed side-by-side; the flag was set via
  `initJoin?ignoreCertificateErrors=true` and persisted using a local
  patched build. After the fix, both nodes report each other as
  `state: Connected` and `Heartbeat failed` log entries stop appearing.
- No unit-test changes were needed because `HttpApiClient` already has
  the `ignoreCertificateErrors` constructor parameter exercised by the
  initJoin path.

## Helm-chart context (for reviewers who are curious)

This bug surfaced while building a community Helm chart that runs two
independent Helm releases of Technitium DNS in the same Kubernetes
namespace and clusters them automatically via the existing API (chart:
[helm-technitium-chart](https://github.com/Bugs5382/helm-technitium-chart)). 

Current branch status [here](https://github.com/Bugs5382/helm-technitium-chart/tree/19-feat-v0-2-0)