### PR TITLE
Convert Splithorizon APP SimpleAddress records on zone transfer

### DIFF
--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -3563,13 +3563,13 @@ namespace DnsServerCore.Dns
             if (request.Question[0].Type == DnsResourceRecordType.IXFR)
             {
                 if ((request.Authority.Count == 1) && (request.Authority[0].Type == DnsResourceRecordType.SOA))
-                    xfrRecords = _authZoneManager.QueryIncrementalZoneTransferRecords(request.Question[0].Name, request.Authority[0]);
+                    xfrRecords = _authZoneManager.QueryIncrementalZoneTransferRecords(request.Question[0].Name, request.Authority[0], remoteEP);
                 else
                     return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.FormatError, request.Question) { Tag = DnsServerResponseType.Authoritative };
             }
             else
             {
-                xfrRecords = _authZoneManager.QueryZoneTransferRecords(request.Question[0].Name);
+                xfrRecords = _authZoneManager.QueryZoneTransferRecords(request.Question[0].Name, remoteEP);
             }
 
             IReadOnlyList<EDnsOption> eDnsOptions = null;

--- a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
@@ -17,6 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
+using DnsServerCore.ApplicationCommon;
+using DnsServerCore.Dns.Applications;
 using DnsServerCore.Dns.Dnssec;
 using DnsServerCore.Dns.ResourceRecords;
 using DnsServerCore.Dns.Trees;
@@ -29,8 +31,10 @@ using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using TechnitiumLibrary;
 using TechnitiumLibrary.IO;
 using TechnitiumLibrary.Net;
@@ -2513,9 +2517,10 @@ namespace DnsServerCore.Dns.ZoneManagers
 
         #region zone transfer / import
 
-        public IReadOnlyList<DnsResourceRecord> QueryZoneTransferRecords(string zoneName)
+        public IReadOnlyList<DnsResourceRecord> QueryZoneTransferRecords(string zoneName, IPEndPoint remoteEP)
         {
             AuthZoneInfo zoneInfo = GetAuthZoneInfo(zoneName);
+            
             if (zoneInfo is null)
                 throw new InvalidOperationException("Zone was not found: " + zoneName);
 
@@ -2555,6 +2560,16 @@ namespace DnsServerCore.Dns.ZoneManagers
                                 xfrRecords.Add(glueRecord);
                         }
                         break;
+                    case DnsResourceRecordType.APP:
+                        DnsApplicationRecordData rd = record.RDATA as DnsApplicationRecordData;
+                        if (rd.AppName == "Split Horizon" && rd.ClassPath == "SplitHorizon.SimpleAddress")
+                        {
+                            xfrRecords.AddRange(ConvertSplitHorizonZoneTransferRequest(record, remoteEP));
+                        }
+                        else
+                            xfrRecords.Add(record);
+                        
+                        break;
 
                     default:
                         xfrRecords.Add(record);
@@ -2568,7 +2583,7 @@ namespace DnsServerCore.Dns.ZoneManagers
             return xfrRecords;
         }
 
-        public IReadOnlyList<DnsResourceRecord> QueryIncrementalZoneTransferRecords(string zoneName, DnsResourceRecord clientSoaRecord)
+        public IReadOnlyList<DnsResourceRecord> QueryIncrementalZoneTransferRecords(string zoneName, DnsResourceRecord clientSoaRecord, IPEndPoint remoteEP)
         {
             AuthZoneInfo authZone = GetAuthZoneInfo(zoneName, true);
             if (authZone is null)
@@ -2620,7 +2635,7 @@ namespace DnsServerCore.Dns.ZoneManagers
             {
                 //client's serial was not found in zone history
                 //do full zone transfer
-                return QueryZoneTransferRecords(zoneName);
+                return QueryZoneTransferRecords(zoneName, remoteEP);
             }
 
             List<DnsResourceRecord> xfrRecords = new List<DnsResourceRecord>();
@@ -2630,7 +2645,25 @@ namespace DnsServerCore.Dns.ZoneManagers
 
             //write history
             for (int i = index; i < zoneHistory.Count; i++)
-                xfrRecords.Add(zoneHistory[i]);
+            {
+                DnsResourceRecord current = zoneHistory[i];
+                switch(current.Type)
+                {
+                    case DnsResourceRecordType.APP:
+                        DnsApplicationRecordData rd = current.RDATA as DnsApplicationRecordData;
+                        if (rd.AppName == "Split Horizon" && rd.ClassPath == "SplitHorizon.SimpleAddress")
+                        {
+                            xfrRecords.AddRange(ConvertSplitHorizonZoneTransferRequest(current, remoteEP));
+                        }
+                        else
+                            xfrRecords.Add(zoneHistory[i]);
+                        break;
+                    default:
+                        xfrRecords.Add(zoneHistory[i]);
+                        break;
+                }
+            }
+                
 
             //end incremental message
             xfrRecords.Add(currentSoaRecord);
@@ -2638,7 +2671,121 @@ namespace DnsServerCore.Dns.ZoneManagers
             //condense
             return CondenseIncrementalZoneTransferRecords(zoneName, clientSoaRecord, xfrRecords);
         }
