### PR TITLE
Add DNSSEC online signing for APP and ANAME/ALIAS records

### DIFF
--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -4135,10 +4135,24 @@ namespace DnsServerCore.Dns
 
                             if (dnssecOk)
                             {
-                                //add proof of non existence (NODATA) for the APP record's own owner name; the
-                                //dynamic answer's actual content has no static NSEC/NSEC3 coverage of its own,
-                                //but nonexistence of any record at this exact name is already provable statically
-                                IReadOnlyList<DnsResourceRecord> nsecRecords = _authZoneManager.GetNSecProofOfNonExistenceNoData(request.Question[0].Name);
+                                IReadOnlyList<DnsResourceRecord> nsecRecords;
+
+                                if (rcode == DnsResponseCode.NxDomain)
+                                {
+                                    //non-wildcard APP record answering for a subdomain beneath its own owner
+                                    //name (closest-ancestor fallback) that the app declined to answer: qname
+                                    //itself does not exist, so this needs a real NXDOMAIN proof of cover, not
+                                    //the NODATA proof for the record's own owner name
+                                    nsecRecords = _authZoneManager.GetNSecProofOfNonExistenceNxDomain(request.Question[0].Name, false);
+                                }
+                                else
+                                {
+                                    //add proof of non existence (NODATA) for the APP record's own owner name; the
+                                    //dynamic answer's actual content has no static NSEC/NSEC3 coverage of its own,
+                                    //but nonexistence of any record at this exact name is already provable statically
+                                    nsecRecords = _authZoneManager.GetNSecProofOfNonExistenceNoData(request.Question[0].Name);
+                                }
+
                                 if (nsecRecords.Count > 0)
                                 {
                                     List<DnsResourceRecord> newAuthority = new List<DnsResourceRecord>(authority.Count + nsecRecords.Count);

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -3970,6 +3970,123 @@ namespace DnsServerCore.Dns
             }
         }
 
