### PR TITLE
webapp: add Search field to Zones tab

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -1957,6 +1957,7 @@ WHERE:
 - `node` (optional): The node domain name for which the this API call is intended. When unspecified, the current node is used. This parameter can be used only when Clustering is initialized.
 - `pageNumber` (optional): When this parameter is specified, the API will return paginated results based on the page number and zones per pages options. When not specified, the API will return a list of all zones.
 - `zonesPerPage` (optional): The number of zones per page to be returned. This option is only used when `pageNumber` options is specified. The default value is `10` when not specified.
+- `filter` (optional): When specified, only zones whose name contains the given substring (case-insensitive) are returned. Both the wire-format zone name and its IDN-decoded Unicode form are matched. Filtering is applied before pagination so that `pageNumber`, `totalPages` and `totalZones` reflect the filtered result set.
 
 RESPONSE:
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Technitium DNS Server Change Log
 
+## Unreleased
+
+- Added Search field to the Zones tab to filter zones by case-insensitive substring match. The matching is performed server-side against both the zone name and its IDN-decoded Unicode form, and is applied before pagination. The `/api/zones/list` API now accepts an optional `filter` query parameter.
+
 ## Version 15.2
 Release Date: 9 May 2026
 

--- a/DnsServerCore/WebServiceZonesApi.cs
+++ b/DnsServerCore/WebServiceZonesApi.cs
@@ -1457,6 +1457,26 @@ namespace DnsServerCore
                     return _dnsWebService._authManager.IsPermitted(PermissionSection.Zones, zoneInfo.Name, sessionUser, PermissionFlag.View);
                 });
 