+        public List<DnsResourceRecord> ConvertSplitHorizonZoneTransferRequest(DnsResourceRecord record, IPEndPoint remoteEP)
+        {
+            List<DnsResourceRecord> results = new List<DnsResourceRecord>();
+            DnsApplicationRecordData rd = record.RDATA as DnsApplicationRecordData;
 
+            // Load networks
+            Dictionary<string, List<NetworkAddress>> _networks;
+            string config = File.ReadAllText(Path.Combine(_dnsServer.ConfigFolder, "apps", "Split Horizon", "dnsApp.config"));
+            Console.WriteLine(config);
+
+            using JsonDocument networkDocument = JsonDocument.Parse(config);
+            JsonElement jsonConfig = networkDocument.RootElement;
+
+            if (jsonConfig.TryGetProperty("networks", out JsonElement jsonNetworks))
+            {
+                Dictionary<string, List<NetworkAddress>> networks = new Dictionary<string, List<NetworkAddress>>();
+
+                foreach (JsonProperty jsonProperty in jsonNetworks.EnumerateObject())
+                {
+                    string networkName = jsonProperty.Name;
+
+                    JsonElement jsonNetworkAddresses = jsonProperty.Value;
+                    if (jsonNetworkAddresses.ValueKind == JsonValueKind.Array)
+                    {
+                        List<NetworkAddress> networkAddresses = new List<NetworkAddress>(jsonNetworkAddresses.GetArrayLength());
+
+                        foreach (JsonElement jsonNetworkAddress in jsonNetworkAddresses.EnumerateArray())
+                            networkAddresses.Add(NetworkAddress.Parse(jsonNetworkAddress.GetString()));
+
+                        networks.TryAdd(networkName, networkAddresses);
+                    }
+                }
+
+                _networks = networks;
+            }
+            else
+            {
+                _networks = new Dictionary<string, List<NetworkAddress>>(1);
+            }
+
+            using (JsonDocument jsonDocument = JsonDocument.Parse(rd.Data))
+            {
+                JsonElement jsonAppRecordData = jsonDocument.RootElement;
+                JsonElement jsonAddresses = default;
+
+                NetworkAddress selectedNetwork = null;
+
+                foreach (JsonProperty jsonProperty in jsonAppRecordData.EnumerateObject())
+                {
+                    string name = jsonProperty.Name;
+
+                    // We skip public/private records here and look for defined networks/addresses first
+                    if ((name == "public") || (name == "private"))
+                        continue;
+
+                    if (_networks.TryGetValue(name, out List<NetworkAddress> networkAddresses))
+                    {
+                        foreach (NetworkAddress networkAddress in networkAddresses)
+                        {
+                            if (networkAddress.Contains(remoteEP.Address))
+                            {
+                                jsonAddresses = jsonProperty.Value;
+                                break;
+                            }
+                        }
+
+                        if (jsonAddresses.ValueKind != JsonValueKind.Undefined)
+                            break;
+                    }
+                    else if (NetworkAddress.TryParse(name, out NetworkAddress networkAddress))
+                    {
+                        if (networkAddress.Contains(remoteEP.Address) && ((selectedNetwork is null) || (networkAddress.PrefixLength > selectedNetwork.PrefixLength)))
+                        {
+                            selectedNetwork = networkAddress;
+                            jsonAddresses = jsonProperty.Value;
+                        }
+                    }
+
+                    
+                }
+
+                if (jsonAddresses.ValueKind == JsonValueKind.Undefined)
+                {
+                    if (NetUtilities.IsPrivateIP(remoteEP.Address))
+                    {
+                        jsonAppRecordData.TryGetProperty("private", out jsonAddresses);
+                    }
+                    else
+                    {
+                        jsonAppRecordData.TryGetProperty("public", out jsonAddresses);
+                    }
+                }
+
+                foreach (JsonElement jsonAddress in jsonAddresses.EnumerateArray())
+                {
+                    if (IPAddress.TryParse(jsonAddress.GetString(), out IPAddress address))
+                    {
+                        switch (address.AddressFamily)
+                        {
+                            case AddressFamily.InterNetwork:
+                                results.Add(new DnsResourceRecord(record.Name, DnsResourceRecordType.A, DnsClass.IN, record.TTL, new DnsARecordData(address)));
+                                break;
+                            case AddressFamily.InterNetworkV6:
+                                results.Add(new DnsResourceRecord(record.Name, DnsResourceRecordType.AAAA, DnsClass.IN, record.TTL, new DnsAAAARecordData(address)));
+                                break;
+
+                            default:
+                                break;
+                        }
+                    }
+                }
+            }
+
+            return results;
+        }
         public void SyncZoneTransferRecords(string zoneName, IReadOnlyList<DnsResourceRecord> xfrRecords)
         {
             if ((xfrRecords.Count < 2) || (xfrRecords[0].Type != DnsResourceRecordType.SOA) || !xfrRecords[0].Name.Equals(zoneName, StringComparison.OrdinalIgnoreCase) || !xfrRecords[xfrRecords.Count - 1].Equals(xfrRecords[0]))

--- a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
-using DnsServerCore.ApplicationCommon;
-using DnsServerCore.Dns.Applications;
 using DnsServerCore.Dns.Dnssec;
 using DnsServerCore.Dns.ResourceRecords;
 using DnsServerCore.Dns.Trees;

--- a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
@@ -1380,6 +1380,7 @@ namespace DnsServerCore.Dns.ZoneManagers
             {
                 zoneInfo.ZoneTransfer = sourceZoneInfo.ZoneTransfer;
                 zoneInfo.ZoneTransferNetworkACL = sourceZoneInfo.ZoneTransferNetworkACL;
+                zoneInfo.ZoneTransferSplitHorizonServers = sourceZoneInfo.ZoneTransferSplitHorizonServers;
                 zoneInfo.ZoneTransferTsigKeyNames = sourceZoneInfo.ZoneTransferTsigKeyNames;
 
                 zoneInfo.Notify = sourceZoneInfo.Notify;
@@ -2562,7 +2563,10 @@ namespace DnsServerCore.Dns.ZoneManagers
                         DnsApplicationRecordData rd = record.RDATA as DnsApplicationRecordData;
                         if (rd.AppName == "Split Horizon" && rd.ClassPath == "SplitHorizon.SimpleAddress")
                         {
-                            xfrRecords.AddRange(ConvertSplitHorizonZoneTransferRequest(record, remoteEP));
+                            if(zoneInfo.ApexZone.IsSplitHorizonConversionNeeded(remoteEP.Address))
+                                xfrRecords.AddRange(ConvertSplitHorizonZoneTransferRequest(record, remoteEP));
+                            else
+                                xfrRecords.Add(record);
                         }
                         else
                             xfrRecords.Add(record);
@@ -2651,13 +2655,16 @@ namespace DnsServerCore.Dns.ZoneManagers
                         DnsApplicationRecordData rd = current.RDATA as DnsApplicationRecordData;
                         if (rd.AppName == "Split Horizon" && rd.ClassPath == "SplitHorizon.SimpleAddress")
                         {
-                            xfrRecords.AddRange(ConvertSplitHorizonZoneTransferRequest(current, remoteEP));
+                            if (authZone.ApexZone.IsSplitHorizonConversionNeeded(remoteEP.Address))
+                                xfrRecords.AddRange(ConvertSplitHorizonZoneTransferRequest(current, remoteEP));
+                            else
+                                xfrRecords.Add(current);
                         }
                         else
-                            xfrRecords.Add(zoneHistory[i]);
+                            xfrRecords.Add(current);
                         break;
                     default:
-                        xfrRecords.Add(zoneHistory[i]);
+                        xfrRecords.Add(current);
                         break;
                 }
             }

