### PR TITLE
Reduce allocations in concurrent forwarder selection

### DIFF
--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -5197,45 +5197,63 @@ namespace DnsServerCore.Dns
                     if (_proxy is null)
                     {
                         //recursive resolve forwarders only when proxy is null else let proxy resolve it to allow using .onion or private domains
-                        List<NameServerAddress> newForwarders = new List<NameServerAddress>(forwarders.Count);
-                        List<Task<NameServerAddress>> resolveTasks = new List<Task<NameServerAddress>>(forwarders.Count);
+                        NameServerAddress[] forwarderSnapshot = [.. forwarders];
+                        forwarders = forwarderSnapshot;
 
-                        foreach (NameServerAddress forwarder in forwarders)
+                        // Preserve the existing empty-forwarder failure path too.
+                        bool useResolutionPath = forwarderSnapshot.Length < 1;
+
+                        foreach (NameServerAddress forwarder in forwarderSnapshot)
                         {
                             if (forwarder.IsIPEndPointStale)
                             {
-                                //refresh forwarder IPEndPoint if stale
-                                resolveTasks.Add(TechnitiumLibrary.TaskExtensions.TimeoutAsync(async delegate (CancellationToken cancellationToken1)
-                                {
-                                    await forwarder.RecursiveResolveIPAddressAsync(dnsCache, null, _ipv6Mode, _udpPayloadSize, _randomizeName, _resolverRetries, _resolverTimeout, _resolverConcurrency, _resolverMaxStackCount, cancellationToken1);
-                                    return forwarder;
-                                }, RECURSIVE_RESOLUTION_TIMEOUT, cancellationToken));
-                            }
-                            else
-                            {
-                                newForwarders.Add(forwarder);
+                                useResolutionPath = true;
+                                break;
                             }
                         }
 
-                        Exception lastException = null;
-
-                        foreach (Task<NameServerAddress> resolveTask in resolveTasks)
+                        if (useResolutionPath)
                         {
-                            try
+                            List<NameServerAddress> newForwarders = new List<NameServerAddress>(forwarders.Count);
+                            List<Task<NameServerAddress>> resolveTasks = new List<Task<NameServerAddress>>(forwarders.Count);
+
+                            foreach (NameServerAddress forwarder in forwarders)
                             {
-                                newForwarders.Add(await resolveTask);
+                                if (forwarder.IsIPEndPointStale)
+                                {
+                                    //refresh forwarder IPEndPoint if stale
+                                    resolveTasks.Add(TechnitiumLibrary.TaskExtensions.TimeoutAsync(async delegate (CancellationToken cancellationToken1)
+                                    {
+                                        await forwarder.RecursiveResolveIPAddressAsync(dnsCache, null, _ipv6Mode, _udpPayloadSize, _randomizeName, _resolverRetries, _resolverTimeout, _resolverConcurrency, _resolverMaxStackCount, cancellationToken1);
+                                        return forwarder;
+                                    }, RECURSIVE_RESOLUTION_TIMEOUT, cancellationToken));
+                                }
+                                else
+                                {
+                                    newForwarders.Add(forwarder);
+                                }
                             }
-                            catch (Exception ex)
+
+                            Exception lastException = null;
+
+                            foreach (Task<NameServerAddress> resolveTask in resolveTasks)
                             {
-                                lastException = ex;
-                                _resolverLog?.Write(ex);
+                                try
+                                {
+                                    newForwarders.Add(await resolveTask);
+                                }
+                                catch (Exception ex)
+                                {
+                                    lastException = ex;
+                                    _resolverLog?.Write(ex);
+                                }
                             }
+
+                            if (newForwarders.Count < 1)
+                                throw new DnsServerException("Failed to resolve forwarder domain name for all forwarders: " + forwarders.Join(), lastException);
+
+                            forwarders = newForwarders;
                         }
-
-                        if (newForwarders.Count < 1)
-                            throw new DnsServerException("Failed to resolve forwarder domain name for all forwarders: " + forwarders.Join(), lastException);
-
-                        forwarders = newForwarders;
                     }
 
                     //query forwarders and update cache


### PR DESCRIPTION
## Summary

- snapshot configured forwarders once per concurrent/no-proxy resolution
- avoid allocating the two selection lists and async resolution closures when every endpoint is already fresh
- retain the existing stale-endpoint resolution path unchanged

This is deliberately separate from #2060: it is a hot-path allocation optimization, not a statistics-retention fix.

## Why

The global forwarding path currently allocates `newForwarders` and `resolveTasks` for every concurrent resolution, even when the configured endpoints are already resolved. That is the common case for long-running forwarders, including concurrent DNS-over-QUIC upstream configurations.

The candidate takes one typed array snapshot first, preserving per-query membership, source order, duplicates, and object identity. It scans that snapshot for stale endpoints. Fresh snapshots pass directly to the existing `DnsClient` path; if any endpoint is stale—or the configuration is empty—the stock resolution/error path runs with the snapshot.

Proxy and sequential branches are untouched.

## Allocation measurement

Release, .NET SDK 10.0.302, selection fragment only (before `DnsClient`):

| Forwarders | Current | Candidate | Saved |
|---:|---:|---:|---:|
| 2 | 176 B/op | 40 B/op | 136 B/op |
| 8 | 272 B/op | 88 B/op | 184 B/op |
| 64 | 1,168 B/op | 536 B/op | 632 B/op |

For the ordinary two-forwarder case this removes 136 B/op from this fragment. It is not presented as a percentage reduction for the whole resolver request.

## Verification

- documented Linux Release publish succeeds
- equivalence harness covers empty, single and multiple inputs
- configured order, duplicates, null behavior and object identity preserved
- membership is stable after caller-owned source mutation
- mutation during source enumeration still fails rather than promising unsupported concurrent mutation
- stale ordering and failure behavior preserved
- proxy and sequential branches bypass the new path
- `git diff --check` passes

The stale case pays for the initial snapshot before entering the unchanged resolution path. That small rare-path cost is the tradeoff for a single source observation and stable per-query membership.