### PR TITLE
Fix Filter AAAA: preserve AuthoritativeAnswer on synthesized NODATA response

### DIFF
--- a/Apps/FilterAaaaApp/App.cs
+++ b/Apps/FilterAaaaApp/App.cs
@@ -213,7 +213,7 @@ namespace FilterAaaa
 
                     DnsResourceRecord[] authority = [new DnsResourceRecord(qname, DnsResourceRecordType.SOA, DnsClass.IN, _defaultTtl, new DnsSOARecordData(_dnsServer.ServerDomain, _dnsServer.ResponsiblePerson.Address, 1, 3600, 900, 86400, _defaultTtl))];
 
-                    return new DnsDatagram(response.Identifier, true, response.OPCODE, false, false, response.RecursionDesired, response.RecursionAvailable, false, false, DnsResponseCode.NoError, response.Question, answer, authority) { Tag = response.Tag };
+                    return new DnsDatagram(response.Identifier, true, response.OPCODE, response.AuthoritativeAnswer, false, response.RecursionDesired, response.RecursionAvailable, false, false, DnsResponseCode.NoError, response.Question, answer, authority) { Tag = response.Tag };
                 }
             }
 


### PR DESCRIPTION
Fixes #2139

The synthesized NODATA response always hardcoded authoritativeAnswer to false, even when the original response was authoritative. This is correct when filtering a recursively-resolved/forwarded answer (AA=0 is right there anyway), but wrong when the server is authoritative for the zone being filtered. The confirmed negative answer gets downgraded to non-authoritative for no reason.

This matters beyond protocol correctness: a resolver forwarding to this server (e.g. Unbound with a forward-zone) treats a non-authoritative NODATA as inconclusive and falls back to real recursive resolution instead of trusting it, silently defeating the filter for anyone running this behind a forwarding resolver for their own authoritative zones.

RecursionDesired/RecursionAvailable a few arguments later were already being carried over correctly from the original response; this just extends the same treatment to AuthoritativeAnswer. See #2139 for full reproduction steps.