--- a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
@@ -2677,7 +2677,6 @@ namespace DnsServerCore.Dns.ZoneManagers
             // Load networks
             Dictionary<string, List<NetworkAddress>> _networks;
             string config = File.ReadAllText(Path.Combine(_dnsServer.ConfigFolder, "apps", "Split Horizon", "dnsApp.config"));
-            Console.WriteLine(config);
 
             using JsonDocument networkDocument = JsonDocument.Parse(config);
             JsonElement jsonConfig = networkDocument.RootElement;

--- a/DnsServerCore/Dns/Zones/ApexZone.cs
+++ b/DnsServerCore/Dns/Zones/ApexZone.cs
@@ -84,6 +84,7 @@ namespace DnsServerCore.Dns.Zones
 
         protected AuthZoneTransfer _zoneTransfer;
         IReadOnlyCollection<NetworkAccessControl> _zoneTransferNetworkACL;
+        IReadOnlyCollection<IPAddress> _zoneTransferSplitHorizonServers;
         IReadOnlySet<string> _zoneTransferTsigKeyNames;
         readonly List<DnsResourceRecord> _zoneHistory; //for IXFR support
 
@@ -135,6 +136,7 @@ namespace DnsServerCore.Dns.Zones
 
             _zoneTransfer = zoneInfo.ZoneTransfer;
             _zoneTransferNetworkACL = zoneInfo.ZoneTransferNetworkACL;
