### PR TITLE
Fix DHCP broadcast handling on FreeBSD

### DIFF
--- a/DnsServerCore/Dhcp/DhcpServer.cs
+++ b/DnsServerCore/Dhcp/DhcpServer.cs
@@ -261,7 +261,39 @@ namespace DnsServerCore.Dhcp
                         else
                             udpSocket = udpListener; //no appropriate socket found so use default socket
 
-                        if (OperatingSystem.IsMacOS())
+                        if (OperatingSystem.IsFreeBSD())
+                        {
+                            Scope broadcastScope = null;
+
+                            foreach (KeyValuePair<string, Scope> entry in _scopes)
+                            {
+                                Scope scope = entry.Value;
+
+                                if (!scope.Enabled)
+                                    continue;
+
+                                if (!scope.InterfaceAddress.Equals(response.ServerIdentifier.Address))
+                                    continue;
+
+                                if (!response.YourClientIpAddress.Equals(IPAddress.Any) &&
+                                    !scope.IsAddressInNetwork(response.YourClientIpAddress))
+                                    continue;
+
+                                if (broadcastScope is not null)
+                                    throw new InvalidOperationException("Multiple DHCP scopes match FreeBSD broadcast response.");
+
+                                broadcastScope = scope;
+                            }
+
+                            if (broadcastScope is null)
+                                throw new InvalidOperationException("No DHCP scope found for FreeBSD broadcast response.");
+
+                            await udpSocket.SendToAsync(
+                                new ArraySegment<byte>(sendBuffer, 0, (int)sendBufferStream.Position),
+                                SocketFlags.DontRoute,
+                                new IPEndPoint(broadcastScope.BroadcastAddress, 68));
+                        }
+                        else if (OperatingSystem.IsMacOS())
                             await udpSocket.SendToAsync(new ArraySegment<byte>(sendBuffer, 0, (int)sendBufferStream.Position), SocketFlags.None, new IPEndPoint(IPAddress.Broadcast, 68));
                         else
                             await udpSocket.SendToAsync(new ArraySegment<byte>(sendBuffer, 0, (int)sendBufferStream.Position), SocketFlags.DontRoute, new IPEndPoint(IPAddress.Broadcast, 68)); //no routing for broadcast
@@ -627,6 +659,34 @@ namespace DnsServerCore.Dhcp
                         return null; //message destination address must be broadcast address
 
                     //broadcast request
+                    if (OperatingSystem.IsFreeBSD() && (ipPacketInformation.Interface == 0))
+                    {
+                        Scope fallbackScope = null;
+                        int fallbackScopeCount = 0;
+
+                        foreach (KeyValuePair<string, Scope> entry in _scopes)
+                        {
+                            Scope scope = entry.Value;
+
+                            if (!scope.Enabled)
+                                continue;
+
+                            if (scope.GetReservedLease(request) != null)
+                                return scope;
+
+                            if (!scope.AllowOnlyReservedLeases)
+                            {
+                                fallbackScope = scope;
+                                fallbackScopeCount++;
+                            }
+                        }
+
+                        if (fallbackScopeCount == 1)
+                            return fallbackScope;
+
+                        return null;
+                    }
+
                     Scope foundScope = null;
 
                     foreach (KeyValuePair<string, Scope> entry in _scopes)


### PR DESCRIPTION
## Summary

This PR fixes two FreeBSD-specific DHCPv4 issues:

1. `IPPacketInformation.Interface` may be returned as `0` for IPv4 broadcast DHCP packets on FreeBSD, preventing the server from matching the request to the correct DHCP scope.

2. Sending DHCP broadcast replies to `255.255.255.255` fails on FreeBSD in the tested environment, while sending to the matching scope's directed broadcast address succeeds.

## Changes

- Add a FreeBSD-only fallback for DHCP scope selection when the received interface index is `0`.
- Send FreeBSD DHCP broadcast replies to the matching scope's `BroadcastAddress`.
- Preserve the existing behavior for macOS and all other platforms.

## Testing

Tested with:

- Technitium DNS Server 15.4.0
- FreeBSD 15.1 / OPNsense 26.7.x
- .NET 10.0.10

After applying both changes, the complete DHCP exchange succeeds:

`DHCPDISCOVER -> DHCPOFFER -> DHCPREQUEST -> DHCPACK`

The FreeBSD-specific socket behavior and reproducer results are documented in the related issue.

Refs #2099