+        //Online DNSSEC signing for dynamically resolved answers (APP and ANAME/ALIAS records): the actual answer
+        //content is not known until query time, so it cannot be pre-signed by the normal offline zone signing
+        //cycle. Only the RRset(s) that directly answer the query (owner name == qname) are signed here; any
+        //other owner names an app/ANAME chain may touch (e.g. an externally recursed CNAME target) are left
+        //unsigned since they are not this zone's data to sign.
+        private IReadOnlyList<DnsResourceRecord> SignDynamicAnswer(ApexZone apexZone, string recordOwnerName, string qname, IReadOnlyList<DnsResourceRecord> answer)
+        {
+            Dictionary<DnsResourceRecordType, List<DnsResourceRecord>> rrsetsByType = null;
+
+            foreach (DnsResourceRecord record in answer)
+            {
+                if (!record.Name.Equals(qname, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                rrsetsByType ??= new Dictionary<DnsResourceRecordType, List<DnsResourceRecord>>();
+
+                if (!rrsetsByType.TryGetValue(record.Type, out List<DnsResourceRecord> rrset))
+                {
+                    rrset = new List<DnsResourceRecord>();
+                    rrsetsByType[record.Type] = rrset;
+                }
+
+                rrset.Add(record);
+            }
+
+            if (rrsetsByType is null)
+                return answer;
+
+            List<DnsResourceRecord> newAnswer = new List<DnsResourceRecord>(answer);
+
+            foreach (List<DnsResourceRecord> rrset in rrsetsByType.Values)
+                newAnswer.AddRange(SignDynamicAnswerRRSet(apexZone, recordOwnerName, rrset));
+
+            return newAnswer;
+        }
+
+        //Two-phase sign so that a wildcard-owned dynamic record (e.g. "*.example.com") gets an RRSIG with the
+        //correct RFC 4035 Labels field: DnssecPrivateKey.SignRRSet derives Labels from records[0].Name, so the
+        //RRset must be signed under its literal owner name in the zone (the wildcard form), then the resulting
+        //RRSIG's envelope owner name is rewritten to the actual (possibly QNAME-expanded) answer name, mirroring
+        //AuthZone.QueryRecordsWildcard's handling of static wildcard records.
+        private IReadOnlyList<DnsResourceRecord> SignDynamicAnswerRRSet(ApexZone apexZone, string recordOwnerName, IReadOnlyList<DnsResourceRecord> rrset)
+        {
+            string answerName = rrset[0].Name;
+
+            if (recordOwnerName.Equals(answerName, StringComparison.OrdinalIgnoreCase))
+                return apexZone.SignRRSet(rrset);
+
+            DnsResourceRecord[] signingRRset = new DnsResourceRecord[rrset.Count];
+
+            for (int i = 0; i < rrset.Count; i++)
+                signingRRset[i] = new DnsResourceRecord(recordOwnerName, rrset[i].Type, rrset[i].Class, rrset[i].TTL, rrset[i].RDATA);
+
+            IReadOnlyList<DnsResourceRecord> rrsigRecords = apexZone.SignRRSet(signingRRset);
+            if (rrsigRecords.Count == 0)
+                return rrsigRecords;
+
+            DnsResourceRecord[] rewrittenRRSigRecords = new DnsResourceRecord[rrsigRecords.Count];
+
+            for (int i = 0; i < rrsigRecords.Count; i++)
+                rewrittenRRSigRecords[i] = new DnsResourceRecord(answerName, rrsigRecords[i].Type, rrsigRecords[i].Class, rrsigRecords[i].TTL, rrsigRecords[i].RDATA);
+
+            return rewrittenRRSigRecords;
+        }
+
+        //Signs every RRset in an ANAME/ALIAS-resolved answer. Each record already carries the ANAME record's own
+        //owner name (set by ResolveANAMEAsync), which for a wildcard-owned ANAME has already been expanded to the
+        //queried name by AuthZoneManager.InternalQuery's wildcard substitution. To get the correct RFC 4035
+        //Labels field in that case, re-derive the literal (possibly wildcard) owner name of the AuthZone that
+        //actually stores the ANAME record via AuthZoneManager.GetRecordOwnerName, and route through the same
+        //two-phase signing path APP already uses.
+        private IReadOnlyList<DnsResourceRecord> SignAnameAnswer(ApexZone apexZone, IReadOnlyList<DnsResourceRecord> answer, out IReadOnlyList<DnsResourceRecord> wildcardProofAuthority)
+        {
+            wildcardProofAuthority = null;
+
+            if (answer.Count == 0)
+                return answer;
+
+            Dictionary<(string, DnsResourceRecordType), List<DnsResourceRecord>> rrsetsByNameType = new Dictionary<(string, DnsResourceRecordType), List<DnsResourceRecord>>();
+
+            foreach (DnsResourceRecord record in answer)
+            {
+                var key = (record.Name.ToLowerInvariant(), record.Type);
+                if (!rrsetsByNameType.TryGetValue(key, out List<DnsResourceRecord> rrset))
+                {
+                    rrset = new List<DnsResourceRecord>();
+                    rrsetsByNameType[key] = rrset;
+                }
+
+                rrset.Add(record);
+            }
+
+            List<DnsResourceRecord> newAnswer = new List<DnsResourceRecord>(answer);
+            List<DnsResourceRecord> newWildcardProofAuthority = null;
+
+            foreach (List<DnsResourceRecord> rrset in rrsetsByNameType.Values)
+            {
+                string recordOwnerName = _authZoneManager.GetRecordOwnerName(rrset[0].Name) ?? rrset[0].Name;
+                newAnswer.AddRange(SignDynamicAnswerRRSet(apexZone, recordOwnerName, rrset));
+
+                if (recordOwnerName.StartsWith('*'))
+                {
+                    //RFC 4035 5.3.4: prove the exact qname does not exist as a literal zone entry, so the
+                    //validator can tell this wildcard expansion apart from a spoofed answer
+                    IReadOnlyList<DnsResourceRecord> wildcardProof = _authZoneManager.GetNSecProofOfWildcardAnswer(rrset[0].Name);
+                    if (wildcardProof.Count > 0)
+                    {
+                        newWildcardProofAuthority ??= new List<DnsResourceRecord>();
+                        newWildcardProofAuthority.AddRange(wildcardProof);
+                    }
+                }
+            }
+
+            wildcardProofAuthority = newWildcardProofAuthority;
+            return newAnswer;
+        }
+
         private async Task<DnsDatagram> ProcessAPPAsync(DnsDatagram request, DnsDatagram response, IPEndPoint remoteEP, DnsTransportProtocol protocol, bool isRecursionAllowed, bool skipDnsAppAuthoritativeRequestHandlers, int clientTimeout)
         {
             DnsResourceRecord appResourceRecord = response.Authority[0];
@@ -3980,6 +4097,7 @@ namespace DnsServerCore.Dns
                 if (application.DnsAppRecordRequestHandlers.TryGetValue(appRecord.ClassPath, out IDnsAppRecordRequestHandler appRecordRequestHandler))
                 {
                     AuthZoneInfo zoneInfo = _authZoneManager.FindAuthZoneInfo(appResourceRecord.Name);
+                    bool dnssecOk = request.DnssecOk && (zoneInfo.Type == AuthZoneType.Primary) && (zoneInfo.ApexZone.DnssecStatus != AuthZoneDnssecStatus.Unsigned);
 
                     DnsDatagram appResponse = await appRecordRequestHandler.ProcessRequestAsync(request, remoteEP, protocol, isRecursionAllowed, zoneInfo.Name, appResourceRecord.Name, appResourceRecord.TTL, appRecord.Data);
                     if (appResponse is null)
@@ -4013,13 +4131,73 @@ namespace DnsServerCore.Dns
                             else
                                 rcode = DnsResponseCode.NxDomain;
 
-                            authority = zoneInfo.ApexZone.GetRecords(DnsResourceRecordType.SOA);
+                            authority = zoneInfo.ApexZone.QueryRecords(DnsResourceRecordType.SOA, dnssecOk);
+
+                            if (dnssecOk)
+                            {
+                                //add proof of non existence (NODATA) for the APP record's own owner name; the
+                                //dynamic answer's actual content has no static NSEC/NSEC3 coverage of its own,
+                                //but nonexistence of any record at this exact name is already provable statically
+                                IReadOnlyList<DnsResourceRecord> nsecRecords = _authZoneManager.GetNSecProofOfNonExistenceNoData(request.Question[0].Name);
+                                if (nsecRecords.Count > 0)
+                                {
+                                    List<DnsResourceRecord> newAuthority = new List<DnsResourceRecord>(authority.Count + nsecRecords.Count);
+
+                                    newAuthority.AddRange(authority);
+                                    newAuthority.AddRange(nsecRecords);
+
+                                    authority = newAuthority;
+                                }
+                            }
                         }
 
                         return new DnsDatagram(request.Identifier, true, request.OPCODE, false, false, request.RecursionDesired, isRecursionAllowed, false, request.CheckingDisabled, rcode, request.Question, null, authority) { Tag = DnsServerResponseType.Authoritative };
                     }
                     else
                     {
+                        if (dnssecOk && appResponse.AuthoritativeAnswer && (appResponse.Answer.Count > 0))
+                        {
+                            IReadOnlyList<DnsResourceRecord> signedAnswer = SignDynamicAnswer(zoneInfo.ApexZone, appResourceRecord.Name, request.Question[0].Name, appResponse.Answer);
+                            if (signedAnswer.Count > appResponse.Answer.Count)
+                            {
+                                IReadOnlyList<DnsResourceRecord> signedAuthority = appResponse.Authority;
+
+                                if (appResourceRecord.Name.StartsWith('*'))
+                                {
+                                    //RFC 4035 5.3.4: prove the exact qname does not exist as a literal zone entry,
+                                    //so the validator can tell this wildcard expansion apart from a spoofed answer
+                                    IReadOnlyList<DnsResourceRecord> wildcardProof = _authZoneManager.GetNSecProofOfWildcardAnswer(request.Question[0].Name);
+                                    if (wildcardProof.Count > 0)
+                                    {
+                                        List<DnsResourceRecord> newAuthority = new List<DnsResourceRecord>(appResponse.Authority.Count + wildcardProof.Count);
+
+                                        newAuthority.AddRange(appResponse.Authority);
+                                        newAuthority.AddRange(wildcardProof);
+
+                                        signedAuthority = newAuthority;
+                                    }
+                                }
+
+                                appResponse = new DnsDatagram(appResponse.Identifier, appResponse.IsResponse, appResponse.OPCODE, appResponse.AuthoritativeAnswer, appResponse.Truncation, appResponse.RecursionDesired, appResponse.RecursionAvailable, appResponse.AuthenticData, appResponse.CheckingDisabled, appResponse.RCODE, appResponse.Question, signedAnswer, signedAuthority, appResponse.Additional, appResponse.EDNS is null ? ushort.MinValue : appResponse.EDNS.UdpPayloadSize, appResponse.EDNS is null ? EDnsHeaderFlags.None : appResponse.EDNS.Flags, appResponse.EDNS?.Options);
+                            }
+                        }
+                        else if (dnssecOk && appResponse.AuthoritativeAnswer && (appResponse.RCODE == DnsResponseCode.NoError) && (appResponse.Answer.Count == 0))
+                        {
+                            //some apps (e.g. the NO DATA app) construct their own explicit NODATA response
+                            //instead of returning null - secure it the same way as the null-appResponse NODATA
+                            //path above: signed SOA + NSEC/NSEC3 proof of non existence at the queried name
+                            IReadOnlyList<DnsResourceRecord> signedSoa = zoneInfo.ApexZone.QueryRecords(DnsResourceRecordType.SOA, dnssecOk);
+                            IReadOnlyList<DnsResourceRecord> nsecRecords = _authZoneManager.GetNSecProofOfNonExistenceNoData(request.Question[0].Name);
+
+                            List<DnsResourceRecord> newAuthority = new List<DnsResourceRecord>(appResponse.Authority.Count + signedSoa.Count + nsecRecords.Count);
+
+                            newAuthority.AddRange(appResponse.Authority);
+                            newAuthority.AddRange(signedSoa);
+                            newAuthority.AddRange(nsecRecords);
+
+                            appResponse = new DnsDatagram(appResponse.Identifier, appResponse.IsResponse, appResponse.OPCODE, appResponse.AuthoritativeAnswer, appResponse.Truncation, appResponse.RecursionDesired, appResponse.RecursionAvailable, appResponse.AuthenticData, appResponse.CheckingDisabled, appResponse.RCODE, appResponse.Question, appResponse.Answer, newAuthority, appResponse.Additional, appResponse.EDNS is null ? ushort.MinValue : appResponse.EDNS.UdpPayloadSize, appResponse.EDNS is null ? EDnsHeaderFlags.None : appResponse.EDNS.Flags, appResponse.EDNS?.Options);
+                        }
+
                         if (appResponse.AuthoritativeAnswer)
                             appResponse.Tag = DnsServerResponseType.Authoritative;
 
@@ -4474,6 +4652,7 @@ namespace DnsServerCore.Dns
 
             DnsResponseCode rcode = DnsResponseCode.NoError;
             IReadOnlyList<DnsResourceRecord> authority = null;
+            IReadOnlyList<DnsResourceRecord> finalAnswer = responseAnswer;
 
             if (responseAnswer.Count == 0)
             {
@@ -4483,6 +4662,8 @@ namespace DnsServerCore.Dns
                 }
                 else
                 {
+                    //authority (SOA, and NSEC/NSEC3 proof when signed) was already resolved by the caller in
+                    //AuthZoneManager.InternalQuery for use with this NODATA response
                     authority = response.Authority;
 
                     //update last used on
@@ -4492,8 +4673,18 @@ namespace DnsServerCore.Dns
                         record.GetAuthGenericRecordInfo().LastUsedOn = utcNow;
                 }
             }
+            else if (request.DnssecOk)
+            {
+                AuthZoneInfo zoneInfo = _authZoneManager.FindAuthZoneInfo(request.Question[0].Name);
+                if ((zoneInfo is not null) && (zoneInfo.Type == AuthZoneType.Primary) && (zoneInfo.ApexZone.DnssecStatus != AuthZoneDnssecStatus.Unsigned))
+                {
+                    finalAnswer = SignAnameAnswer(zoneInfo.ApexZone, responseAnswer, out IReadOnlyList<DnsResourceRecord> wildcardProofAuthority);
+                    if (wildcardProofAuthority is not null)
+                        authority = wildcardProofAuthority;
+                }
+            }
 
-            return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, true, false, request.RecursionDesired, isRecursionAllowed, false, request.CheckingDisabled, rcode, request.Question, responseAnswer, authority) { Tag = response.Tag };
+            return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, true, false, request.RecursionDesired, isRecursionAllowed, false, request.CheckingDisabled, rcode, request.Question, finalAnswer, authority) { Tag = response.Tag };
         }
 
         private async Task<bool> IsAllowedAsync(DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol)