+            _zoneTransferSplitHorizonServers = zoneInfo.ZoneTransferSplitHorizonServers;
             _zoneTransferTsigKeyNames = zoneInfo.ZoneTransferTsigKeyNames;
 
             if (zoneInfo.ZoneHistory is null)
@@ -1328,6 +1330,33 @@ namespace DnsServerCore.Dns.Zones
                     throw new ArgumentOutOfRangeException(nameof(ZoneTransferNetworkACL), "Network ACL cannot have more than 255 entries.");
                 else
                     _zoneTransferNetworkACL = value;
+            }
+        }
+
+        public bool IsSplitHorizonConversionNeeded(IPAddress remoteEP)
+        {
+            if ((ZoneTransferSplitHorizonServers is null) || (ZoneTransferSplitHorizonServers.Count < 1))
+                return false;
+
+            foreach (IPAddress address in ZoneTransferSplitHorizonServers)
+            {
+                if (address.Equals(remoteEP))
+                    return true;
+            }
+            return false;
+        }
+
+        public IReadOnlyCollection<IPAddress> ZoneTransferSplitHorizonServers
+        {
+            get { return _zoneTransferSplitHorizonServers; }
+            set
+            {
+                if ((value is null) || (value.Count == 0))
+                    _zoneTransferSplitHorizonServers = null;
+                else if (value.Count > byte.MaxValue)
+                    throw new ArgumentOutOfRangeException(nameof(ZoneTransferSplitHorizonServers), "Zone transfer Split Horizon Servers cannot have more than 255 entries.");
+                else
+                    _zoneTransferSplitHorizonServers = value;
             }
         }
 

--- a/DnsServerCore/Dns/Zones/AuthZoneInfo.cs
+++ b/DnsServerCore/Dns/Zones/AuthZoneInfo.cs
@@ -65,6 +65,7 @@ namespace DnsServerCore.Dns.Zones
 
         readonly AuthZoneTransfer _zoneTransfer;
         readonly IReadOnlyCollection<NetworkAccessControl> _zoneTransferNetworkACL;
+        readonly IReadOnlyCollection<IPAddress> _zoneTransferSplitHorizonServers;
         readonly IReadOnlySet<string> _zoneTransferTsigKeyNames;
         readonly IReadOnlyList<DnsResourceRecord> _zoneHistory; //for IXFR support
 
@@ -473,6 +474,7 @@ namespace DnsServerCore.Dns.Zones
                 case 12:
                 case 13:
                 case 14:
