### PR TITLE
Fix fetching claims from the UserInfo endpoint

### DIFF
--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -44,8 +44,10 @@ using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Quic;
@@ -1732,6 +1734,26 @@ namespace DnsServerCore
 
                             context.HandleResponse();
                             context.Response.Redirect("/#error=" + Uri.EscapeDataString("SSO remote failure. Please contact your administrator."));
+
+                            return Task.CompletedTask;
+                        },
+                        OnUserInformationReceived = delegate (UserInformationReceivedContext context)
+                        {
+                            var userClaims = context.User.RootElement.EnumerateObject().Select(element => element.Name).ToImmutableHashSet();
+                            var knownClaims = context.Options.ClaimActions.Select(action => action.ClaimType).ToImmutableHashSet();
+                            // Only add claim actions for the claims that exist in the user info response and are not already mapped by default
+                            if (userClaims.Contains("email") && !knownClaims.Contains("email")) {
+                                context.Options.ClaimActions.MapUniqueJsonKey("email", "email");
+                            }
+                            if (userClaims.Contains("preferred_username") && !knownClaims.Contains("preferred_username")) {
+                                context.Options.ClaimActions.MapUniqueJsonKey("preferred_username", "preferred_username");
+                            }
+                            if (userClaims.Contains("groups") && !knownClaims.Contains("groups")) {
+                                context.Options.ClaimActions.MapJsonKey("groups", "groups");
+                            }
+                            if (userClaims.Contains("roles") && !knownClaims.Contains("roles")) {
+                                context.Options.ClaimActions.MapJsonKey("roles", "roles");
+                            }
 
                             return Task.CompletedTask;
                         }


### PR DESCRIPTION
I think that I finally found a solution for #1894.

For claims to be extraced from the **UserInfo** response, they must have corresponding `ClaimAction` defined. According to [the documentation][]:

> The ASP.NET Core client app uses the `GetClaimsFromUserInfoEndpoint` property to configure this. One important difference from the first settings, is that you must specify the claims you require using the `MapUniqueJsonKey` method, otherwise only the `name`, `given_name` and `email` standard claims will be available in the client app. The claims included in the id_token are mapped per default.

Any claims that were present only in the **UserInfo** response (which was the case with `preferred_username` and `groups`) and didn't have a corresponding `ClaimAction` were ignored. This also explains why, after creating a user and disabling the workaround, I was still able to login - `name` was still present and used for matching a user.

**PS:** Last time I touched .NET was in university, so I have no idea about the conventions and best practices. Feel free to refactor the code, if needed :smile:

[the documentation]: https://learn.microsoft.com/en-us/aspnet/core/security/authentication/claims?view=aspnetcore-11.0#mapping-claims-using-openid-connect-authentication