--- a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
@@ -833,14 +833,26 @@ namespace DnsServerCore.Dns.ZoneManagers
         //a static fact independent of what the app/ANAME resolves per query - no new denial machinery needed.
         internal IReadOnlyList<DnsResourceRecord> GetNSecProofOfWildcardAnswer(string qname)
         {
+            return GetNSecProofOfNonExistenceNxDomain(qname, true);
+        }
+
+        //General NXDOMAIN proof of non existence for a qname, for the case where a non-wildcard dynamic (APP)
+        //record answers on behalf of a subdomain beneath its own owner name (e.g. an APP record at
+        //"app.example.com" answering for "x.y.app.example.com" via the closest-ancestor fallback in
+        //InternalQuery) and the app declines to answer, so the response is a genuine NXDOMAIN rather than
+        //NODATA. Unlike GetNSecProofOfNonExistenceNoData (which proves "this exact name exists but the type
+        //doesn't", using the static NSEC/NSEC3 record stored at the record's own owner name), this proves the
+        //qname itself does not exist at all - the correct static-chain proof for that rcode.
+        internal IReadOnlyList<DnsResourceRecord> GetNSecProofOfNonExistenceNxDomain(string qname, bool isWildcardAnswer)
+        {
             AuthZone zone = _root.FindZone(qname, out _, out _, out ApexZone apexZone, out _);
             if ((apexZone is null) || (apexZone.DnssecStatus == AuthZoneDnssecStatus.Unsigned))
                 return Array.Empty<DnsResourceRecord>();
 
             if (apexZone.DnssecStatus == AuthZoneDnssecStatus.SignedWithNSEC3)
-                return _root.FindNSec3ProofOfNonExistenceNxDomain(qname, true);
+                return _root.FindNSec3ProofOfNonExistenceNxDomain(qname, isWildcardAnswer);
 
-            return _root.FindNSecProofOfNonExistenceNxDomain(qname, true);
+            return _root.FindNSecProofOfNonExistenceNxDomain(qname, isWildcardAnswer);
         }
 
         //Returns the literal owner name of the AuthZone actually storing records at qname (e.g. "*.example.com"