+                case 15:
                     {
                         _name = bR.BaseStream.ReadShortString();
                         _type = (AuthZoneType)bR.ReadByte();
@@ -495,6 +497,7 @@ namespace DnsServerCore.Dns.Zones
 
                                 _zoneTransfer = (AuthZoneTransfer)bR.ReadByte();
                                 _zoneTransferNetworkACL = ReadNetworkACLFrom(bR);
+                                _zoneTransferSplitHorizonServers = ReadZoneTransferSplitHorizonServersFrom(bR);
                                 _zoneTransferTsigKeyNames = ReadZoneTransferTsigKeyNamesFrom(bR);
                                 _zoneHistory = ReadZoneHistoryFrom(bR);
 
@@ -522,6 +525,7 @@ namespace DnsServerCore.Dns.Zones
 
                                 _zoneTransfer = (AuthZoneTransfer)bR.ReadByte();
                                 _zoneTransferNetworkACL = ReadNetworkACLFrom(bR);
+                                _zoneTransferSplitHorizonServers = ReadZoneTransferSplitHorizonServersFrom(bR);
                                 _zoneTransferTsigKeyNames = ReadZoneTransferTsigKeyNamesFrom(bR);
                                 _zoneHistory = ReadZoneHistoryFrom(bR);
 
@@ -574,6 +578,7 @@ namespace DnsServerCore.Dns.Zones
 
                                 _zoneTransfer = (AuthZoneTransfer)bR.ReadByte();
                                 _zoneTransferNetworkACL = ReadNetworkACLFrom(bR);
+                                _zoneTransferSplitHorizonServers = ReadZoneTransferSplitHorizonServersFrom(bR);
                                 _zoneTransferTsigKeyNames = ReadZoneTransferTsigKeyNamesFrom(bR);
                                 _zoneHistory = ReadZoneHistoryFrom(bR);
 
@@ -613,6 +618,7 @@ namespace DnsServerCore.Dns.Zones
 
                                 _zoneTransfer = (AuthZoneTransfer)bR.ReadByte();
                                 _zoneTransferNetworkACL = ReadNetworkACLFrom(bR);
+                                _zoneTransferSplitHorizonServers = ReadZoneTransferSplitHorizonServersFrom(bR);
                                 _zoneTransferTsigKeyNames = ReadZoneTransferTsigKeyNamesFrom(bR);
                                 _zoneHistory = ReadZoneHistoryFrom(bR);
 
@@ -630,6 +636,7 @@ namespace DnsServerCore.Dns.Zones
 
                                 _zoneTransfer = (AuthZoneTransfer)bR.ReadByte();
                                 _zoneTransferNetworkACL = ReadNetworkACLFrom(bR);
+                                _zoneTransferSplitHorizonServers = ReadZoneTransferSplitHorizonServersFrom(bR);
                                 _zoneTransferTsigKeyNames = ReadZoneTransferTsigKeyNamesFrom(bR);
 
                                 _primaryNameServerAddresses = ReadNameServerAddressesFrom(bR);
@@ -670,6 +677,7 @@ namespace DnsServerCore.Dns.Zones
 
                 _zoneTransfer = _apexZone.ZoneTransfer;
                 _zoneTransferNetworkACL = _apexZone.ZoneTransferNetworkACL;
+                _zoneTransferSplitHorizonServers = _apexZone.ZoneTransferSplitHorizonServers;
                 _zoneTransferTsigKeyNames = _apexZone.ZoneTransferTsigKeyNames;
 
                 if (loadHistory)
@@ -693,6 +701,7 @@ namespace DnsServerCore.Dns.Zones
 
                 _zoneTransfer = _apexZone.ZoneTransfer;
                 _zoneTransferNetworkACL = _apexZone.ZoneTransferNetworkACL;
+                _zoneTransferSplitHorizonServers = _apexZone.ZoneTransferSplitHorizonServers;
                 _zoneTransferTsigKeyNames = _apexZone.ZoneTransferTsigKeyNames;
 
                 _primaryNameServerAddresses = secondaryCatalogZone.PrimaryNameServerAddresses;
@@ -734,6 +743,7 @@ namespace DnsServerCore.Dns.Zones
 
                 _zoneTransfer = _apexZone.ZoneTransfer;
                 _zoneTransferNetworkACL = _apexZone.ZoneTransferNetworkACL;
+                _zoneTransferSplitHorizonServers = _apexZone.ZoneTransferSplitHorizonServers;
                 _zoneTransferTsigKeyNames = _apexZone.ZoneTransferTsigKeyNames;
 
                 if (loadHistory)
@@ -778,6 +788,7 @@ namespace DnsServerCore.Dns.Zones
 
                 _zoneTransfer = _apexZone.ZoneTransfer;
                 _zoneTransferNetworkACL = _apexZone.ZoneTransferNetworkACL;
+                _zoneTransferSplitHorizonServers = _apexZone.ZoneTransferSplitHorizonServers;
                 _zoneTransferTsigKeyNames = _apexZone.ZoneTransferTsigKeyNames;
 
                 if (loadHistory)
@@ -801,6 +812,7 @@ namespace DnsServerCore.Dns.Zones
 
                 _zoneTransfer = _apexZone.ZoneTransfer;
                 _zoneTransferNetworkACL = _apexZone.ZoneTransferNetworkACL;
+                _zoneTransferSplitHorizonServers = _apexZone.ZoneTransferSplitHorizonServers;
                 _zoneTransferTsigKeyNames = _apexZone.ZoneTransferTsigKeyNames;
 
                 if (loadHistory)
@@ -974,6 +986,34 @@ namespace DnsServerCore.Dns.Zones
                 return acl;
 
             return null;
+        }
+
+        private static HashSet<IPAddress> ReadZoneTransferSplitHorizonServersFrom(BinaryReader bR)
+        {
+            int count = bR.ReadByte();
+            HashSet<IPAddress> zoneTransferSplitHorizonServers = new HashSet<IPAddress>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                if (IPAddress.TryParse(bR.BaseStream.ReadShortString(), out IPAddress address))
+                {
+                    zoneTransferSplitHorizonServers.Add(address);
+                }
+            }
+            return zoneTransferSplitHorizonServers;
+        }
+
+        private static void WriteZoneTransferSplitHorizonServersTo(IReadOnlyCollection<IPAddress> zoneTransferSplitHorizonServers, BinaryWriter bW)
+        {
+            if(zoneTransferSplitHorizonServers is null)
+            {
+                bW.Write((byte)0);
+            } else
+            {
+                bW.Write(Convert.ToByte(zoneTransferSplitHorizonServers.Count));
+                foreach (IPAddress splitHorizonServer in zoneTransferSplitHorizonServers)
+                    bW.BaseStream.WriteShortString(splitHorizonServer.ToString());
+            }
         }
 
         private static HashSet<string> ReadZoneTransferTsigKeyNamesFrom(BinaryReader bR)
@@ -1191,7 +1231,7 @@ namespace DnsServerCore.Dns.Zones
             if (_apexZone is null)
                 throw new InvalidOperationException();
 
