### PR TITLE
DnsServer: Delete stale Unix socket files before binding to prevent 'address already in use' errors on restart

### DIFF
--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -6424,7 +6424,20 @@ namespace DnsServerCore.Dns
 
                     //bind to unix socket
                     if (_enableDnsOverHttpUnixSocket && (_dnsOverHttpUnixSocket is not null))
+                    {
+                        try
+                        {
+                            File.Delete(_dnsOverHttpUnixSocket);
+                        }
+                        catch (DirectoryNotFoundException)
+                        { }
+                        catch (Exception ex)
+                        {
+                            _log.Write(ex);
+                        }
+
                         serverOptions.ListenUnixSocket(_dnsOverHttpUnixSocket);
+                    }
 
                     //bind to https port
                     if (_enableDnsOverHttps && (_dohSslServerAuthenticationOptions is not null))
@@ -6528,6 +6541,17 @@ namespace DnsServerCore.Dns
                 }
 
                 _dohWebService = null;
+            }
+
+            // clean up stale unix socket file
+            if (_enableDnsOverHttpUnixSocket && (_dnsOverHttpUnixSocket is not null))
+            {
+                try
+                {
+                    File.Delete(_dnsOverHttpUnixSocket);
+                }
+                catch
+                { }
             }
         }
 

--- a/DnsServerCore/DnsWebService.cs
+++ b/DnsServerCore/DnsWebService.cs
@@ -1828,7 +1828,20 @@ namespace DnsServerCore
 
                 //unix socket
                 if (!httpOnlyMode && _webServiceEnableHttpUnixSocket && (_webServiceHttpUnixSocket is not null))
+                {
+                    try
+                    {
+                        File.Delete(_webServiceHttpUnixSocket);
+                    }
+                    catch (DirectoryNotFoundException)
+                    { }
+                    catch (Exception ex)
+                    {
+                        _log.Write(ex);
+                    }
+
                     serverOptions.ListenUnixSocket(_webServiceHttpUnixSocket);
+                }
 
                 //https
                 if (!httpOnlyMode && _webServiceEnableTls && (_webServiceSslServerAuthenticationOptions is not null))
@@ -1964,6 +1977,17 @@ namespace DnsServerCore
             {
                 await _webService.DisposeAsync();
                 _webService = null;
+            }
+
+            // clean up stale unix socket file
+            if (_webServiceEnableHttpUnixSocket && (_webServiceHttpUnixSocket is not null))
+            {
+                try
+                {
+                    File.Delete(_webServiceHttpUnixSocket);
+                }
+                catch
+                { }
             }
 
             _ssoHttpHandler?.Dispose();


### PR DESCRIPTION
When the DNS server is restarted, the Unix domain socket files from the previous run persist on disk. Kestrel's `ListenUnixSocket()` then fails with:

```
System.IO.IOException: Failed to bind to address http://unix:<path>: address already in use.
 ---> System.Net.Sockets.SocketException (48): Address already in use
```

This PR deletes the socket file before calling `ListenUnixSocket()` so that a stale file from a previous run does not prevent binding. `DirectoryNotFoundException` is silently ignored since it means the parent directory does not exist yet, and `ListenUnixSocket` will fail with a clearer error in that case.

Affected:
- Web Service Unix socket in `DnsWebService.cs`
- DNS-over-HTTPS Unix socket in `DnsServer.cs`