--- a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
@@ -805,6 +805,53 @@ namespace DnsServerCore.Dns.ZoneManagers
             return _root.GetApexZone(zoneName);
         }
 
+        internal IReadOnlyList<DnsResourceRecord> GetNSecProofOfNonExistenceNoData(string qname)
+        {
+            //when qname only matches via a wildcard (e.g. a wildcard-owned APP record), FindZone returns the
+            //exact zone as null and provides the wildcard zone via closest instead - same fallback chain
+            //InternalQuery itself uses (see the closest.QueryRecords(APP, ...) / apexZone.QueryRecords(APP, ...)
+            //fallback above). FindNSecProofOfNonExistenceNoData/FindNSec3ProofOfNonExistenceNoData already detect
+            //a wildcard-named zone internally and add the extra proof-of-cover records for the exact qname.
+            AuthZone zone = _root.FindZone(qname, out SubDomainZone closest, out _, out ApexZone apexZone, out _);
+            AuthZone effectiveZone = zone ?? closest;
+
+            if ((effectiveZone is null) || (apexZone is null) || (apexZone.DnssecStatus == AuthZoneDnssecStatus.Unsigned))
+                return Array.Empty<DnsResourceRecord>();
+
+            if (apexZone.DnssecStatus == AuthZoneDnssecStatus.SignedWithNSEC3)
+                return _root.FindNSec3ProofOfNonExistenceNoData(qname, effectiveZone, apexZone);
+
+            return _root.FindNSecProofOfNonExistenceNoData(qname, effectiveZone);
+        }
+
+        //RFC 4035 5.3.4: a positive answer synthesized from a wildcard must also include proof that the exact
+        //qname does not exist as a literal zone entry (otherwise a validator cannot tell the wildcard expansion
+        //apart from a spoofed answer, and rejects the response outright - confirmed empirically with delv, which
+        //fails "no valid NSEC" on a wildcard-owned APP/ANAME positive answer without this). Only relevant when
+        //recordOwnerName (the record's literal, possibly-wildcard owner from GetRecordOwnerName) starts with "*".
+        //Reuses the zone's existing static NSEC/NSEC3 chain, since whether a literal zone node exists at qname is
+        //a static fact independent of what the app/ANAME resolves per query - no new denial machinery needed.
+        internal IReadOnlyList<DnsResourceRecord> GetNSecProofOfWildcardAnswer(string qname)
+        {
+            AuthZone zone = _root.FindZone(qname, out _, out _, out ApexZone apexZone, out _);
+            if ((apexZone is null) || (apexZone.DnssecStatus == AuthZoneDnssecStatus.Unsigned))
+                return Array.Empty<DnsResourceRecord>();
+
+            if (apexZone.DnssecStatus == AuthZoneDnssecStatus.SignedWithNSEC3)
+                return _root.FindNSec3ProofOfNonExistenceNxDomain(qname, true);
+
+            return _root.FindNSecProofOfNonExistenceNxDomain(qname, true);
+        }
+
+        //Returns the literal owner name of the AuthZone actually storing records at qname (e.g. "*.example.com"
+        //for a wildcard hit), as opposed to qname itself. Used to sign a dynamically resolved answer (ANAME/ALIAS)
+        //under its true wildcard owner so DnssecPrivateKey.SignRRSet computes the correct RFC 4035 Labels field.
+        internal string GetRecordOwnerName(string qname)
+        {
+            AuthZone zone = _root.FindZone(qname, out SubDomainZone closest, out _, out _, out _);
+            return (zone ?? closest)?.Name;
+        }
+
         public bool NameExists(string zoneName, string domain)
         {
             ValidateIfDomainBelongsToZone(zoneName, domain);
@@ -3226,7 +3273,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                     else
                     {
                         answer = null;
-                        authority = closest.QueryRecords(DnsResourceRecordType.APP, false);
+                        authority = closest.QueryRecords(DnsResourceRecordType.APP, dnssecOk);
                     }
                 }
 