-            bW.Write((byte)14); //version
+            bW.Write((byte)15); //version
 
             bW.BaseStream.WriteShortString(_name);
             bW.Write((byte)_type);
@@ -1211,6 +1251,7 @@ namespace DnsServerCore.Dns.Zones
 
                     bW.Write((byte)_zoneTransfer);
                     WriteNetworkACLTo(_zoneTransferNetworkACL, bW);
+                    WriteZoneTransferSplitHorizonServersTo(_zoneTransferSplitHorizonServers, bW);
                     WriteZoneTransferTsigKeyNamesTo(_zoneTransferTsigKeyNames, bW);
                     WriteZoneHistoryTo(_zoneHistory, bW);
 
@@ -1235,6 +1276,7 @@ namespace DnsServerCore.Dns.Zones
 
                     bW.Write((byte)_zoneTransfer);
                     WriteNetworkACLTo(_zoneTransferNetworkACL, bW);
+                    WriteZoneTransferSplitHorizonServersTo(_zoneTransferSplitHorizonServers, bW);
                     WriteZoneTransferTsigKeyNamesTo(_zoneTransferTsigKeyNames, bW);
                     WriteZoneHistoryTo(_zoneHistory, bW);
 
@@ -1278,6 +1320,7 @@ namespace DnsServerCore.Dns.Zones
 
                     bW.Write((byte)_zoneTransfer);
                     WriteNetworkACLTo(_zoneTransferNetworkACL, bW);
+                    WriteZoneTransferSplitHorizonServersTo(_zoneTransferSplitHorizonServers, bW);
                     WriteZoneTransferTsigKeyNamesTo(_zoneTransferTsigKeyNames, bW);
                     WriteZoneHistoryTo(_zoneHistory, bW);
 
@@ -1312,6 +1355,7 @@ namespace DnsServerCore.Dns.Zones
 
                     bW.Write((byte)_zoneTransfer);
                     WriteNetworkACLTo(_zoneTransferNetworkACL, bW);
+                    WriteZoneTransferSplitHorizonServersTo(_zoneTransferSplitHorizonServers, bW);
                     WriteZoneTransferTsigKeyNamesTo(_zoneTransferTsigKeyNames, bW);
                     WriteZoneHistoryTo(_zoneHistory, bW);
 
@@ -1326,6 +1370,7 @@ namespace DnsServerCore.Dns.Zones
 
                     bW.Write((byte)_zoneTransfer);
                     WriteNetworkACLTo(_zoneTransferNetworkACL, bW);
+                    WriteZoneTransferSplitHorizonServersTo(_zoneTransferSplitHorizonServers, bW);
                     WriteZoneTransferTsigKeyNamesTo(_zoneTransferTsigKeyNames, bW);
 
                     WriteNameServerAddressesTo(_primaryNameServerAddresses, bW);
@@ -1582,6 +1627,24 @@ namespace DnsServerCore.Dns.Zones
                     throw new InvalidOperationException();
 
                 _apexZone.ZoneTransferNetworkACL = value;
+            }
+        }
+
+        public IReadOnlyCollection<IPAddress> ZoneTransferSplitHorizonServers
+        {
+            get
+            {
+                if (_apexZone is null)
+                    return _zoneTransferSplitHorizonServers;
+
+                return _apexZone.ZoneTransferSplitHorizonServers;
+            }
+            set
+            {
+                if (_apexZone is null)
+                    throw new InvalidOperationException();
+
+                _apexZone.ZoneTransferSplitHorizonServers = value;
             }
         }
 

--- a/DnsServerCore/WebServiceZonesApi.cs
+++ b/DnsServerCore/WebServiceZonesApi.cs
@@ -3168,6 +3168,19 @@ namespace DnsServerCore
                             jsonWriter.WriteEndArray();
                         }
 
