### PR TITLE
Amber theme: fix missing styles, improve active state visibility

### DIFF
--- a/DnsServerCore/www/css/amber-mode.css
+++ b/DnsServerCore/www/css/amber-mode.css
@@ -98,12 +98,13 @@ body.amber-mode {
 }
 
 .amber-mode .nav-tabs {
-    border-bottom: 1px solid #3d2a1c !important;
+    border-bottom: 1px solid #ffc107 !important;
 }
 
     .amber-mode .nav-tabs > li > a:hover {
-        background-color: #3d2a1c !important;
-        border-color: #3d2a1c !important;
+        border-color: #4a3322 !important;
+        border-bottom-color: #ffc107 !important;
+        background-color: #3d2a1c;
         color: #ffb000 !important;
     }
 
@@ -111,8 +112,9 @@ body.amber-mode {
     .amber-mode .nav-tabs > li.active > a:hover,
     .amber-mode .nav-tabs > li.active > a:focus {
         background-color: #251a11 !important;
-        border-color: #3d2a1c #3d2a1c transparent !important;
+        border-color: #ffc107 !important;
         color: #ffb000 !important;
+        border-bottom-color: transparent !important;
     }
 
 .amber-mode .table-hover > tbody > tr:hover {
@@ -127,13 +129,13 @@ body.amber-mode {
 .amber-mode .table > tbody > tr > td,
 .amber-mode .table > tfoot > tr > th,
 .amber-mode .table > tfoot > tr > td {
-    border-top: 1px solid #3d2a1c !important;
+    border-top-color: #3d2a1c !important;
 }
 
 .amber-mode .table-bordered,
 .amber-mode .table-bordered > thead > tr > th,
 .amber-mode .table-bordered > tbody > tr > td {
-    border: 1px solid #3d2a1c !important;
+    border-color: #3d2a1c !important;
 }
 
 .amber-mode .form-control {
@@ -192,6 +194,7 @@ body.amber-mode {
 
 .amber-mode .stats-panel .stats-item,
 .amber-mode .zone-stats-panel .stats-item {
+    color: #ffb000 !important;
     border-right-color: #3d2a1c !important;
 }
 
@@ -224,9 +227,9 @@ body.amber-mode {
     }
 
 .amber-mode .pagination li:not(.active) a {
-    background-color: #2c1e14 !important;
-    border-color: #3d2a1c !important;
     color: #ffb000 !important;
+    background-color: #2c1e14 !important;
+    border: 1px solid #ffc107 !important;
 }
 
     .amber-mode .pagination li:not(.active) a:hover {


### PR DESCRIPTION
Related to discussion #1806

## Changes

- **Add missing stats text color**: `color: #ffb000` for `.stats-panel .stats-item` — without this, stats numbers were inheriting an unreadable color in amber mode
- **Amber accent for active states**: Use `#ffc107` for nav-tab active/hover borders and pagination borders — the previous `#3d2a1c` was invisible against the dark background, providing no visual feedback for the active tab
- **Fix table border shorthand**: Changed `border: 1px solid` to `border-color` so the border width/style from the base stylesheet isn't overridden
- **Structural consistency**: Aligns nav-tab active state pattern with how `dark-mode.css` handles the same components

## Color Palette

| Role | Color |
|------|-------|
| Background | `#1a120b` |
| Surface | `#2c1e14` |
| Border | `#3d2a1c` |
| Accent | `#ffc107` (active tabs, pagination) |
| Text | `#ffb000` |
| Text secondary | `#cc8800` |