### PR TITLE
Fix block list parser mis-parsing ABP cosmetic filters as domains

### DIFF
--- a/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
@@ -425,6 +425,12 @@ namespace DnsServerCore.Dns.ZoneManagers
                             //hosts file format
                             firstWord = PopWord(ref line);
 
+                            if (!DnsClient.IsDomainNameValid(firstWord) && !IPAddress.TryParse(firstWord, out _))
+                                continue; //first word is neither a domain name nor an IP address; this is not a
+                                          //hosts-file/domain-list line (e.g. an unsupported Adblock cosmetic,
+                                          //procedural, or scriptlet filter) so avoid misreading a fragment of it
+                                          //as the intended hostname
+
                             if (line.Length == 0)
                             {
                                 hostname = firstWord;


### PR DESCRIPTION
## Summary

`BlockListZoneManager.ReadListFile` recognizes `#`/`!` comments and
`||domain^` / `@@||domain^` Adblock network-filter syntax explicitly.
Any other line falls through to a "hosts file format" guess: split the
line on whitespace, and if there's a second word, treat *that* as the
domain. The second word is validated with `DnsClient.IsDomainNameValid`
before being enqueued, but the first word is never checked at all.

Adblock Plus cosmetic/procedural filters (`##`, `#@#`, `#?#`) attach a
domain list to a CSS/procedural selector that can contain natural
language, e.g. from easylist.to's `fanboy-annoyance.txt`:

```
tiktok.com##[aria-label="Scroll to the top"]
daily.dev#?#.bottom-0.fixed:has-text(This site uses cookies)
```

Neither line starts with `#` (the `#` is mid-line), `||`, or `@@||`, so
they hit the hosts-format fallback. Splitting on whitespace picks out
the *English word* following the domain as the "second word" — `to`
and `site` respectively. A bare single-label name is syntactically
valid per `IsDomainNameValid`, so both get enqueued as blocked domains.
Once in the block zone, blocking is hierarchical, so this silently
blackholes the entire `.to` and `.site` TLDs — including, amusingly,
`easylist.to` itself.

I found this diagnosing a real installation where `easylist.to` (the
list's own host) and an unrelated `.site`-hosted domain were both
returning NXDOMAIN, traced via the block zone's EDNS debug extension
(`source=block-list-zone; blockListUrl=...; domain=to`) back to this
list.

## Fix

Require the first word to already look like a domain name or IP
address before trusting the hosts-format split at all:

```csharp
if (!DnsClient.IsDomainNameValid(firstWord) && !IPAddress.TryParse(firstWord, out _))
    continue;
```

This isn't specific to `##`/`#@#`/`#?#` — it closes the same hole for
any current or future Adblock/uBlock/AdGuard syntax that isn't
explicitly handled (scriptlet/JS injection `#%#`, AdGuard's `$$` HTML
filtering, etc.), since all of them put a character outside the
`[a-zA-Z0-9-_/.]` domain charset somewhere in that first token. No
marker allowlist to maintain.

## Testing

There's no test project in this repo, so I verified by re-implementing
the exact parsing logic (comment/`||`/`@@||`/hosts-format branches,
`IsDomainNameValid`'s character rules pulled from
`TechnitiumLibrary.Net`, `IPAddress.TryParse` via `socket.inet_pton`)
and running it against 31 block lists from a real deployment's
configured set — before/after enqueued-domain counts:

| List | Before | After | Removed |
|---|---|---|---|
| easylist.to/easylist/fanboy-annoyance.txt | 2499 | 2206 | 293 (incl. `to`, `site`) |
| filters.adtidy.org/.../15.txt | 178145 | 178126 | 19 |
| 29 other configured lists (StevenBlack/hosts, AdAway, OISD, Hagezi, etc.) | — | — | **0** |

Zero regressions on every genuine hosts-format list; the fix only
strips entries from the two lists that use Adblock cosmetic-filter
syntax, and confirmed `to`/`site` no longer appear in the parsed output
of `fanboy-annoyance.txt` after the change.