### PR TITLE
Wild IP App: Add hexadecimal IPv4 support

### DIFF
--- a/Apps/WildIpApp/App.cs
+++ b/Apps/WildIpApp/App.cs
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using DnsServerCore.ApplicationCommon;
 using System;
+using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 using System.Text.Json;
@@ -119,10 +120,35 @@ namespace WildIp
                                 rawIp[i++] = x;
                         }
 
-                        if (i != 4)
-                            return null; //failed to parse ipv4
+                        if (i == 4)
+                        {
+                            address = new IPAddress(rawIp);
+                        }
+                        else
+                        {
+                            //failed to parse decimal ipv4; attempt to parse an 8-character hexadecimal ipv4 label
+                            parts = subdomain.Split(aaaaRecordSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-                        address = new IPAddress(rawIp);
+                            foreach (string part in parts)
+                            {
+                                if (
+                                    (part.Length == 8) &&
+                                    uint.TryParse(part, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint value)
+                                )
+                                {
+                                    rawIp[0] = (byte)(value >> 24);
+                                    rawIp[1] = (byte)(value >> 16);
+                                    rawIp[2] = (byte)(value >> 8);
+                                    rawIp[3] = (byte)value;
+
+                                    address = new IPAddress(rawIp);
+                                    break;
+                                }
+                            }
+
+                            if (address is null)
+                                return null; //failed to parse ipv4
+                        }
                     }
 
                     if (!string.IsNullOrEmpty(appRecordData))
@@ -182,7 +208,7 @@ namespace WildIp
         #region properties
 
         public string Description
-        { get { return "Returns the IP address that was embedded in the subdomain name for A and AAAA queries. It works similar to sslip.io."; } }
+        { get { return "Returns the IP address that was embedded in the subdomain name for A and AAAA queries, including compact hexadecimal IPv4 labels. It works similar to sslip.io."; } }
 
         public string ApplicationRecordDataTemplate
         {

--- a/Apps/WildIpApp/README.md
+++ b/Apps/WildIpApp/README.md
@@ -25,6 +25,8 @@ Create an APP record for the base name you want to use (for example `ip.example.
 
 - Parses decimal octets from the subdomain using `.` and `-` separators.
 - Example: `192-168-1-10.ip.example.com` → `192.168.1.10`
+- Accepts an 8-character hexadecimal IPv4 label, with optional labels before it.
+- Examples: `c0a8010a.ip.example.com` and `web.c0a8010a.ip.example.com` → `192.168.1.10`
 
 ### AAAA queries
 

--- a/Apps/WildIpApp/WildIpApp.csproj
+++ b/Apps/WildIpApp/WildIpApp.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-		<Version>6.0</Version>
+		<Version>6.1</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<Company>Technitium</Company>
 		<Product>Technitium DNS Server</Product>
@@ -13,7 +13,7 @@
 		<RootNamespace>WildIp</RootNamespace>
 		<PackageProjectUrl>https://technitium.com/dns/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/TechnitiumSoftware/DnsServer</RepositoryUrl>
-		<Description>Allows creating APP records in primary and forwarder zones that can return the IP address embedded in the subdomain name for A and AAAA queries. It works similar to sslip.io.</Description>
+		<Description>Allows creating APP records in primary and forwarder zones that can return the IP address embedded in the subdomain name for A and AAAA queries, including compact hexadecimal IPv4 labels. It works similar to sslip.io.</Description>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<OutputType>Library</OutputType>
 	</PropertyGroup>


### PR DESCRIPTION
## Summary

Add support for nip.io-style, eight-character hexadecimal IPv4 labels to the Wild IP App.

For example:

- `c0a864d3.ip.example.com` → `192.168.100.211`
- `C0A864D3.ip.example.com` → `192.168.100.211`
- `service.c0a864d3.ip.example.com` → `192.168.100.211`

## Root cause

Wild IP already recognizes compact 32-character hexadecimal IPv6 labels, but its IPv4 parsing path only collects four decimal octets separated by dots or dashes. A single eight-character IPv4 hexadecimal label therefore failed parsing and produced no synthesized A record.

## Changes

- recognize an exact eight-character hexadecimal IPv4 label after the existing decimal parser
- decode it in network byte order into an IPv4 address
- retain existing dotted, dashed, prefixed, and IPv6 parsing behavior
- pass decoded addresses through the existing `allowedNetworks` check
- bump the Wild IP App version from 6.0 to 6.1
- document compact hexadecimal IPv4 examples

## Validation

- built `TechnitiumLibrary.Net` and `Apps/WildIpApp/WildIpApp.csproj` in Release mode using .NET SDK 10.0.302
- build completed with 0 warnings and 0 errors
- packaged and installed the resulting app on Technitium DNS Server v15.4
- live-tested dotted IPv4, dashed IPv4, lowercase and uppercase hexadecimal IPv4, arbitrary prefixes, dashed IPv6, compact hexadecimal IPv6, and `allowedNetworks` enforcement
- independently reviewed and approved by @mohammed-asadd in the fork staging PR