+                string filter = request.GetQueryOrForm("filter", null);
+                if (!string.IsNullOrEmpty(filter))
+                {
+                    List<AuthZoneInfo> filteredList = new List<AuthZoneInfo>(zoneInfoList.Count);
+
+                    foreach (AuthZoneInfo zoneInfo in zoneInfoList)
+                    {
+                        if (zoneInfo.Name.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                        {
+                            filteredList.Add(zoneInfo);
+                            continue;
+                        }
+
+                        if (DnsClient.TryConvertDomainNameToUnicode(zoneInfo.Name, out string nameIdn) && nameIdn.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                            filteredList.Add(zoneInfo);
+                    }
+
+                    zoneInfoList = filteredList;
+                }
+
                 if (request.TryGetQueryOrForm("pageNumber", int.Parse, out int pageNumber))
                 {
                     int zonesPerPage = request.GetQueryOrForm("zonesPerPage", int.Parse, 10);

--- a/DnsServerCore/www/index.html
+++ b/DnsServerCore/www/index.html
@@ -440,6 +440,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                     <input id="txtZonesEdit" class="form-control" style="width: 300px;" type="text" placeholder="example.com" />
                                                     <button type="submit" class="btn btn-primary" onclick="showEditZone(); return false;">Edit</button>
                                                 </div>
+                                                <div class="form-group" style="margin-left: 10px;">
+                                                    <input id="txtZonesSearch" class="form-control" style="width: 240px;" type="search" placeholder="Search zones..." />
+                                                    <button type="button" id="btnZonesSearchClear" class="btn btn-default" style="display: none;" onclick="clearZonesSearch(); return false;">Clear</button>
+                                                </div>
                                             </form>
                                             <form class="pull-right">
                                                 <div class="form-group">

--- a/DnsServerCore/www/js/zone.js
+++ b/DnsServerCore/www/js/zone.js
@@ -22,7 +22,33 @@ var editZoneInfo;
 var editZoneRecords;
 var editZoneFilteredRecords;
 
+var zonesSearchTimer;
+
+function clearZonesSearch() {
+    $("#txtZonesSearch").val("");
+    $("#btnZonesSearchClear").hide();
+    refreshZones(false, 1);
+}
+
 $(function () {
+    $("#txtZonesSearch").on("input", function () {
+        if (zonesSearchTimer != null)
+            clearTimeout(zonesSearchTimer);
+
+        zonesSearchTimer = setTimeout(function () {
+            refreshZones(false, 1);
+        }, 300);
+    });
+
+    $("#txtZonesSearch").on("keydown", function (e) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            if (zonesSearchTimer != null)
+                clearTimeout(zonesSearchTimer);
+            refreshZones(false, 1);
+        }
+    });
+
     $("input[type=radio][name=rdAddZoneType]").on("change", function () {
         $("#txtAddZone").prop("disabled", false);
         $("#divAddZoneCatalogZone").hide();
@@ -663,6 +689,11 @@ function refreshZones(checkDisplay, pageNumber) {
         zonesPerPage = 10;
 
     var node = $("#optZonesClusterNode").val();
+    var filter = $("#txtZonesSearch").val();
+    if (filter == null)
+        filter = "";
+
+    $("#btnZonesSearchClear").css("display", filter.length > 0 ? "" : "none");
 
     var divViewZonesLoader = $("#divViewZonesLoader");
     var divEditZone = $("#divEditZone");
@@ -672,7 +703,7 @@ function refreshZones(checkDisplay, pageNumber) {
     divViewZonesLoader.show();
 
     HTTPRequest({
-        url: "api/zones/list?pageNumber=" + pageNumber + "&zonesPerPage=" + zonesPerPage + "&node=" + encodeURIComponent(node),
+        url: "api/zones/list?pageNumber=" + pageNumber + "&zonesPerPage=" + zonesPerPage + "&node=" + encodeURIComponent(node) + "&filter=" + encodeURIComponent(filter),
         token: sessionData.token,
         success: function (responseJSON) {
             var zones = responseJSON.response.zones;

--- a/DnsServerCore/www/js/zone.js
+++ b/DnsServerCore/www/js/zone.js
@@ -698,6 +698,11 @@ function refreshZones(checkDisplay, pageNumber) {
     var divViewZonesLoader = $("#divViewZonesLoader");
     var divEditZone = $("#divEditZone");
 
+    var searchInput = document.getElementById("txtZonesSearch");
+    var restoreSearchFocus = (document.activeElement === searchInput);
+    var searchSelStart = restoreSearchFocus ? searchInput.selectionStart : null;
+    var searchSelEnd = restoreSearchFocus ? searchInput.selectionEnd : null;
+
     divViewZones.hide();
     divEditZone.hide();
     divViewZonesLoader.show();
@@ -966,10 +971,18 @@ function refreshZones(checkDisplay, pageNumber) {
 
             divViewZonesLoader.hide();
             divViewZones.show();
+
+            if (restoreSearchFocus) {
+                searchInput.focus();
+                try { searchInput.setSelectionRange(searchSelStart, searchSelEnd); } catch (e) { }
+            }
         },
         error: function () {
             divViewZonesLoader.hide();
             divViewZones.show();
+
+            if (restoreSearchFocus)
+                searchInput.focus();
         },
         invalidToken: function () {
             divViewZonesLoader.hide();


### PR DESCRIPTION
## Summary

Adds a Search field to the Zones tab that filters zones by a case-insensitive substring match. The filter applies to both the wire-format zone name and its IDN-decoded Unicode form, and is applied **server-side before pagination** so that page counts and totals stay consistent as the user types.

## Changes

- **`WebServiceZonesApi.ListZones()`** — accepts a new optional `filter` query parameter. When set, the zone list is filtered before pagination, so `pageNumber`, `totalPages` and `totalZones` reflect the filtered set.
- **`www/index.html`** — adds a `Search zones...` input and a Clear button next to the existing Edit form on the Zones tab.
- **`www/js/zone.js`** — wires the input with a 300 ms debounce, Enter-key submit, and Clear button. `refreshZones()` reads the value and passes it to `/api/zones/list`. Page resets to 1 on every filter change.
- **`APIDOCS.md`** — documents the new `filter` parameter on `/api/zones/list`.
- **`CHANGELOG.md`** — added an `Unreleased` section with a bullet for this change. Feel free to fold it into the next release section in whatever style you prefer.

## Why

On servers with many zones, paging through to find a specific one is tedious. Substring search makes the UI usable at scale and keeps the existing pagination, sorting, and cluster-node selector working unchanged.

## Notes

- The `filter` parameter is fully backward compatible — when absent, behaviour is identical to before.
- Filtering is `StringComparison.OrdinalIgnoreCase` on `zoneInfo.Name`, and falls back to checking the IDN-decoded Unicode form via `DnsClient.TryConvertDomainNameToUnicode` so users can search internationalised zone names by their displayed text.
- I confirm I am the original author and agree with the IPR / CLA terms in `CONTRIBUTING.md`.

## Test plan

- [x] Build and run the DNS server.
- [x] Open the Zones tab with multiple zones present; confirm the new Search box appears next to Edit.
- [x] Type a substring; results filter live (300 ms debounce); status line shows the filtered totals; pagination works against the filtered set.
- [x] Press Enter — filter applies immediately.
- [x] Click Clear — input empties, full zone list returns.
- [ ] With an IDN zone present, type the Unicode form — zone is matched.
- [ ] Confirm the cluster-node dropdown still works with the filter applied (filter forwards through cluster proxy).
- [ ] Confirm calling `GET /api/zones/list` without `filter` returns identical results to the prior release.

## Future work (not in this PR)

A future enhancement could add a top-level Search tab that fans out across zones, records and other entities. The records side would need a new endpoint that enumerates RRs across all zones with a substring match on name / RDATA / comments — happy to follow up with that in a separate PR if there's interest.