@@ -3241,7 +3288,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                     else
                     {
                         answer = null;
-                        authority = apexZone.QueryRecords(DnsResourceRecordType.APP, false);
+                        authority = apexZone.QueryRecords(DnsResourceRecordType.APP, dnssecOk);
                         if (authority.Count == 0)
                         {
                             if ((apexZone is ForwarderZone) || (apexZone is SecondaryForwarderZone))
@@ -3359,7 +3406,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                                 return GetReferralResponse(request, false, apexZone, apexZone);
                         }
 
-                        authority = zone.QueryRecords(DnsResourceRecordType.APP, false);
+                        authority = zone.QueryRecords(DnsResourceRecordType.APP, dnssecOk);
                         if (authority.Count == 0)
                         {
                             if ((apexZone is ForwarderZone) || (apexZone is SecondaryForwarderZone))
@@ -3435,7 +3482,31 @@ namespace DnsServerCore.Dns.ZoneManagers
 
                                 case DnsResourceRecordType.ANAME:
                                 case DnsResourceRecordType.ALIAS:
-                                    authority = apexZone.GetRecords(DnsResourceRecordType.SOA); //adding SOA for use with NO DATA response
+                                    {
+                                        //adding SOA (signed when applicable) for use with NO DATA response if ANAME/ALIAS resolution finds nothing
+                                        authority = apexZone.QueryRecords(DnsResourceRecordType.SOA, dnssecOk);
+
+                                        if (dnssecOk)
+                                        {
+                                            //add proof of non existence (NODATA) to prove that no such type or record exists, in case ANAME/ALIAS resolution finds nothing
+                                            IReadOnlyList<DnsResourceRecord> nsecRecords;
+
+                                            if (apexZone.DnssecStatus == AuthZoneDnssecStatus.SignedWithNSEC3)
+                                                nsecRecords = _root.FindNSec3ProofOfNonExistenceNoData(question.Name, zone, apexZone);
+                                            else
+                                                nsecRecords = _root.FindNSecProofOfNonExistenceNoData(question.Name, zone);
+
+                                            if (nsecRecords.Count > 0)
+                                            {
+                                                List<DnsResourceRecord> newAuthority = new List<DnsResourceRecord>(authority.Count + nsecRecords.Count);
+
+                                                newAuthority.AddRange(authority);
+                                                newAuthority.AddRange(nsecRecords);
+
+                                                authority = newAuthority;
+                                            }
+                                        }
+                                    }
                                     break;
                             }
                         }