+                        jsonWriter.WritePropertyName("zoneTransferSplitHorizonServers");
+                        {
+                            jsonWriter.WriteStartArray();
+
+                            if (zoneInfo.ZoneTransferSplitHorizonServers is not null)
+                            {
+                                foreach (IPAddress address in zoneInfo.ZoneTransferSplitHorizonServers)
+                                    jsonWriter.WriteStringValue(address.ToString());
+                            }
+
+                            jsonWriter.WriteEndArray();
+                        }
+
                         jsonWriter.WritePropertyName("zoneTransferTsigKeyNames");
                         {
                             jsonWriter.WriteStartArray();
@@ -3522,6 +3535,19 @@ namespace DnsServerCore
 
                         if (request.TryGetQueryOrFormEnum("zoneTransfer", out AuthZoneTransfer zoneTransfer))
                             zoneInfo.ZoneTransfer = zoneTransfer;
+
+                        string strZoneTransferSplitHorizonServers = request.QueryOrForm("zoneTransferSplitHorizonServers");
+                        if(strZoneTransferSplitHorizonServers is not null)
+                        {
+                            if((strZoneTransferSplitHorizonServers.Length == 0) || (strZoneTransferSplitHorizonServers.Equals("false", StringComparison.OrdinalIgnoreCase)))
+                            {
+                                zoneInfo.ZoneTransferSplitHorizonServers = null;
+                            }
+                            else
+                            {
+                                zoneInfo.ZoneTransferSplitHorizonServers = strZoneTransferSplitHorizonServers.Split(IPAddress.Parse, ',');
+                            }
+                        }
 
                         string strZoneTransferTsigKeyNames = request.QueryOrForm("zoneTransferTsigKeyNames");
                         if (strZoneTransferTsigKeyNames is not null)

--- a/DnsServerCore/www/index.html
+++ b/DnsServerCore/www/index.html
@@ -5209,6 +5209,17 @@ ns1.example.com ([2001:db8::])
 
                                     <div class="well well-sm form-horizontal">
                                         <div class="form-group">
+                                            <label for="txtZoneOptionsZoneTransferSplitHorizonConversionServers" class="col-sm-3 control-label">Zone Transfer Split Horizon Conversion</label>
+                                            <div class="col-sm-8">
+                                                <textarea id="txtZoneOptionsZoneTransferSplitHorizonConversionServers" class="form-control" rows="3" spellcheck="false"></textarea>
+                                                <div style="padding-top: 5px;">Add one IP address per line for servers that should receive converted zone records.</div>
+                                            </div>
+                                        </div>
+                                        <div><b>Note!</b> Servers listed here will received converted Split Horizon records. This will turn the APP record into A and/or AAAA records</div>
+                                    </div>
+
+                                    <div class="well well-sm form-horizontal">
+                                        <div class="form-group">
                                             <label for="txtZoneOptionsZoneTransferTsigKeyNames" class="col-sm-3 control-label">Zone Transfer TSIG Key Names</label>
                                             <div class="col-sm-8">
                                                 <textarea id="txtZoneOptionsZoneTransferTsigKeyNames" class="form-control" rows="3" spellcheck="false"></textarea>

--- a/DnsServerCore/www/js/zone.js
+++ b/DnsServerCore/www/js/zone.js
@@ -1917,6 +1917,16 @@ function showZoneOptionsModal(zone) {
 
                     {
                         var value = "";
+                        if (responseJSON.response.zoneTransferSplitHorizonServers != null) {
+                            for (var i = 0; i < responseJSON.response.zoneTransferSplitHorizonServers.length; i++) {
+                                value += responseJSON.response.zoneTransferSplitHorizonServers[i] + "\r\n";
+                            }
+                        }
+                        $("#txtZoneOptionsZoneTransferSplitHorizonConversionServers").val(value);
+                    }
+
+                    {
+                        var value = "";
 
                         if (responseJSON.response.zoneTransferTsigKeyNames != null) {
                             for (var i = 0; i < responseJSON.response.zoneTransferTsigKeyNames.length; i++) {
@@ -1962,6 +1972,7 @@ function showZoneOptionsModal(zone) {
                                 $("#rdZoneTransferAllowOnlyZoneNameServers").prop("disabled", false);
                                 $("#rdZoneTransferUseSpecifiedNetworkACL").prop("disabled", false);
                                 $("#rdZoneTransferAllowZoneNameServersAndUseSpecifiedNetworkACL").prop("disabled", false);
+                                $("#txtZoneOptionsZoneTransferSplitHorizonConversionServers").prop("disabled", false);
                                 $("#txtZoneOptionsZoneTransferTsigKeyNames").prop("disabled", false);
                                 $("#optZoneOptionsQuickTsigKeyNames").prop("disabled", false);
 
@@ -1984,6 +1995,7 @@ function showZoneOptionsModal(zone) {
                                 if (responseJSON.response.catalog != null)
                                     $("#txtZoneTransferNetworkACL").prop("disabled", true);
 
+                                $("#txtZoneOptionsZoneTransferSplitHorizonConversionServers").prop("disabled", responseJSON.response.catalog != null);
                                 $("#txtZoneOptionsZoneTransferTsigKeyNames").prop("disabled", responseJSON.response.catalog != null);
                                 $("#optZoneOptionsQuickTsigKeyNames").prop("disabled", responseJSON.response.catalog != null);
 
@@ -2001,6 +2013,7 @@ function showZoneOptionsModal(zone) {
                             $("#rdZoneTransferAllowOnlyZoneNameServers").prop("disabled", false);
                             $("#rdZoneTransferUseSpecifiedNetworkACL").prop("disabled", false);
                             $("#rdZoneTransferAllowZoneNameServersAndUseSpecifiedNetworkACL").prop("disabled", false);
+                            $("#txtZoneOptionsZoneTransferSplitHorizonConversionServers").prop("disabled", false);
                             $("#txtZoneOptionsZoneTransferTsigKeyNames").prop("disabled", false);
                             $("#optZoneOptionsQuickTsigKeyNames").prop("disabled", false);
 
@@ -2014,6 +2027,8 @@ function showZoneOptionsModal(zone) {
                             $("#rdZoneTransferUseSpecifiedNetworkACL").prop("disabled", true);
                             $("#rdZoneTransferAllowZoneNameServersAndUseSpecifiedNetworkACL").prop("disabled", true);
                             $("#txtZoneTransferNetworkACL").prop("disabled", true);
+
+                            $("#txtZoneOptionsZoneTransferSplitHorizonConversionServers").prop("disabled", true);
                             $("#txtZoneOptionsZoneTransferTsigKeyNames").prop("disabled", true);
                             $("#optZoneOptionsQuickTsigKeyNames").prop("disabled", true);
 
@@ -2356,6 +2371,13 @@ function saveZoneOptions() {
     else
         $("#txtZoneTransferNetworkACL").val(zoneTransferNetworkACL.replace(/,/g, "\n"));
 
+    var zoneTransferSplitHorizonServers = cleanTextList($("#txtZoneOptionsZoneTransferSplitHorizonConversionServers").val());
+
+    if ((zoneTransferSplitHorizonServers.length === 0) || (zoneTransferSplitHorizonServers === ","))
+        zoneTransferSplitHorizonServers = false;
+    else
+        $("#txtZoneOptionsZoneTransferSplitHorizonConversionServers").val(zoneTransferSplitHorizonServers.replace(/,/g, "\n"));
+
     var zoneTransferTsigKeyNames = cleanTextList($("#txtZoneOptionsZoneTransferTsigKeyNames").val());
 
     if ((zoneTransferTsigKeyNames.length === 0) || (zoneTransferTsigKeyNames === ","))
@@ -2407,7 +2429,7 @@ function saveZoneOptions() {
             + "&catalog=" + encodeURIComponent(catalog) + "&overrideCatalogQueryAccess=" + overrideCatalogQueryAccess + "&overrideCatalogZoneTransfer=" + overrideCatalogZoneTransfer + "&overrideCatalogNotify=" + overrideCatalogNotify
             + "&primaryNameServerAddresses=" + encodeURIComponent(primaryNameServerAddresses) + "&primaryZoneTransferProtocol=" + primaryZoneTransferProtocol + "&primaryZoneTransferTsigKeyName=" + encodeURIComponent(primaryZoneTransferTsigKeyName) + "&validateZone=" + validateZone
             + "&queryAccess=" + queryAccess + "&queryAccessNetworkACL=" + encodeURIComponent(queryAccessNetworkACL)
-            + "&zoneTransfer=" + zoneTransfer + "&zoneTransferNetworkACL=" + encodeURIComponent(zoneTransferNetworkACL) + "&zoneTransferTsigKeyNames=" + encodeURIComponent(zoneTransferTsigKeyNames)
+            + "&zoneTransfer=" + zoneTransfer + "&zoneTransferNetworkACL=" + encodeURIComponent(zoneTransferNetworkACL) + "&zoneTransferSplitHorizonServers=" + encodeURIComponent(zoneTransferSplitHorizonServers) + "&zoneTransferTsigKeyNames=" + encodeURIComponent(zoneTransferTsigKeyNames)
             + "&notify=" + notify + "&notifyNameServers=" + encodeURIComponent(notifyNameServers) + "&notifySecondaryCatalogsNameServers=" + encodeURIComponent(notifySecondaryCatalogsNameServers)
             + "&update=" + update + "&updateNetworkACL=" + encodeURIComponent(updateNetworkACL) + "&updateSecurityPolicies=" + encodeURIComponent(updateSecurityPolicies)
             + "&node=" + encodeURIComponent(node),


### PR DESCRIPTION
This isn't pretty and isn't complete, however this should allow for zone transfer requests of SplitHorizon APP records to be converted to regular A/AAAA records.

Currently APP records are mirrored verbatim to any dns server, even if the other server does not understand proprietary APP records. In my case I have a public facing BIND server that serves public requests and serves as a cache(secondary zone) for my locally hosted Technitium server (primary zone). However, the BIND server obviously cant understand APP records, as such I need to translate the APP record to A/AAAA records that my BIND server can understand.

Todo:
- Add UI configuration to enable/disable conversion, maybe on a per-server/ip basis?
- Possibly move this to the SplitHorizon App?
- If unable to move this to the SplitHorizon App, is there an option to directly access network definitions from the App instance?

I am curious about your suggestions, you know your code better and there is probably a more efficient way to handle this.