### PR TITLE
Fix: one unloadable type in a DNS App assembly prevents every type in it from registering

### DIFF
--- a/DnsServerCore/Dns/Applications/DnsApplication.cs
+++ b/DnsServerCore/Dns/Applications/DnsApplication.cs
@@ -77,70 +77,94 @@ namespace DnsServerCore.Dns.Applications
 
             foreach (Assembly appAssembly in _appContext.AppAssemblies)
             {
+                Type[] classTypes;
+
                 try
                 {
-                    foreach (Type classType in appAssembly.ExportedTypes)
+                    //use GetTypes(), not ExportedTypes: GetTypes() reports partial results via
+                    //ReflectionTypeLoadException when one or more referenced types fail to load,
+                    //so a single bad type does not abort discovery of the rest of the assembly
+                    classTypes = appAssembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    classTypes = ex.Types; //array may contain null entries for the types that failed to load
+
+                    foreach (Exception loaderException in ex.LoaderExceptions)
                     {
-                        bool isDnsApp = false;
-
-                        foreach (Type interfaceType in classType.GetInterfaces())
-                        {
-                            if (interfaceType == _dnsApplicationInterface)
-                            {
-                                isDnsApp = true;
-                                break;
-                            }
-                        }
-
-                        if (isDnsApp)
-                        {
-                            try
-                            {
-                                IDnsApplication app = Activator.CreateInstance(classType) as IDnsApplication;
-
-                                dnsApplications.Add(classType.FullName, app);
-
-                                if (app is IDnsAppRecordRequestHandler appRecordHandler)
-                                    dnsAppRecordRequestHandlers.Add(classType.FullName, appRecordHandler);
-
-                                if (app is IDnsRequestController requestController)
-                                    dnsRequestControllers.Add(classType.FullName, requestController);
-
-                                if (app is IDnsAuthoritativeRequestHandler requestHandler)
-                                    dnsAuthoritativeRequestHandlers.Add(classType.FullName, requestHandler);
-
-                                if (app is IDnsRequestBlockingHandler blockingHandler)
-                                    dnsRequestBlockingHandlers.Add(classType.FullName, blockingHandler);
-
-                                if (app is IDnsQueryLogger logger)
-                                    dnsQueryLoggers.Add(classType.FullName, logger);
-
-                                if (app is IDnsQueryLogs queryLogs)
-                                    dnsQueryLogs.Add(classType.FullName, queryLogs);
-
-                                if (app is IDnsPostProcessor postProcessor)
-                                    dnsPostProcessors.Add(classType.FullName, postProcessor);
-
-                                if (_description is null)
-                                {
-                                    AssemblyDescriptionAttribute attribute = appAssembly.GetCustomAttribute<AssemblyDescriptionAttribute>();
-                                    if (attribute is not null)
-                                        _description = attribute.Description.Replace("\\n", "\n");
-                                }
-
-                                if (_version is null)
-                                    _version = appAssembly.GetName().Version;
-                            }
-                            catch (Exception ex)
-                            {
-                                _dnsServer.WriteLog(ex);
-                            }
-                        }
+                        if (loaderException is not null)
+                            _dnsServer.WriteLog(loaderException);
                     }
                 }
                 catch (Exception ex)
                 {
                     _dnsServer.WriteLog(ex);
+                    continue;
+                }
+
+                foreach (Type classType in classTypes)
+                {
+                    if (classType is null)
+                        continue; //this type failed to load; ReflectionTypeLoadException.Types already logged above
+
+                    if (!classType.IsVisible)
+                        continue; //match ExportedTypes semantics: only types visible outside the assembly
+
+                    bool isDnsApp = false;
+
+                    foreach (Type interfaceType in classType.GetInterfaces())
+                    {
+                        if (interfaceType == _dnsApplicationInterface)
+                        {
+                            isDnsApp = true;
+                            break;
+                        }
+                    }
+
+                    if (isDnsApp)
+                    {
+                        try
+                        {
+                            IDnsApplication app = Activator.CreateInstance(classType) as IDnsApplication;
+
+                            dnsApplications.Add(classType.FullName, app);
+
+                            if (app is IDnsAppRecordRequestHandler appRecordHandler)
+                                dnsAppRecordRequestHandlers.Add(classType.FullName, appRecordHandler);
+
+                            if (app is IDnsRequestController requestController)
+                                dnsRequestControllers.Add(classType.FullName, requestController);
+
+                            if (app is IDnsAuthoritativeRequestHandler requestHandler)
+                                dnsAuthoritativeRequestHandlers.Add(classType.FullName, requestHandler);
+
+                            if (app is IDnsRequestBlockingHandler blockingHandler)
+                                dnsRequestBlockingHandlers.Add(classType.FullName, blockingHandler);
+
+                            if (app is IDnsQueryLogger logger)
+                                dnsQueryLoggers.Add(classType.FullName, logger);
+
+                            if (app is IDnsQueryLogs queryLogs)
+                                dnsQueryLogs.Add(classType.FullName, queryLogs);
+
+                            if (app is IDnsPostProcessor postProcessor)
+                                dnsPostProcessors.Add(classType.FullName, postProcessor);
+
+                            if (_description is null)
+                            {
+                                AssemblyDescriptionAttribute attribute = appAssembly.GetCustomAttribute<AssemblyDescriptionAttribute>();
+                                if (attribute is not null)
+                                    _description = attribute.Description.Replace("\\n", "\n");
+                            }
+
+                            if (_version is null)
+                                _version = appAssembly.GetName().Version;
+                        }
+                        catch (Exception ex)
+                        {
+                            _dnsServer.WriteLog(ex);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## The bug

`DnsApplication`'s constructor discovers app classes like this (`DnsApplication.cs`, trimmed):

```csharp
try
{
    foreach (Type classType in appAssembly.ExportedTypes)
    {
        // register classType if it implements IDnsApplication
    }
}
catch (Exception ex)
{
    _dnsServer.WriteLog(ex);
}
```

`ExportedTypes` calls `GetExportedTypes()`, which resolves every type in the assembly before returning anything. If a single type fails to resolve (for example, its base type lives in an assembly that isn't present), the whole call throws and the loop body never runs. The catch logs that one exception and the app ends up installed with no classes registered at all. The install API still reports `"status": "ok"`, so nothing looks wrong anywhere except a single loader exception in the log, and that exception says nothing about the healthy types that were never attempted.

Since apps are sideloaded zips that carry their own dependency DLLs, a missing or mispackaged DLL is all it takes to hit this. And if the assembly contains an `IDnsRequestBlockingHandler`, blocking is now off while the server keeps resolving normally, which is a hard failure mode to notice.

## The fix

Use `Assembly.GetTypes()` and handle its partial-failure mode: on `ReflectionTypeLoadException`, the exception's `Types` array still contains every type that did load (with `null` in the slots for the ones that didn't). The loop now logs each entry of `LoaderExceptions` and carries on with the types that loaded. Any other exception is logged and aborts that assembly, same as before.

`GetTypes()` also returns non-exported types, unlike `ExportedTypes`, so the loop gains a `classType.IsVisible` check to keep the original exported-only behavior. For an assembly where every type loads cleanly, the registration outcome is unchanged.

## Testing

Repro: an app assembly with three public classes implementing `IDnsApplication` (AlphaApp, BravoApp, CharlieApp), where BravoApp's base type lives in a second helper assembly that is deliberately left out of the app zip.

On a stock v15.4.0 container, installing that zip reports `"status": "ok"` but `/api/apps/list` shows `"dnsApps": []` -- none of the three classes registered -- and the log contains one `FileNotFoundException` thrown from inside `GetExportedTypes()`. With this change, AlphaApp and CharlieApp both register, BravoApp is skipped, and its loader exception is logged.

Also verified the change builds standalone on an otherwise clean v15.4.0 tree (DnsServerCore build and DnsServerApp publish).