--- a/DnsServerCore/Dns/Zones/AuthZone.cs
+++ b/DnsServerCore/Dns/Zones/AuthZone.cs
@@ -576,6 +576,17 @@ namespace DnsServerCore.Dns.Zones
             throw new NotImplementedException();
         }
 
+        //Deliberately NOT adding A/AAAA to the NSEC/NSEC3 type bitmap for APP/ANAME/ALIAS-owned names to hint at
+        //their dynamically resolved answer types: doing so makes the bitmap claim those types exist at this name,
+        //which contradicts a NODATA response served here when the app/ANAME resolution declines to answer for
+        //that exact type (confirmed empirically - RFC 4035 5.4 requires a NODATA proof's bitmap to NOT list the
+        //queried type, and a validator correctly rejects the contradiction as bogus). The accepted tradeoff:
+        //a resolver doing RFC 8198 aggressive NSEC/NSEC3 caching (the Unbound/BIND default) may synthesize a
+        //local NODATA answer for A/AAAA at this name from an unrelated cached NSEC/NSEC3 covering it, without
+        //ever querying this server - a real but disclosed limitation, not a correctness bug. Resolving it properly
+        //needs per-query NSEC synthesis (RFC 4470/4471 white lies) matching what the app actually declines to
+        //answer, which is out of scope here (see the "online signing" PR's tier 3).
+
         internal IReadOnlyList<DnsResourceRecord> GetUpdatedNSecRRSet(string nextDomainName, uint ttl)
         {
             List<DnsResourceRecordType> types = new List<DnsResourceRecordType>(_entries.Count);

--- a/DnsServerCore/Dns/Zones/PrimarySubDomainZone.cs
+++ b/DnsServerCore/Dns/Zones/PrimarySubDomainZone.cs
@@ -57,20 +57,10 @@ namespace DnsServerCore.Dns.Zones
         {
             if (_primaryZone.DnssecStatus != AuthZoneDnssecStatus.Unsigned)
             {
-                switch (type)
+                foreach (DnsResourceRecord record in records)
                 {
-                    case DnsResourceRecordType.ANAME:
-                    case DnsResourceRecordType.APP:
-                        throw new DnsServerException("The record type is not supported by DNSSEC signed primary zones.");
-
-                    default:
-                        foreach (DnsResourceRecord record in records)
-                        {
-                            if (record.GetAuthGenericRecordInfo().Disabled)
-                                throw new DnsServerException("Cannot set records: disabling records in a signed zones is not supported.");
-                        }
-
-                        break;
+                    if (record.GetAuthGenericRecordInfo().Disabled)
+                        throw new DnsServerException("Cannot set records: disabling records in a signed zones is not supported.");
                 }
             }
 
@@ -110,18 +100,8 @@ namespace DnsServerCore.Dns.Zones
         {
             if (_primaryZone.DnssecStatus != AuthZoneDnssecStatus.Unsigned)
             {
-                switch (record.Type)
-                {
-                    case DnsResourceRecordType.ANAME:
-                    case DnsResourceRecordType.APP:
-                        throw new DnsServerException("The record type is not supported by DNSSEC signed primary zones.");
-
-                    default:
-                        if (record.GetAuthGenericRecordInfo().Disabled)
-                            throw new DnsServerException("Cannot add record: disabling records in a signed zones is not supported.");
-
-                        break;
-                }
+                if (record.GetAuthGenericRecordInfo().Disabled)
+                    throw new DnsServerException("Cannot add record: disabling records in a signed zones is not supported.");
             }
 
             switch (record.Type)

--- a/DnsServerCore/Dns/Zones/PrimaryZone.cs
+++ b/DnsServerCore/Dns/Zones/PrimaryZone.cs
@@ -1875,10 +1875,6 @@ namespace DnsServerCore.Dns.Zones
                 case DnsResourceRecordType.RRSIG:
                     throw new InvalidOperationException();
 
-                case DnsResourceRecordType.ANAME:
-                case DnsResourceRecordType.APP:
-                    throw new DnsServerException("Cannot sign RRSet: The record type [" + rrsetType.ToString() + "] is not supported by DNSSEC signed primary zones.");
-
                 default:
                     if ((rrsetType == DnsResourceRecordType.NS) && (records[0].Name.Length > _name.Length))
                         return Array.Empty<DnsResourceRecord>(); //referrer NS records are not signed
@@ -2509,20 +2505,10 @@ namespace DnsServerCore.Dns.Zones
         {
             if (_dnssecStatus != AuthZoneDnssecStatus.Unsigned)
             {
-                switch (type)
+                foreach (DnsResourceRecord record in records)
                 {
-                    case DnsResourceRecordType.ANAME:
-                    case DnsResourceRecordType.APP:
-                        throw new DnsServerException("The record type is not supported by DNSSEC signed primary zones.");
-
-                    default:
-                        foreach (DnsResourceRecord record in records)
-                        {
-                            if (record.GetAuthGenericRecordInfo().Disabled)
-                                throw new DnsServerException("Cannot set records: disabling records in a signed zones is not supported.");
-                        }
-
-                        break;
+                    if (record.GetAuthGenericRecordInfo().Disabled)
+                        throw new DnsServerException("Cannot set records: disabling records in a signed zones is not supported.");
                 }
             }
 
@@ -2621,18 +2607,8 @@ namespace DnsServerCore.Dns.Zones
         {
             if (_dnssecStatus != AuthZoneDnssecStatus.Unsigned)
             {
-                switch (record.Type)
-                {
-                    case DnsResourceRecordType.ANAME:
-                    case DnsResourceRecordType.APP:
-                        throw new DnsServerException("The record type is not supported by DNSSEC signed primary zones.");
-
-                    default:
-                        if (record.GetAuthGenericRecordInfo().Disabled)
-                            throw new DnsServerException("Cannot add record: disabling records in a signed zones is not supported.");
-
-                        break;
-                }
+                if (record.GetAuthGenericRecordInfo().Disabled)
+                    throw new DnsServerException("Cannot add record: disabling records in a signed zones is not supported.");
             }
 
             switch (record.Type)


### PR DESCRIPTION
## Summary

Adds DNSSEC "online" (dynamic, per-query) signing for `APP` records
and `ANAME`/`ALIAS` records, so both can now exist and work
correctly in a DNSSEC signed primary zone. Today
`PrimaryZone.SetRecords`/`AddRecord`/`SignRRSet` explicitly refuse
both types when the zone is signed, and even setting that aside, the
dynamically resolved answer was never signed.

This follows up on #1928, and discussions #825, #1357, and #1346,
where online signing has been described as a planned feature for
exactly this purpose. #1346 tied it to clustering support for key
distribution across nodes; clustering has since shipped (November
2025) and is stable, so that dependency shouldn't block the scope
covered here.

## Scope

Two tiers, both reusing the zone's existing static NSEC/NSEC3 chain
and the existing `SignRRSet` path (the same one the offline re-sign
cycle already uses) rather than needing any new denial of existence
machinery:

- Positive answers: the app's or ANAME's synthesized answer gets
  signed at query time with the zone's active ZSK, including the
  correct RFC 4035 Labels field and the RFC 4035 5.3.4 wildcard
  proof of cover for wildcard owned records.
- Secure NODATA: when the app declines to answer (returns null) or
  ANAME resolution finds nothing, the response now includes a signed
  SOA and the zone's existing NSEC/NSEC3 proof of nonexistence at
  the record's own owner name.

Not in scope: proving nonexistence of an arbitrary name under a
wildcard owned dynamic record (a true NXDOMAIN, for a name the app
or ANAME never had an answer for) needs per query NSEC synthesis,
RFC 4470/4471 "white lies". That needs genuinely new denial of
existence machinery rather than reuse, so I scoped it out as a
follow up PR rather than bundling it here, especially since #1346
suggests you may already have a specific design in mind for it.

One real consequence of leaving white lies out: a resolver doing RFC
8198 aggressive NSEC/NSEC3 caching (the Unbound/BIND default) may
occasionally skip querying for a dynamic name if it already has an
unrelated cached NSEC/NSEC3 covering it. I looked at partially
working around this by declaring A/AAAA in the type bitmap at
APP/ANAME owned names, but that directly contradicts a NODATA
response at that same name (the bitmap can't simultaneously claim a
type exists and deny it). Confirmed with delv that a validator
correctly rejects that as bogus, so I left it out rather than ship
something half right.

## Verification

Deployed to a scratch signed zone and validated with delv (BIND's
validating resolver tool) against a manually configured trust
anchor, real cryptographic chain of trust validation rather than
just checking an RRSIG is present. Covered non-wildcard and wildcard
owners, both record types, and both NSEC and NSEC3:

- Positive answers: fully validated across APP/ANAME x wildcard/non
  wildcard x NSEC/NSEC3
- NODATA at the record's own name: fully validated across the same
  combinations
- Confirmed unsigned zone behavior is unchanged

## Open to adjusting scope

If you'd rather this be shaped differently, tied to specific
clustering key distribution work, or folded into a broader design
you already have in mind, happy to rework it.